### PR TITLE
feat: update docs to remove the old syntax

### DIFF
--- a/blog/2023-08-17-what-is-an-indexer.md
+++ b/blog/2023-08-17-what-is-an-indexer.md
@@ -56,13 +56,9 @@ networks:
           - event: "NewGreeting"
             requiredEntities:
               - name: "Greeting"
-                labels:
-                  - "greetingWithChanges"
           - event: "ClearGreeting"
             requiredEntities:
-              - name: "Greeting"
-                labels:
-                  - "greetingWithChanges"
+              - name: "Greeting"                
 ```
 
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -27,7 +27,6 @@ The `config.yaml` outlines the specifications for the indexer including details 
       - `event` - Event signature or name of the event (must match the name in the ABI)
       - `required_entities` - An array of entities that need to loaded and made accessible within the handler function (an empty array indicates that no entities are required)
         - `name` - The name of the required entity (must match an entity defined in `schema.graphql`)
-        - `label` - A user defined label that corresponds to this entity load
 
 ## Example `config.yaml` from Greeter template:
 
@@ -48,13 +47,9 @@ networks:
           - event: "NewGreeting"
             requiredEntities:
               - name: "Greeting"
-                labels:
-                  - "greetingWithChanges"
           - event: "ClearGreeting"
             requiredEntities:
               - name: "Greeting"
-                labels:
-                  - "greetingWithChanges"
 ```
 
 After you have set up your config file you can run `envio codegen` to generate the functions that you will use in your handlers.

--- a/docs/event-handlers.mdx
+++ b/docs/event-handlers.mdx
@@ -53,7 +53,7 @@ Loader functions are called via
 
 Loader functions are used to load the specific entities (defined in the `schema.graphql`) that should be modified by the event.
 
-Entities with specific IDs can be loaded via `context.<entityName>.<labelName>Load(<id>)`.
+Entities with specific IDs can be loaded via `context.<entityName>.Load(<id>)`.
 
 A single event can be used to modify single or multiple entities.
 
@@ -106,7 +106,7 @@ Below is a list of raw event information that can be accessed:
 - `transactionHash`
 - `transactionIndex`
 
-Handler functions can access the loaded entities information via `context.<entityName>.<labelName>()`.
+Handler functions can access the loaded entities information via `context.<entityName>.get(<id>)`.
 
 Handler functions can also provides the following functions per loaded entity, that can be used to interact with that entity:
 
@@ -124,8 +124,6 @@ events:
   - name: "NewGreeting"
     requiredEntities:
       - name: "Greeting"
-        labels:
-          - "greetingWithChanges"
 ```
 
 ### Example of a Loader function for the `NewGreeting` event:
@@ -137,7 +135,7 @@ events:
 let { GreeterContract } = require("../generated/src/Handlers.bs.js");
 
 GreeterContract.NewGreeting.loader((event, context) => {
-  context.greeting.greetingWithChangesLoad(event.params.user.toString());
+  context.greeting.load(event.params.user.toString());
 });
 ```
 
@@ -150,7 +148,7 @@ import { GreeterContract_NewGreeting_loader } from "../generated/src/Handlers.ge
 import { greetingEntity } from "../generated/src/Types.gen";
 
 GreeterContract_NewGreeting_loader(({ event, context }) => {
-  context.greeting.greetingWithChangesLoad(event.params.user.toString());
+  context.greeting.load(event.params.user.toString());
 });
 ```
 
@@ -161,18 +159,18 @@ GreeterContract_NewGreeting_loader(({ event, context }) => {
 open Types
 
 Handlers.GreeterContract.NewGreeting.loader((~event, ~context) => {
-  context.greeting.greetingWithChangesLoad(event.params.user->Ethers.ethAddressToString)
+  context.greeting.load(event.params.user->Ethers.ethAddressToString)
 })
 ```
 
   </TabItem>
 </Tabs>
 
-- Within the function that is being registered, the user must define the criteria for loading the `greetingWithChanges` entity which corresponds to the label defined in the config.
+- Within the function that is being registered, the user must define the criteria for loading the greeting entity.
 - This is made available to the user through the load entity context defined as `contextUpdator`.
-- In the case of the above example, the `greetingWithChanges` loads a `Greeting` entity that corresponds to the id received from the event.
+- In the case of the above example, we load a `Greeting` entity that corresponds to the id passed from the event.
 
-### Example of registering a Handler function for the `NewGreeting` event and using the label `greetingWithChanges`:
+### Example of registering a Handler function for the `NewGreeting` event:
 
 <Tabs>
   <TabItem value="javascript" label="Javascript">
@@ -181,7 +179,7 @@ Handlers.GreeterContract.NewGreeting.loader((~event, ~context) => {
 let { GreeterContract } = require("../generated/src/Handlers.bs.js");
 
 GreeterContract.NewGreeting.handler((event, context) => {
-  let existingGreeter = context.greeting.greetingWithChanges();
+  let existingGreeter = context.greeting.get(event.params.user.toString());
 
   if (existingGreeter != undefined) {
     context.greeting.set({
@@ -211,7 +209,7 @@ import { greetingEntity } from "../generated/src/Types.gen";
 
 GreeterContract_NewGreeting_handler(({ event, context }) => {
 (({ event, context }) => {
-  let currentGreeter = context.greeting.greetingWithChanges();
+  let currentGreeter = context.greeting.get(event.params.user.toString());
 
   if (currentGreeter != null) {
     let greetingObject: greetingEntity = {
@@ -241,7 +239,7 @@ GreeterContract_NewGreeting_handler(({ event, context }) => {
 open Types
 
 Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
-  let currentGreeterOpt = context.greeting.greetingWithChanges()
+  let currentGreeterOpt = context.greeting.get(event.params.user->Ethers.ethAddressToString)
 
   switch currentGreeterOpt {
   | Some(existingGreeter) => {
@@ -271,7 +269,7 @@ Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
   </TabItem>
 </Tabs>
 
-- Once the user has defined their `loader` function, they are then able to retrieve the loaded entity information via the labels defined in the `config.yaml` file.
+- Once the user has defined their `loader` function, they are then able to retrieve the loaded entity information.
 - In the above example, if a `Greeting` entity is found matching the load criteria in the `loader` function, it will be available via `greetingWithChanges`.
 - This is made available to the user through the handler context defined simply as `context`.
 - This `context` is the gateway by which the user can interact with the indexer and the underlying database.

--- a/todo/simple-bank.md
+++ b/todo/simple-bank.md
@@ -1,4 +1,7 @@
----
+<!-- Syntax here is outdated, this doc isnt live either    -->
+
+
+<!-- ---
 id: simple-bank
 title: SimpleBank
 sidebar_label: SimpleBank
@@ -47,19 +50,11 @@ networks:
           - event: "DepositMade"
             requiredEntities:
               - name: "Account"
-                labels:
-                  - "accountBalanceChanges"
               - name: "Bank"
-                labels:
-                  - "totalBalanceChanges"
           - event: "WithdrawalMade"
             requiredEntities: # if this field isn't specified it should default to include all entities
               - name: "Account"
-                labels:
-                  - "accountBalanceChanges"
               - name: "Bank"
-                labels:
-                  - "totalBalanceChanges"
 
 ```
 
@@ -81,7 +76,6 @@ networks:
       - `event` - Signature or name or of the event (must match the name in the abi)
       - `required_entities` - An array of entities that need to loaded and made accessible within the handler function (an empty array indicates that no entities are required)
         - `name` - The name of the required entity (must match an entity defined in the schema)
-        - `label` - A user defined label that corresponds to this entity load
 
 ## GraphQL Schema definition
 
@@ -222,4 +216,4 @@ Admin-secret for Hasura is `testing`
 
 Alternatively you can open the file `index.html` for a cleaner experience (no Hasura stuff). Unfortunately, Hasura is currently not configured to make the data public.
 
----
+--- -->


### PR DESCRIPTION
Reverts Float-Capital/envio-docs#98

This PR should only be merged when v0.0.11 is labelled as `latest` on npm

closes #89 