### PR TITLE
replace code snippet with table of supported networks on hypersync

### DIFF
--- a/docs/hypersync.md
+++ b/docs/hypersync.md
@@ -9,28 +9,24 @@ slug: /hypersync
 
 > Beam me up, scotty! 🖖
 
-Envio hypersync is our blazingly fast indexed layer on top of the blockchain that allows for hyper speed syncing. 
+Envio hypersync is our blazingly fast indexed layer on top of the blockchain that allows for hyper speed syncing.
 
 What would usually take hours to sync ~100,000 events can now be done in the order of less than a minute.
 
-Since this service is a layer above the blockchain we maintain and host this service for each supported network. 
+Since this service is a layer above the blockchain we maintain and host this service for each supported network.
 
-Below is a list of networks our hypersync feature supports 
+Below is a table of networks supported on our hypersync feature
 
-```rust
-pub enum SupportedNetwork {
-    EthereumMainnet,
-    EthereumGoerli,
-    Polygon,
-    ArbitrumOne,
-    Base,
-    BinanceChain,
-    AvalancheCChain,
-    Optimism,
-    Linea,
-}
-
-```
+| Network Name     | ID    |
+| ---------------- | ----- |
+| Ethereum Mainnet | 1     |
+| Optimism         | 10    |
+| Bsc              | 56    |
+| Matic            | 137   |
+| ArbitrumOne      | 42161 |
+| Avalanche        | 43114 |
+| BaseTestnet      | 84531 |
+| Linea            | 59144 |
 
 > Disclaimer: currently the hypersync feature is not real-time - it intentionally lags 10 blocks behind the latest block to allow for chain reorganizations in the future.
 


### PR DESCRIPTION
closes #153 

@JonoPrest do you mind taking a double check at the list of networks here?

I basically took all the networks from `chain_helpers.rs` that were part of `SupportedNetworks` subenum and it seems to differ to the previous list of networks from the `SupportedNetwork` enum