### PR TITLE
feat: basic links for fuel

### DIFF
--- a/docs/hyperfuel.md
+++ b/docs/hyperfuel.md
@@ -1,0 +1,18 @@
+---
+id: hyperfuel
+title: HyperFuel
+sidebar_label: HyperFuel
+slug: /hyperfuel
+---
+
+HyperFuel is a HyperSync adaptation specialized for supporting [Fuel](https://fuel.network/).
+
+HyperFuel is under active development so please contact us if you have any questions or issues :)
+
+You can integrate with HyperFuel using any of our clients:
+ - Python: https://github.com/enviodev/hyperfuel-client-python
+ - Nodejs: https://github.com/enviodev/hyperfuel-client-node
+ - Rust: https://github.com/enviodev/hyperfuel-client-rust
+ - json api: https://github.com/enviodev/hyperfuel-docs
+
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -96,7 +96,7 @@ module.exports = {
     {
       type: "category",
       label: "HyperSync",
-      items: ["overview-hypersync", "hypersync-usage", "hypersync-clients"],
+      items: ["overview-hypersync", "hypersync-usage", "hypersync-clients", "hyperfuel"],
     },
     {
       type: "category",


### PR DESCRIPTION
Quickly added some links for HyperFuel clients.  When the clients are more polished (better examples, more comments, rust client migrated) I'll come back to this and add some quickstart code snippets.

I'm open to renaming the sidebar to "Fuel" if "HyperFuel" isn't obvious enough to potential Fuel builders.