### PR TITLE
Fix deprecated use of `~` in the loader and handler parameters

### DIFF
--- a/docs/array-label.mdx
+++ b/docs/array-label.mdx
@@ -51,17 +51,17 @@ type A {
 <TabItem value="javascript" label="Javascript">
 
 ```javascript
-GreeterContract.TestEvent.loader((~event, ~context) => {
-    context.A.allALoad(["id1", "id2", "id3"])
-    context.A.singleALoad("singled")
-    // ... other loaders
-})
-GreeterContract.TestEvent.handler((~event, ~context) => {
-  let arrayOfAs = context.A.allA
-  let singleA = context.A.singleA
+GreeterContract.TestEvent.loader(({ event, context }) => {
+  context.A.allALoad(["id1", "id2", "id3"]);
+  context.A.singleALoad("singled");
+  // ... other loaders
+});
+GreeterContract.TestEvent.handler(({ event, context }) => {
+  let arrayOfAs = context.A.allA;
+  let singleA = context.A.singleA;
 
   // ... rest of the handler that uses or updates these entities.
-})
+});
 ```
 
   </TabItem>

--- a/docs/async-mode.mdx
+++ b/docs/async-mode.mdx
@@ -216,7 +216,7 @@ And here is a diff to highlight the change:
   <TabItem value="rescript" label="Rescript">
 
 ```rescript
-Handlers.GreeterContract.NewGreeting.handlerAsync(async (~event, ~context) => {
+Handlers.GreeterContract.NewGreeting.handlerAsync(async ({ event, context }) => {
   let userId = event.params.user->Ethers.ethAddressToString
   let latestGreeting = event.params.greeting
 
@@ -249,8 +249,8 @@ Handlers.GreeterContract.NewGreeting.handlerAsync(async (~event, ~context) => {
 And here is a diff to highlight the change:
 
 ```diff
-- Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
-+ Handlers.GreeterContract.NewGreeting.handlerAsync(async (~event, ~context) => {
+- Handlers.GreeterContract.NewGreeting.handler(({ event, context }) => {
++ Handlers.GreeterContract.NewGreeting.handlerAsync(async ({ event, context }) => {
     let userId = event.params.user->Ethers.ethAddressToString
     let latestGreeting = event.params.greeting
 

--- a/docs/event-handlers.mdx
+++ b/docs/event-handlers.mdx
@@ -185,7 +185,7 @@ GreeterContract_NewGreeting_loader(({ event, context }) => {
 ```rescript
 open Types
 
-Handlers.GreeterContract.NewGreeting.loader((~event, ~context) => {
+Handlers.GreeterContract.NewGreeting.loader(({ event, context }) => {
   context.user.load(event.params.user->Ethers.ethAddressToString)
 })
 ```
@@ -265,7 +265,7 @@ GreeterContract_NewGreeting_handler(({ event, context }) => {
 ```rescript
 open Types
 
-Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
+Handlers.GreeterContract.NewGreeting.handler(({ event, context }) => {
   let currentUserOpt = context.user.get(event.params.user->Ethers.ethAddressToString)
 
   switch currentUserOpt {
@@ -336,7 +336,7 @@ GreeterContract_NewGreeting_handler(({ event, context }) => {
 ```rescript
 open Types
 
-Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
+Handlers.GreeterContract.NewGreeting.handler(({ event, context }) => {
   let config = ConfigYAML.getConfigByChainId(event.chainId)
 })
 ```

--- a/docs/labels.mdx
+++ b/docs/labels.mdx
@@ -52,12 +52,12 @@ type A {
 <TabItem value="javascript" label="Javascript">
 
 ```javascript
-GreeterContract.TestEvent.loader((~event, ~context) => {
+GreeterContract.TestEvent.loader(({ event, context }) => {
     context.A.allALoad(["id1", "id2", "id3"])
     context.A.singleALoad("singled")
     // ... other loaders
 })
-GreeterContract.TestEvent.handler((~event, ~context) => {
+GreeterContract.TestEvent.handler(({ event, context }) => {
   let arrayOfAs = context.A.allA
   let singleA = context.A.singleA
 

--- a/docs/linked-entity-loaders.mdx
+++ b/docs/linked-entity-loaders.mdx
@@ -63,27 +63,20 @@ networks:
   <TabItem value="javascript" label="Javascript">
 
 ```javascript
-GravatarContract.TestEvent.loader((~event, ~context) => {
-  context.A.load(
-    event.params.id,
-    {loadB: {loadC: {loadImportantData: true}, loadA: {}}},
-  )
+GravatarContract.TestEvent.loader(({ event, context }) => {
+  context.A.load(event.params.id, {
+    loadB: { loadC: { loadImportantData: true }, loadA: {} },
+  });
   // ... other loaders
-})
+});
 
-GravatarContract.TestEvent.handler((~event, ~context) => {
+GravatarContract.TestEvent.handler(({ event, context }) => {
   const entityA = context.A.get(event.params.id);
-  const linkedB = context.A.getB(
-    entityA
-  );
-  const linkedC = context.B.getC(
-    linkedB
-  );
-  const importantDataEntity = context.C.getImportantData(
-    linkedC
-  );
+  const linkedB = context.A.getB(entityA);
+  const linkedC = context.B.getC(linkedB);
+  const importantDataEntity = context.C.getImportantData(linkedC);
   // ... rest of the handler that uses or updates these entities.
-})
+});
 ```
 
   </TabItem>

--- a/docs/multichain.mdx
+++ b/docs/multichain.mdx
@@ -182,11 +182,11 @@ GreeterContract_ClearGreeting_handler(({ event, context }) => {
 ```rescript
 open Types
 
-Handlers.GreeterContract.NewGreeting.loader((~event, ~context) => {
+Handlers.GreeterContract.NewGreeting.loader(({ event, context }) => {
   context.greeting.load(event.params.user->Ethers.ethAddressToString)
 })
 
-Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
+Handlers.GreeterContract.NewGreeting.handler(({ event, context }) => {
   let currentUserOpt = context.greeting.get(event.params.user->Ethers.ethAddressToString)
 
   switch currentUserOpt {
@@ -213,12 +213,12 @@ Handlers.GreeterContract.NewGreeting.handler((~event, ~context) => {
   }
 })
 
-Handlers.GreeterContract.ClearGreeting.loader((~event, ~context) => {
+Handlers.GreeterContract.ClearGreeting.loader(({ event, context }) => {
   context.greeting.load(event.params.user->Ethers.ethAddressToString)
   ()
 })
 
-Handlers.GreeterContract.ClearGreeting.handler((~event, ~context) => {
+Handlers.GreeterContract.ClearGreeting.handler(({ event, context }) => {
   let currentUserOpt = context.greeting.get(event.params.user->Ethers.ethAddressToString)
 
   switch currentUserOpt {
@@ -249,7 +249,9 @@ To activate "Unordered Multichain Mode", add a field to your config.yaml file li
 unordered_multichain_mode: true
 networks: ...
 ```
-Or you can set it via environment variable (this would take precedence over config): 
+
+Or you can set it via environment variable (this would take precedence over config):
+
 ```sh
 UNORDERED_MULTICHAIN_MODE=true
 ```


### PR DESCRIPTION
This was just forgotten. Also worrying that there were `~` on lots of the `javascript` examples which was never correct.

We really do need to get some versioning in our docs... Anyone with a pre-rescript 11 indexer version will still need the ~.

