### PR TITLE
Add edit links to all the pages - direct to github

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -331,6 +331,7 @@ const config = {
         path: 'docs/HyperSync',
         routeBasePath: 'docs/HyperSync',
         sidebarPath: require.resolve('./sidebarsHyperSync.js'),
+        editUrl: 'https://github.com/enviodev/docs/edit/main/',
         showLastUpdateAuthor: false,
         showLastUpdateTime: false,
         // versions: {
@@ -348,6 +349,7 @@ const config = {
         path: 'docs/HyperIndex',
         routeBasePath: 'docs/HyperIndex',
         sidebarPath: require.resolve('./sidebarsHyperIndex.js'),
+        editUrl: 'https://github.com/enviodev/docs/edit/main/',
         showLastUpdateAuthor: false,
         showLastUpdateTime: false,
         // versions: {


### PR DESCRIPTION
This works, scroll down to bottom of any page and it will show: 
![image](https://github.com/enviodev/docs/assets/6032276/9dd808a6-22c7-4496-8a95-8aa995cdeee0)


Click that, and it takes you to the 'edit' view in github :muscle: 