### PR TITLE
hypersync network update

### DIFF
--- a/docs/HyperIndex/Advanced/hypersync.md
+++ b/docs/HyperIndex/Advanced/hypersync.md
@@ -26,6 +26,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Ethereum Mainnet | 1            |
 | Goerli           | 5            |
 | Optimism         | 10           |
+| Flare | 14 |
 | Rootstock        | 30           |
 | Lukso            | 42           |
 | Crab             | 44           |

--- a/docs/HyperIndex/Advanced/hypersync.md
+++ b/docs/HyperIndex/Advanced/hypersync.md
@@ -26,12 +26,12 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Ethereum Mainnet | 1            |
 | Goerli           | 5            |
 | Optimism         | 10           |
-| Flare            | 14           |
 | Rootstock        | 30           |
 | Lukso            | 42           |
 | Crab             | 44           |
 | Darwinia         | 46           |
-| Bsc              | 56           |
+| BSC              | 56           |
+| BSC Testnet      | 97           |
 | Gnosis           | 100          |
 | Polygon          | 137          |
 | ShimmerEVM       | 148          |
@@ -57,6 +57,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Arbitrum One     | 42161        |
 | Arbitrum Nova    | 42170        |
 | Celo             | 42220        |
+| Fuji             | 43113        |
 | Avalanche        | 43114        |
 | Linea            | 59144        |
 | Amoy             | 80002        |
@@ -71,6 +72,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | NeonEVM          | 245022934    |
 | Aurora           | 1313161554   |
 | Harmony          | 1666600000/1 |
+
 
 ## Greeter example
 

--- a/docs/HyperIndex/contract-import.md
+++ b/docs/HyperIndex/contract-import.md
@@ -100,7 +100,6 @@ Please note: This is a list of supported networks for the no-code quickstart. En
 - `public-goods`
 - `a1-milkomeda`
 - `c1-milkomeda`
-- `flare`
 - `mantle`
 - `zeta`
 - `neon-evm`

--- a/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
+++ b/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
@@ -19,6 +19,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Ethereum Mainnet | 1          | https://eth.rpc.hypersync.xyz or https://1.rpc.hypersync.xyz                   |
 | Goerli           | 5          | https://goerli.rpc.hypersync.xyz or https://5.rpc.hypersync.xyz                |
 | Optimism         | 10         | https://optimism-sepolia.rpc.hypersync.xyz or https://10.rpc.hypersync.xyz     |
+| Flare | 14 | https://flare.rpc.hypersync.xyz or https://14.rpc.hypersync.xyz |
 | Rootstock        | 30         | https://rsk.rpc.hypersync.xyz or https://30.rpc.hypersync.xyz                  |
 | Lukso            | 42         | https://lukso.rpc.hypersync.xyz or https://42.rpc.hypersync.xyz                |
 | Crab             | 44         | https://crab.rpc.hypersync.xyz or https://44.rpc.hypersync.xyz                 |

--- a/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
+++ b/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
@@ -24,7 +24,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Crab             | 44         | https://crab.rpc.hypersync.xyz or https://44.rpc.hypersync.xyz                 |
 | Darwinia         | 46         | https://darwinia.rpc.hypersync.xyz or https://46.rpc.hypersync.xyz             |
 | BSC              | 56         | https://bsc.rpc.hypersync.xyz or https://56.rpc.hypersync.xyz                  |
-| BSC Testnet      | 97         | https://bsc-testnet.rpc.hypersync.xyz or https://97.rpc.hypersync.xyz                  |
+| BSC Testnet      | 97         | https://bsc-testnet.rpc.hypersync.xyz or https://97.rpc.hypersync.xyz          |
 | Gnosis           | 100        | https://gnosis.rpc.hypersync.xyz or https://100.rpc.hypersync.xyz              |
 | Polygon          | 137        | https://polygon.rpc.hypersync.xyz or https://137.rpc.hypersync.xyz             |
 | ShimmerEVM       | 148        | https://shimmer-evm.rpc.hypersync.xyz or https://148.rpc.hypersync.xyz         |
@@ -49,7 +49,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Arbitrum One     | 42161      | https://arbitrum.rpc.hypersync.xyz or https://42161.rpc.hypersync.xyz          |
 | Arbitrum Nova    | 42170      | https://arbitrum-nova.rpc.hypersync.xyz or https://42170.rpc.hypersync.xyz     |
 | Celo             | 42220      | https://celo.rpc.hypersync.xyz or https://42220.rpc.hypersync.xyz              |
-| Fuji             | 43113      | https://fuji.rpc.hypersync.xyz or https://43113.rpc.hypersync.xyz         |
+| Fuji             | 43113      | https://fuji.rpc.hypersync.xyz or https://43113.rpc.hypersync.xyz              |
 | Avalanche        | 43114      | https://avalanche.rpc.hypersync.xyz or https://43114.rpc.hypersync.xyz         |
 | Linea            | 59144      | https://linea.rpc.hypersync.xyz or https://59144.rpc.hypersync.xyz             |
 | Amoy             | 80002      | https://amoy.rpc.hypersync.xyz or https://80001.rpc.hypersync.xyz              |

--- a/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
+++ b/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
@@ -19,12 +19,12 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Ethereum Mainnet | 1          | https://eth.rpc.hypersync.xyz or https://1.rpc.hypersync.xyz                   |
 | Goerli           | 5          | https://goerli.rpc.hypersync.xyz or https://5.rpc.hypersync.xyz                |
 | Optimism         | 10         | https://optimism-sepolia.rpc.hypersync.xyz or https://10.rpc.hypersync.xyz     |
-| Flare            | 14         | https://flare.rpc.hypersync.xyz or https://14.rpc.hypersync.xyz                |
 | Rootstock        | 30         | https://rsk.rpc.hypersync.xyz or https://30.rpc.hypersync.xyz                  |
 | Lukso            | 42         | https://lukso.rpc.hypersync.xyz or https://42.rpc.hypersync.xyz                |
 | Crab             | 44         | https://crab.rpc.hypersync.xyz or https://44.rpc.hypersync.xyz                 |
 | Darwinia         | 46         | https://darwinia.rpc.hypersync.xyz or https://46.rpc.hypersync.xyz             |
-| Bsc              | 56         | https://bsc.rpc.hypersync.xyz or https://56.rpc.hypersync.xyz                  |
+| BSC              | 56         | https://bsc.rpc.hypersync.xyz or https://56.rpc.hypersync.xyz                  |
+| BSC Testnet      | 97         | https://bsc-testnet.rpc.hypersync.xyz or https://97.rpc.hypersync.xyz                  |
 | Gnosis           | 100        | https://gnosis.rpc.hypersync.xyz or https://100.rpc.hypersync.xyz              |
 | Polygon          | 137        | https://polygon.rpc.hypersync.xyz or https://137.rpc.hypersync.xyz             |
 | ShimmerEVM       | 148        | https://shimmer-evm.rpc.hypersync.xyz or https://148.rpc.hypersync.xyz         |
@@ -49,6 +49,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Arbitrum One     | 42161      | https://arbitrum.rpc.hypersync.xyz or https://42161.rpc.hypersync.xyz          |
 | Arbitrum Nova    | 42170      | https://arbitrum-nova.rpc.hypersync.xyz or https://42170.rpc.hypersync.xyz     |
 | Celo             | 42220      | https://celo.rpc.hypersync.xyz or https://42220.rpc.hypersync.xyz              |
+| Fuji             | 43113      | https://fuji.rpc.hypersync.xyz or https://43113.fuji.hypersync.xyz         |
 | Avalanche        | 43114      | https://avalanche.rpc.hypersync.xyz or https://43114.rpc.hypersync.xyz         |
 | Linea            | 59144      | https://linea.rpc.hypersync.xyz or https://59144.rpc.hypersync.xyz             |
 | Amoy             | 80002      | https://amoy.rpc.hypersync.xyz or https://80001.rpc.hypersync.xyz              |

--- a/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
+++ b/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
@@ -49,7 +49,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Arbitrum One     | 42161      | https://arbitrum.rpc.hypersync.xyz or https://42161.rpc.hypersync.xyz          |
 | Arbitrum Nova    | 42170      | https://arbitrum-nova.rpc.hypersync.xyz or https://42170.rpc.hypersync.xyz     |
 | Celo             | 42220      | https://celo.rpc.hypersync.xyz or https://42220.rpc.hypersync.xyz              |
-| Fuji             | 43113      | https://fuji.rpc.hypersync.xyz or https://43113.fuji.hypersync.xyz         |
+| Fuji             | 43113      | https://fuji.rpc.hypersync.xyz or https://43113.rpc.hypersync.xyz         |
 | Avalanche        | 43114      | https://avalanche.rpc.hypersync.xyz or https://43114.rpc.hypersync.xyz         |
 | Linea            | 59144      | https://linea.rpc.hypersync.xyz or https://59144.rpc.hypersync.xyz             |
 | Amoy             | 80002      | https://amoy.rpc.hypersync.xyz or https://80001.rpc.hypersync.xyz              |

--- a/docs/HyperSync/hypersync-url-endpoints.md
+++ b/docs/HyperSync/hypersync-url-endpoints.md
@@ -17,6 +17,7 @@ Don't see your network here? Request a network using this discord [form](https:/
 | Ethereum Mainnet | 1          | https://eth.hypersync.xyz or https://1.hypersync.xyz                   |
 | Goerli           | 5          | https://goerli.hypersync.xyz or https://5.hypersync.xyz                |
 | Optimism         | 10         | https://optimism-sepolia.hypersync.xyz or https://10.hypersync.xyz     |
+| Flare | 14 | https://flare.hypersync.xyz or https://14.hypersync.xyz |
 | Rootstock        | 30         | https://rsk.hypersync.xyz or https://30.hypersync.xyz                  |
 | Lukso            | 42         | https://lukso.hypersync.xyz or https://42.hypersync.xyz                |
 | Crab             | 44         | https://crab.hypersync.xyz or https://44.hypersync.xyz                 |

--- a/docs/HyperSync/hypersync-url-endpoints.md
+++ b/docs/HyperSync/hypersync-url-endpoints.md
@@ -17,12 +17,12 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Ethereum Mainnet | 1          | https://eth.hypersync.xyz or https://1.hypersync.xyz                   |
 | Goerli           | 5          | https://goerli.hypersync.xyz or https://5.hypersync.xyz                |
 | Optimism         | 10         | https://optimism-sepolia.hypersync.xyz or https://10.hypersync.xyz     |
-| Flare            | 14         | https://flare.hypersync.xyz or https://14.hypersync.xyz                |
 | Rootstock        | 30         | https://rsk.hypersync.xyz or https://30.hypersync.xyz                  |
 | Lukso            | 42         | https://lukso.hypersync.xyz or https://42.hypersync.xyz                |
 | Crab             | 44         | https://crab.hypersync.xyz or https://44.hypersync.xyz                 |
 | Darwinia         | 46         | https://darwinia.hypersync.xyz or https://46.hypersync.xyz             |
-| Bsc              | 56         | https://bsc.hypersync.xyz or https://56.hypersync.xyz                  |
+| BSC              | 56         | https://bsc.hypersync.xyz or https://56.hypersync.xyz                  |
+| BSC Testnet      | 97         | https://bsc-testnet.hypersync.xyz or https://97.hypersync.xyz                  |
 | Gnosis           | 100        | https://gnosis.hypersync.xyz or https://100.hypersync.xyz              |
 | Polygon          | 137        | https://polygon.hypersync.xyz or https://137.hypersync.xyz             |
 | ShimmerEVM       | 148        | https://shimmer-evm.hypersync.xyz or https://148.hypersync.xyz         |
@@ -47,6 +47,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Arbitrum One     | 42161      | https://arbitrum.hypersync.xyz or https://42161.hypersync.xyz          |
 | Arbitrum Nova    | 42170      | https://arbitrum-nova.hypersync.xyz or https://42170.hypersync.xyz     |
 | Celo             | 42220      | https://celo.hypersync.xyz or https://42220.hypersync.xyz              |
+| Fuji             | 43113      | https://fuji.hypersync.xyz or https://43113.hypersync.xyz              |
 | Avalanche        | 43114      | https://avalanche.hypersync.xyz or https://43114.hypersync.xyz         |
 | Linea            | 59144      | https://linea.hypersync.xyz or https://59144.hypersync.xyz             |
 | Amoy             | 80002      | https://amoy.hypersync.xyz or https://80001.hypersync.xyz              |

--- a/docs/HyperSync/hypersync-url-endpoints.md
+++ b/docs/HyperSync/hypersync-url-endpoints.md
@@ -22,7 +22,7 @@ Don't see your network here? Pop us a message in [Discord](https://discord.gg/Q9
 | Crab             | 44         | https://crab.hypersync.xyz or https://44.hypersync.xyz                 |
 | Darwinia         | 46         | https://darwinia.hypersync.xyz or https://46.hypersync.xyz             |
 | BSC              | 56         | https://bsc.hypersync.xyz or https://56.hypersync.xyz                  |
-| BSC Testnet      | 97         | https://bsc-testnet.hypersync.xyz or https://97.hypersync.xyz                  |
+| BSC Testnet      | 97         | https://bsc-testnet.hypersync.xyz or https://97.hypersync.xyz          |
 | Gnosis           | 100        | https://gnosis.hypersync.xyz or https://100.hypersync.xyz              |
 | Polygon          | 137        | https://polygon.hypersync.xyz or https://137.hypersync.xyz             |
 | ShimmerEVM       | 148        | https://shimmer-evm.hypersync.xyz or https://148.hypersync.xyz         |


### PR DESCRIPTION
adds bsc testnet & fuji to hypersync and hyperrpc endpoint pages . removes flare from both these pages. 

doesn't add bsc testnet & fuji to contract import list, as these are not listed in latest envio version v1.3.0. removes flare from contract import list. 
