### PR TITLE
fixes redirect link to hyperindex on fuel on fuel ecosystem

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -163,6 +163,10 @@ const redirectsList = [
     from: "/docs/reserved-words",
     to: "/docs/HyperIndex/reserved-words",
   },
+  {
+    from: "/docs/hyperfuel",
+    to: "/docs/HyperIndex/fuel",
+  },
   //// HyperSync
   {
     from: "/docs/overview-hypersync",


### PR DESCRIPTION
From: https://docs.envio.dev/docs/hyperfuel
To: https://docs.envio.dev/docs/HyperIndex/fuel