### PR TITLE
fixes hyperrpc redirect for supported networks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -197,8 +197,8 @@ const redirectsList = [
     to: "/docs/HyperSync/hypersync-supported-networks",
   },
   {
-    from: "/docs/HyperSync/hypersync-url-endpoints",
-    to: "/docs/HyperSync/hypersync-supported-networks",
+    from: "/docs/HyperSync/hyperrpc-url-endpoints",
+    to: "/docs/HyperSync/hyperrpc-supported-networks",
   },
   {
     from: "/docs/hyperfuel-query",


### PR DESCRIPTION
There was a duplicate, which is resolved below:

Previous:

```
  {
    from: "/docs/HyperSync/hypersync-url-endpoints",
    to: "/docs/HyperSync/hypersync-supported-networks",
  },
  {
    from: "/docs/HyperSync/hypersync-url-endpoints",
    to: "/docs/HyperSync/hypersync-supported-networks",
  },
```
  
  In this PR:

```
    {
    from: "/docs/HyperSync/hypersync-url-endpoints",
    to: "/docs/HyperSync/hypersync-supported-networks",
  },
  {
    from: "/docs/HyperSync/hyperrpc-url-endpoints",
    to: "/docs/HyperSync/hyperrpc-supported-networks",
  },
```
  