### PR TITLE
Logo correctly redirects to main site

### DIFF
--- a/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
+++ b/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
@@ -70,3 +70,5 @@ Here is a table of the currently supported networks on HyperRPC and their respec
 
 
 
+
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -261,6 +261,7 @@ const config = {
             maxWidth: 200,
             maxHeight: 40,
           },
+          href: "https://envio.dev",
         },
         items: [
           {


### PR DESCRIPTION
Now when you click top left logo it takes you to the actual site which is correctly excpected behaviour 