### PR TITLE
Fix overwritten redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,7 @@ const darkCodeTheme = themes.dracula;
 
 const redirectsList = [
   {
-    from: "/",
+    from: "/docs",
     to: "/docs/HyperIndex/overview",
   },
   {


### PR DESCRIPTION
Now this page https://docs.envio.dev/docs/ will also redirects (and doesn't break)

The redirect was overwritten (benign, but made an error message in the terminal):

![image](https://github.com/user-attachments/assets/30af08e4-1761-438a-bb01-273e41e6b837)

This PR introduced the warning: https://github.com/enviodev/docs/pull/401/files

Try it: https://envio-docs-git-js-redirects-envio-9ec2d675.vercel.app/docs/ and https://envio-docs-git-js-redirects-envio-9ec2d675.vercel.app/ both redirect correctly.