### PR TITLE
Docs update after Fuel Merge

### DIFF
--- a/HyperIndex_versioned_docs/version-v1/Tutorials/tutorial-indexing-fuel.md
+++ b/HyperIndex_versioned_docs/version-v1/Tutorials/tutorial-indexing-fuel.md
@@ -39,13 +39,7 @@ Open your terminal in an empty directory and initialize a new indexer by running
 npx envio init
 ```
 
-In the following prompt, let's name our indexer `sway-farm-indexer`:
-
-```bash
-? Name your indexer: sway-farm-indexer
-```
-
-Then, choose the directory where you want to set up your project. The default is the current directory, but in the tutorial, I'll use the indexer name:
+In the following prompt, choose the directory where you want to set up your project. The default is the current directory, but in the tutorial, I'll use the indexer name:
 
 ```bash
 ? Specify a folder name (ENTER to skip): sway-farm-indexer
@@ -225,7 +219,7 @@ import { SwayFarmContract, SwayFarm_SellItemEntity } from "generated";
 
 SwayFarmContract.SellItem.handler(async ({ event, context }) => {
   const entity: SwayFarm_SellItemEntity = {
-    id: `${event.transactionId}_${event.receiptIndex}`,
+    id: `${event.chainId}_${event.block.height}_${event.logIndex}`,
   };
 
   context.SwayFarm_SellItem.set(entity);
@@ -251,7 +245,7 @@ SwayFarmContract.NewPlayer.handler(async ({ event, context }) => {
   // Set the Player entity in the DB with the intial values
   context.Player.set({
     // The address in Sway is a union type of user Address and ContractID. Envio supports most of the Sway types, and the address value was decoded as a discriminated union 100% typesafe
-    id: event.data.address.payload.bits,
+    id: event.params.address.payload.bits,
     // Initial values taken from the contract logic
     farmingSkill: 1n,
     totalValueSold: 0n,
@@ -259,18 +253,18 @@ SwayFarmContract.NewPlayer.handler(async ({ event, context }) => {
 });
 
 SwayFarmContract.LevelUp.handler(async ({ event, context }) => {
-  const playerInfo = event.data.player_info;
+  const playerInfo = event.params.player_info;
   context.Player.set({
-    id: event.data.address.payload.bits,
+    id: event.params.address.payload.bits,
     farmingSkill: playerInfo.farming_skill,
     totalValueSold: playerInfo.total_value_sold,
   });
 });
 
 SwayFarmContract.SellItem.handler(async ({ event, context }) => {
-  const playerInfo = event.data.player_info;
+  const playerInfo = event.params.player_info;
   context.Player.set({
-    id: event.data.address.payload.bits,
+    id: event.params.address.payload.bits,
     farmingSkill: playerInfo.farming_skill,
     totalValueSold: playerInfo.total_value_sold,
   });

--- a/docs/HyperIndex/Tutorials/greeter-tutorial.md
+++ b/docs/HyperIndex/Tutorials/greeter-tutorial.md
@@ -45,12 +45,6 @@ Run
 envio init
 ```
 
-Name your indexer
-
-```bash
-? Name your indexer: (My Envio Indexer)
-```
-
 Choose the directory where you would like to setup your project (default is the current directory)
 
 ```bash

--- a/docs/HyperIndex/Tutorials/tutorial-indexing-fuel.md
+++ b/docs/HyperIndex/Tutorials/tutorial-indexing-fuel.md
@@ -39,13 +39,7 @@ Open your terminal in an empty directory and initialize a new indexer by running
 npx envio init
 ```
 
-In the following prompt, let's name our indexer `sway-farm-indexer`:
-
-```bash
-? Name your indexer: sway-farm-indexer
-```
-
-Then, choose the directory where you want to set up your project. The default is the current directory, but in the tutorial, I'll use the indexer name:
+In the following prompt, choose the directory where you want to set up your project. The default is the current directory, but in the tutorial, I'll use the indexer name:
 
 ```bash
 ? Specify a folder name (ENTER to skip): sway-farm-indexer
@@ -225,7 +219,7 @@ import { SwayFarmContract, SwayFarm_SellItemEntity } from "generated";
 
 SwayFarmContract.SellItem.handler(async ({ event, context }) => {
   const entity: SwayFarm_SellItemEntity = {
-    id: `${event.transactionId}_${event.receiptIndex}`,
+    id: `${event.chainId}_${event.block.height}_${event.logIndex}`,
   };
 
   context.SwayFarm_SellItem.set(entity);
@@ -251,7 +245,7 @@ SwayFarmContract.NewPlayer.handler(async ({ event, context }) => {
   // Set the Player entity in the DB with the intial values
   context.Player.set({
     // The address in Sway is a union type of user Address and ContractID. Envio supports most of the Sway types, and the address value was decoded as a discriminated union 100% typesafe
-    id: event.data.address.payload.bits,
+    id: event.params.address.payload.bits,
     // Initial values taken from the contract logic
     farmingSkill: 1n,
     totalValueSold: 0n,
@@ -259,18 +253,18 @@ SwayFarmContract.NewPlayer.handler(async ({ event, context }) => {
 });
 
 SwayFarmContract.LevelUp.handler(async ({ event, context }) => {
-  const playerInfo = event.data.player_info;
+  const playerInfo = event.params.player_info;
   context.Player.set({
-    id: event.data.address.payload.bits,
+    id: event.params.address.payload.bits,
     farmingSkill: playerInfo.farming_skill,
     totalValueSold: playerInfo.total_value_sold,
   });
 });
 
 SwayFarmContract.SellItem.handler(async ({ event, context }) => {
-  const playerInfo = event.data.player_info;
+  const playerInfo = event.params.player_info;
   context.Player.set({
-    id: event.data.address.payload.bits,
+    id: event.params.address.payload.bits,
     farmingSkill: playerInfo.farming_skill,
     totalValueSold: playerInfo.total_value_sold,
   });

--- a/docs/HyperIndex/fuel/fuel.md
+++ b/docs/HyperIndex/fuel/fuel.md
@@ -90,6 +90,6 @@ Also, some other event fields were moved:
 - `receiptIndex` -> `logIndex`
 - `receiptType` -> removed
 
-These are all Fuel-related changes, but if you use `loaders` follow the [v1 to v2 migration guide](/migration-guide-v1-v2) to update to the V2 API.
+These are all Fuel-related changes, but if you use `loaders` follow the [v1 to v2 migration guide](/docs/HyperIndex/migration-guide-v1-v2) to update to the V2 API.
 
 If you need help, create an issue in our [GitHub repository](https://github.com/enviodev/hyperindex). We'll be happy to help!

--- a/docs/HyperIndex/fuel/fuel.md
+++ b/docs/HyperIndex/fuel/fuel.md
@@ -46,10 +46,50 @@ Or gain inspiration from already running indexers built by other developers on F
 
 ### State of the art
 
-Currently, `HyperIndex` on Fuel supports the most features EVM indexer does, including advanced features such as [Dynamic Contracts / Factories](../Advanced/dynamic-contracts.md), [Testing Framework](/docs/HyperIndex/testing) and [Hosted Service](../Hosted_Service/hosted-service.md).
+`HyperIndex` on Fuel supports all relevant features EVM indexer does, including [Dynamic Contracts / Factories](../Advanced/dynamic-contracts.md), [Testing Framework](/docs/HyperIndex/testing), [No-code Quickstart](/docs/HyperIndex/contract-import), [Hosted Service](../Hosted_Service/hosted-service.md) and more.
 
-Also, compared to EVM, Fuel provides many more kinds of possible events. Now, we support indexing only `LogData` receipts (the `log` calls in a [Sway](https://docs.fuel.network/docs/sway/) contract), but there's a plan to also support `Transfer`, `TransferOut`, `Mint`, `Burn`, and `Call` receipts in the near future.
-
-We will also work on a [No-code Quickstart](/docs/HyperIndex/contract-import), predicates support, and more.
+Also, compared to EVM, Fuel provides many more kinds of possible events. Now, we support indexing only `LogData` receipts (the `log` calls in a [Sway](https://docs.fuel.network/docs/sway/) contract), but we are working on supporting `Transfer`, `TransferOut`, `Mint`, `Burn`, and `Call` receipts in the near future.
 
 > Join our [Discord](https://discord.com/invite/gt7yEUZKeB) channel to make sure you catch all new releases.
+
+### Migration Guide from the `envio@2.x.x-fuel` verion
+
+With the V2.3 release, we merged the Fuel indexer into the main `envio` repo. This means that you can now use the `envio` version to run both Fuel and EVM indexers.
+
+However, if you are using the `envio` version suffixed with `-fuel`, you will need to migrate to the new version. It shouldn't take more than a few minutes to do so.
+
+To migrate, start with updating the package version:
+
+```bash
+pnpm i envio@latest
+```
+
+> If you installed `envio` globally, you will also need to run `pnpm i -g envio@latest`
+
+Then in your handlers rename `data` to `params`:
+
+```diff
+SwayFarmContract.NewPlayer.handler(async ({ event, context }) => {
+  context.Player.set({
+-   id: event.data.address.payload.bits,
+-   createdAt: event.time,
++   id: event.params.address.payload.bits,
++   createdAt: event.block.time,
+    ...
+  });
+});
+```
+
+Also, some other event fields were moved:
+
+- `time` -> `block.time`
+- `blockHeight` -> `block.height`
+- X => `block.id`
+- `transactionId` -> `transaction.id`
+- `contractId` -> `srcAddress`
+- `receiptIndex` -> `logIndex`
+- `receiptType` -> removed
+
+These are all Fuel-related changes, but if you use `loaders` follow the [v1 to v2 migration guide](/docs/HyperIndex/v1/migration-guide-v1-v2) to update to the V2 API.
+
+If you need help, create an issue in our [GitHub repository](https://github.com/enviodev/hyperindex). We'll be happy to help!

--- a/docs/HyperIndex/fuel/fuel.md
+++ b/docs/HyperIndex/fuel/fuel.md
@@ -90,6 +90,6 @@ Also, some other event fields were moved:
 - `receiptIndex` -> `logIndex`
 - `receiptType` -> removed
 
-These are all Fuel-related changes, but if you use `loaders` follow the [v1 to v2 migration guide](/docs/HyperIndex/v1/migration-guide-v1-v2) to update to the V2 API.
+These are all Fuel-related changes, but if you use `loaders` follow the [v1 to v2 migration guide](/migration-guide-v1-v2) to update to the V2 API.
 
 If you need help, create an issue in our [GitHub repository](https://github.com/enviodev/hyperindex). We'll be happy to help!


### PR DESCRIPTION
- Remove `Name` prompt
- Update tutorial
- Update Fuel indexer state of the art
- Add migration guide

https://envio-docs-git-dz-fuel-merge-envio-9ec2d675.vercel.app/docs/HyperIndex/fuel
https://envio-docs-git-dz-fuel-merge-envio-9ec2d675.vercel.app/docs/HyperIndex/tutorial-indexing-fuel