### PR TITLE
chaindensity adjustments

### DIFF
--- a/blog/2024-08-19-building-chaindensity.md
+++ b/blog/2024-08-19-building-chaindensity.md
@@ -10,7 +10,7 @@ slug: /building-chaindensity
 
 ## Introduction: The Genesis of ChainDensity
 
-Understanding address activity in blockchain networks is more than just a technical necessity, it reveals the underlying dynamics of decentralized applications. Enter [ChainDensity](https://chaindensity.xyz/), a simple yet powerful tool designed to visualize event and transaction density across [Ethereum](https://ethereum.org/) and any other EVM-compatible blockchain.
+Understanding address activity in blockchain networks is more than just a technical necessity, it reveals the underlying dynamics of decentralized applications. Enter [ChainDensity](https://chaindensity.xyz/), a simple yet powerful tool designed to visualize event and transaction density across Ethereum and any other EVM-compatible blockchain.
 
 ChainDensity transforms raw data into clear visualizations, empowering developers, data analysts, and researchers to uncover trends, optimize performance, and harness the full potential of blockchain technology. By creating density plots that span the entire length of a chain, ChainDensity allows users to quickly grasp when an address is most active and assess its total activity over time.
 
@@ -34,7 +34,10 @@ Event density analysis is very insightful for blockchain data indexing. Traditio
 
 ChainDensity addresses this challenge head-on. It provides a rapid assessment of the volume of events to be indexed and their distribution across the chain. This information is invaluable for planning indexing projects, estimating timelines, and determining the most appropriate indexing methodologies.
 
-Pro-tip: indexing millions of events? Consider using [HyperIndex](https://docs.envio.dev/docs/HyperIndex/hyperindex-basics) (which leverages [HyperSync](https://docs.envio.dev/docs/HyperIndex/hypersync) under the hood) to speed up the process.
+:::tip
+Have an indexer and syncing millions of events?  
+Consider using [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview) (which leverages [HyperSync](https://docs.envio.dev/docs/HyperIndex/hypersync) under the hood as an alternative  data source to RPC) to significantly speed up the process.
+ :::
 
 
 ## The Blockchain Data Retrieval Challenge
@@ -49,14 +52,14 @@ This inefficiency isn't unique to ChainDensity's use case; it's a common hurdle 
 
 ## Enter HyperSync: Modern Blockchain Data Retrieval
 
-[HyperSync](https://docs.envio.dev/docs/HyperIndex/hypersync) emerges as a game-changing solution in the blockchain data retrieval landscape. This highly specialized data node, built with Rust, offers a quantum leap in data retrieval speeds while providing unparalleled flexibility.
+[HyperSync](https://docs.envio.dev/docs/HyperSync/overview) emerges as a game-changing solution in the blockchain data retrieval landscape. This highly specialized data node, built with Rust, offers a quantum leap in data retrieval speeds while providing unparalleled flexibility.
 
 ### Key Features of HyperSync:
 
 * A powerful API that is capable of filtering blocks, transactions, logs, and traces.
 * Granular control over data retrieval.
-* Support for [Python](https://www.python.org/), [Rust](https://www.rust-lang.org/), and [NodeJs](https://nodejs.org/en) clients.
-* Compatibility with over 50 EVM chains and [Fuel](https://fuel.network/).
+* Support for [Python](https://github.com/enviodev/hypersync-client-python), [Rust](https://github.com/enviodev/hypersync-client-rust), and [NodeJs](https://github.com/enviodev/hypersync-client-node) clients.
+* Compatibility with ~60 EVM chains and [Fuel](https://github.com/enviodev/hyperfuel-json-api).
 
 ### HyperSync in Action: The ChainDensity Example
 
@@ -131,7 +134,7 @@ Why not head over to the [repo](https://github.com/enviodev/chain-density) and m
 
 ## Use HyperSync yourself
 
-Explore [ChainDensity](https://chaindensity.xyz) to experience the power of [HyperSync](https://docs.envio.dev/docs/HyperIndex/hypersync) firsthand. If you're looking to leverage HyperSync for your project, visit our documentation or hop in our [Discord](https://discord.com/invite/gt7yEUZKeB) for support.
+Explore [ChainDensity](https://chaindensity.xyz) to experience the power of [HyperSync](https://docs.envio.dev/docs/HyperSync/overview) firsthand. If you're looking to leverage HyperSync for your project, visit our documentation or hop in our [Discord](https://discord.com/invite/gt7yEUZKeB) for support.
 
 ## About Envio
 

--- a/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
+++ b/docs/HyperSync/HyperRPC/hyperrpc-url-endpoints.md
@@ -53,9 +53,12 @@ Here is a table of the currently supported networks on HyperRPC and their respec
 | Lukso Testnet        | 4201       | https://lukso-testnet.rpc.hypersync.xyz or https://4201.rpc.hypersync.xyz           |                 |
 | Manta                | 169        | https://manta.rpc.hypersync.xyz or https://169.rpc.hypersync.xyz                    |                 |
 | Mantle               | 5000       | https://mantle.rpc.hypersync.xyz or https://5000.rpc.hypersync.xyz                  |                 |
+| Merlin               | 4200       | https://merlin.rpc.hypersync.xyz or https://4200.rpc.hypersync.xyz                  |                 |
 | Metis                | 1088       | https://metis.rpc.hypersync.xyz or https://1088.rpc.hypersync.xyz                   |                 |
 | Mev Commit           | 17864      | https://mev-commit.rpc.hypersync.xyz or https://17864.rpc.hypersync.xyz             |                 |
+| Mev Commit Traces    | 17864      | https://mev-commit-traces.rpc.hypersync.xyz or https://17864.rpc.hypersync.xyz      | ✔️              |
 | Mode                 | 34443      | https://mode.rpc.hypersync.xyz or https://34443.rpc.hypersync.xyz                   |                 |
+| Moonbase Alpha       | 1287       | https://moonbase-alpha.rpc.hypersync.xyz or https://1287.rpc.hypersync.xyz          |                 |
 | Moonbeam             | 1284       | https://moonbeam.rpc.hypersync.xyz or https://1284.rpc.hypersync.xyz                |                 |
 | Morph Testnet        | 2810       | https://morph-testnet.rpc.hypersync.xyz or https://2810.rpc.hypersync.xyz           |                 |
 | Neon Evm             | 245022934  | https://neon-evm.rpc.hypersync.xyz or https://245022934.rpc.hypersync.xyz           |                 |

--- a/docs/HyperSync/hypersync-supported-networks.md
+++ b/docs/HyperSync/hypersync-supported-networks.md
@@ -55,9 +55,12 @@ The Tier is the level of support (and therefore reliability) based on the infras
 | Lukso Testnet        | 4201       | https://lukso-testnet.hypersync.xyz or https://4201.hypersync.xyz                   | bronze |                 |
 | Manta                | 169        | https://manta.hypersync.xyz or https://169.hypersync.xyz                            | bronze |                 |
 | Mantle               | 5000       | https://mantle.hypersync.xyz or https://5000.hypersync.xyz                          | gold   |                 |
+| Merlin               | 4200       | https://merlin.hypersync.xyz or https://4200.hypersync.xyz                          | bronze |                 |
 | Metis                | 1088       | https://metis.hypersync.xyz or https://1088.hypersync.xyz                           | bronze |                 |
 | Mev Commit           | 17864      | https://mev-commit.hypersync.xyz or https://17864.hypersync.xyz                     | bronze |                 |
+| Mev Commit Traces    | 17864      | https://mev-commit-traces.hypersync.xyz or https://17864.hypersync.xyz              | bronze | ✔️              |
 | Mode                 | 34443      | https://mode.hypersync.xyz or https://34443.hypersync.xyz                           | bronze |                 |
+| Moonbase Alpha       | 1287       | https://moonbase-alpha.hypersync.xyz or https://1287.hypersync.xyz                  | gold   |                 |
 | Moonbeam             | 1284       | https://moonbeam.hypersync.xyz or https://1284.hypersync.xyz                        | gold   |                 |
 | Morph Testnet        | 2810       | https://morph-testnet.hypersync.xyz or https://2810.hypersync.xyz                   | bronze |                 |
 | Neon Evm             | 245022934  | https://neon-evm.hypersync.xyz or https://245022934.hypersync.xyz                   | bronze |                 |


### PR DESCRIPTION
- We were referencing the wrong hypersync page throughout (the indexer's hypersync page: https://docs.envio.dev/docs/HyperIndex/hypersync ) instead of Hypersync page itself (https://docs.envio.dev/docs/HyperIndex/overview). Where we have the *pro tip *section; i think here the indexer's hypersync page is good to reference as it's about the indexer. 
- where we mention python, rust, jsnode we had linked to python, rust and node js docs. I think more effective linking to the respective Hypersync Pyhton, rust, nodejs repos for clickthroughs is better. Not sure what value linking to python site brings -  @Jordy-Baby  was this for the seo stuff? I think more value here is linking/having a clickthrough to the respective Hypersync Python, rust, nodejs repos.
- Same for fuel, linking to fuel's docs instead of fuel hypersync 