### PR TITLE
Add rpc requests article

### DIFF
--- a/docs/HyperIndex/Guides/contract-state.md
+++ b/docs/HyperIndex/Guides/contract-state.md
@@ -137,7 +137,8 @@ UniswapV3Factory.PoolCreated.handler(async ({ event, context }) => {
 
 Note how we use the `multicall` feature from Viem to batch our 3 queries into one request to improve performance and help avoid rate limiting. Very useful!
 
-Here, we use an alchemy API key to make RPC requests to the ethereum mainnet. You can get an alchemy API key [here](https://www.alchemy.com/) and add it to your `.env` file. Alternatively, use any other rpc provider of your choice.
+
+We recommend using an RPC from [dRPC](https://drpc.org/) and adding it to your `.env` file. Alternatively, use any other rpc provider of your choice.
 
 There are 2 edge cases that we need to be aware of when fetching token information: 
 
@@ -375,4 +376,4 @@ export class Entry<T extends Shape> {
 ### Challenges
 
 1. **Historical state**: The RPC requests as shown here function as a regular RPC requests that return the current contract state. They do not fetch historical contract state. In other words, normal RPC requests always return current contract state, not the contract state for the block which your indexer is processing. For our use case, this doesn't matter as the name, symbol, and decimals of a token should not change over time. But let's say you want to fetch the ether balance of an account at a specific historical block, you would a need [special rpc request](https://docs.etherscan.io/api-pro/api-pro#get-historical-ether-balance-for-a-single-address-by-blockno) that is able to fetch historical state.
-2. **Rate limiting**: Rate limiting refers to when a server limits the number of requests a client can make in a given amount of time. This is done to prevent abuse of the server. So if you make too many RPC requests in a short period of time to the same server, your requests may be blocked. The simplest way to avoid this is to check the rate limits of the server you are making requests to and adding a sufficient delay between requests. A slightly more complex way is to use multiple RPC URLs and rotate your requests between them. In our use case, the multicall feature to batch our requests was sufficient to avoid rate limiting.
+2. **Rate limiting**: Rate limiting refers to when a server limits the number of requests a client can make in a given amount of time. This is done to prevent abuse of the server. So if you make too many RPC requests in a short period of time to the same server, your requests may be blocked. The simplest way to avoid this is to use a paid unthrottled rpc or to check the rate limits of the server you are making requests to and adding a sufficient delay between requests. A slightly more complex way is to use multiple RPC URLs and rotate your requests between them. In our use case, the multicall feature to batch our requests was sufficient to avoid rate limiting.

--- a/docs/HyperIndex/Guides/contract-state.md
+++ b/docs/HyperIndex/Guides/contract-state.md
@@ -9,20 +9,29 @@ slug: /contract-state
 
 TLDR; The repo for the code base can be found [here](https://github.com/enviodev/rpc-token-data-example)
 
-What do you do if a specific event handler doesn't have all the information you want to fetch from the blockchain? You can make RPC requests to fetch the information you need. In this guide, we aim to get token information for every token invovled in a Uniswap V3 pool creation event. For each token we should index its name, symbol and decimals. 
+**Scenario**  
+In this guide, we aim to get token information for every token involved in a [Uniswap V3 pool creation event](https://docs.uniswap.org/contracts/v3/reference/core/interfaces/IUniswapV3Factory#poolcreated). For each token we should index its name, symbol and decimals.
 
+**Problem**  
 At first glance this may appear to be a simple task as we are only indexing over one event, the [pool created](https://docs.uniswap.org/contracts/v3/reference/core/interfaces/IUniswapV3Factory#poolcreated) event. However, there is one catch, have a look at the event signature: 
 
 ```yaml
 PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)
 ```
 
-The event only provides the token addresses, not the token name, symbol, and decimals. So how are we to fetch this extra information in our event handler? In order to do this, we need to make RPC requests to the token contract.
+The event only provides the token addresses, not the token name, symbol, and decimals. So how are we to fetch this extra information in our event handler? 
+
+**Solution**  
+In order to do this, we need to make RPC requests to the token contract.
+
+### Prerequisites
+
+This guide assumes basic familiarity with the viem library for making contract calls. Check out the [viem documentation](https://viem.sh/) for more information. This [medium article](https://medium.com/@0xape/typescript-and-viem-quickstart-for-blockchain-scripting-3f1846970b6f) is highly recommended for a gentle introduction to viem with a very similar example to what we are doing here.
 
 ### Part 1: Create our Uniswap V3 `poolcreated` indexer
 
 `npx envio init`
-Ethereum mainnet contract: [0x1F98431c8aD98523631AE4a59f267346ea31F984](scope.sh/1/address/0x1F98431c8aD98523631AE4a59f267346ea31F984)
+Ethereum mainnet contract address: [0x1F98431c8aD98523631AE4a59f267346ea31F984](scope.sh/1/address/0x1F98431c8aD98523631AE4a59f267346ea31F984)
 
 We then make some light modifications to remove unnecessary events and simplify the schema. The resulting config, schema, and event handlers look as follows:
 
@@ -33,7 +42,7 @@ We remove the `FeeAmountEnabled` and `OwnerChanged` events as they are not relev
 :::
 
 ```yaml
-name: envio-indexer
+name: uniswap-v3-factory-token-indexer
 networks:
 - id: 1
   start_block: 12369620
@@ -50,15 +59,15 @@ rollback_on_reorg: false
 > shema.graphql
 
 :::info
-Simply our schema to only include the pool and token information.
+Simplify our schema to only include the pool and token information.
 :::
 
 ```graphql
 type Token {
   id: ID! #address
   name: String!
-  Symbol: String!
-  Decimals: Int!
+  symbol: String!
+  decimals: Int!
 }
 
 type Pool {
@@ -82,37 +91,50 @@ import { getTokenDetails } from "./tokenDetails";
 
 UniswapV3Factory.PoolCreated.handler(async ({ event, context }) => {
   const entity: Pool = {
-    id: `${event.chainId}-${event.block.number}-${event.logIndex}`,
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
     token0_id: event.params.token0,
     token1_id: event.params.token1,
     fee: event.params.fee,
     tickSpacing: event.params.tickSpacing,
     pool: event.params.pool,
   };
-
-  const {name: name0, symbol: symbol0, decimals: decimals0} = await getTokenDetails(event.params.token0, event.chainId);
-  const {name: name1, symbol: symbol1, decimals: decimals1} = await getTokenDetails(event.params.token1, event.chainId);
-
   context.Pool.set(entity)
-  context.Token.set({
-    id: event.params.token0,
-    name: name0,
-    symbol: symbol0,
-    decimals: decimals0
-  })
-  context.Token.set({
-    id: event.params.token1,
-    name: name1,
-    symbol: symbol1,
-    decimals: decimals1,
-  })
+
+
+  try {
+    const {name: name0, symbol: symbol0, decimals: decimals0} = await getTokenDetails(event.params.token0, event.chainId);
+    context.Token.set({
+      id: event.params.token0,
+      name: name0,
+      symbol: symbol0,
+      decimals: decimals0
+    })
+  } catch (error) {
+    console.log(error)
+    return
+  }
+
+  try {
+    const {name: name1, symbol: symbol1, decimals: decimals1} = await getTokenDetails(event.params.token1, event.chainId);
+    context.Token.set({
+      id: event.params.token1,
+      name: name1,
+      symbol: symbol1,
+      decimals: decimals1,
+    })
+  } catch (error) {
+    console.log(error)
+    return
+  }
 });
 
 ```
 
 ### Part 2: Fetch token information
 
-This guide assumes basic familiarity with the viem library more making contract calls. Check out the [viem documentation](https://viem.sh/) for more information.
+Note how we use the `multicall` feature from Viem to batch our 3 queries into one request to improve performance and help avoid rate limiting. Very useful!
+
+Here, we use an alchemy API key to make RPC requests to the ethereum mainnet. You can get an alchemy API key [here](https://www.alchemy.com/) and add it to your `.env` file. Alternatively, use any other rpc provider of your choice.
 
 > src/tokenDetails.ts
 
@@ -176,7 +198,9 @@ export async function getTokenDetails(
 
 ### Part 3: Cache token information
 
-Seeing as our token details should not change over time, we can cache the token information to avoid making the same rpc request multiple times. We can do this by creating a simple cache object that stores the token information. In this case, we cache the data in a json file. For use cases with more data, you should consider using a proper database as accessing json data repeatedly can be slow. See [ipfs](https://docs.envio.dev/docs/HyperIndex/ipfs) for an example of how to cache using a SQLite database.
+To highlight how important this step is in our use case, imagine how many Uniswap V3 pools have been created with USDC. It would be a complete waste of time to make an rpc request for USDC every time it was involved in a pool creation event!
+
+Since the token details we care about don't change over time, we can cache this information to avoid making the same rpc request multiple times.  We can do this by creating a simple cache object that stores the token information. In this case, we cache the data in a json file. For use cases with more data, you should consider using a proper database as accessing a large json file repeatedly can be slow. See the [ipfs example](https://docs.envio.dev/docs/HyperIndex/ipfs) for an example of how to cache using a SQLite database.
 
 :::info
 our cache implementation is designed to be easily extendable as you can add as many cache categories as you want. Here we only have one category for token information.
@@ -294,12 +318,7 @@ export class Entry<T extends Shape> {
 }
 ```
 
-### Part 4: Avoiding rate limiting
-
-See if needed
-
-
 ### Challenges
 
-1. **Historical state**: The rpc requests as shown here function as a regular rpc requests that return the current contract state. They do not fetch historical contract state. In other words, normal rpc requests always return current contract state, not the contract state for the block which your indexer is processing. For our use case, this doesn't matter as the name, symbol, and decimals of a token should not change over time. But let's say you want to fetch the ether balance of an account at a specific historical block, you would a need [special rpc request](https://docs.etherscan.io/api-pro/api-pro#get-historical-ether-balance-for-a-single-address-by-blockno) that is able to fetch historical state.
-2. **Rate limiting**: Rate limiting refers to when a server limits the number of requests a client can make in a given amount of time. This is done to prevent abuse of the server. So if you make too many rpc requests in a short period of time to the same server, your requests may be blocked. The simplest way to avoid this is to check the rate limits of the server you are making requests to and adding a sufficient delay between requests. A slightly more complex way is to use multiple RPC URLs and rotate your requests between them.
+1. **Historical state**: The RPC requests as shown here function as a regular RPC requests that return the current contract state. They do not fetch historical contract state. In other words, normal RPC requests always return current contract state, not the contract state for the block which your indexer is processing. For our use case, this doesn't matter as the name, symbol, and decimals of a token should not change over time. But let's say you want to fetch the ether balance of an account at a specific historical block, you would a need [special rpc request](https://docs.etherscan.io/api-pro/api-pro#get-historical-ether-balance-for-a-single-address-by-blockno) that is able to fetch historical state.
+2. **Rate limiting**: Rate limiting refers to when a server limits the number of requests a client can make in a given amount of time. This is done to prevent abuse of the server. So if you make too many RPC requests in a short period of time to the same server, your requests may be blocked. The simplest way to avoid this is to check the rate limits of the server you are making requests to and adding a sufficient delay between requests. A slightly more complex way is to use multiple RPC URLs and rotate your requests between them. In our use case, the multicall feature to batch our requests was sufficient to avoid rate limiting.

--- a/docs/HyperIndex/Guides/rpc-requests.md
+++ b/docs/HyperIndex/Guides/rpc-requests.md
@@ -1,13 +1,13 @@
 ---
 id: rpc-requests
-title: RPC Request for contract state
-sidebar_label: rpc requests
+title: RPC Requests
+sidebar_label: RPC Requests
 slug: /rpc-requests
 ---
 
 # RPC Requests guide
 
-TLDR; The repo for the code base can be found [here]()
+TLDR; The repo for the code base can be found [here](todo_add_link)
 
 What do you do if a specific event handler doesn't have all the information you want to fetch from the blockchain? You can make RPC requests to fetch the information you need. In this guide, we aim to get token information for every token invovled in a Uniswap V3 pool creation event. For each token we should index its name, symbol and decimals. 
 

--- a/docs/HyperIndex/Guides/rpc-requests.md
+++ b/docs/HyperIndex/Guides/rpc-requests.md
@@ -21,7 +21,7 @@ The event only provides the token addresses, not the token name, symbol, and dec
 
 ### Prerequisites
 
-This guide assumes basic familiarity with the viem library for making contract calls. Check out the [viem documentation](https://viem.sh/) for more information. [This medium article](https://medium.com/@0xape/typescript-and-viem-quickstart-for-blockchain-scripting-3f1846970b6f) is highly recommened for a gentle introduction to viem with a very similar example to what we are doing here.
+This guide assumes basic familiarity with the viem library for making contract calls. Check out the [viem documentation](https://viem.sh/) for more information. This [medium article](https://medium.com/@0xape/typescript-and-viem-quickstart-for-blockchain-scripting-3f1846970b6f) is highly recommened for a gentle introduction to viem with a very similar example to what we are doing here.
 
 ### Part 1: Create our Uniswap V3 `poolcreated` indexer
 
@@ -37,7 +37,7 @@ We remove the `FeeAmountEnabled` and `OwnerChanged` events as they are not relev
 :::
 
 ```yaml
-name: envio-indexer
+name: uniswap-v3-factory-token-indexer
 networks:
 - id: 1
   start_block: 12369620
@@ -193,7 +193,7 @@ export async function getTokenDetails(
 
 To highlight how important this step is in our use case, imagine how many Uniswap V3 pools have been created with USDC. It would be a complete waste of time to make an rpc request for USDC every time it was involved in a pool creation event!
 
-Seeing the token details we care about don't change over time, we can cache this information to avoid making the same rpc request multiple times.  We can do this by creating a simple cache object that stores the token information. In this case, we cache the data in a json file. For use cases with more data, you should consider using a proper database as accessing json data repeatedly can be slow. See the [ipfs example](https://docs.envio.dev/docs/HyperIndex/ipfs) for an example of how to cache using a SQLite database.
+Seeing as the token details we care about don't change over time, we can cache this information to avoid making the same rpc request multiple times.  We can do this by creating a simple cache object that stores the token information. In this case, we cache the data in a json file. For use cases with more data, you should consider using a proper database as accessing a large json file repeatedly can be slow. See the [ipfs example](https://docs.envio.dev/docs/HyperIndex/ipfs) for an example of how to cache use a SQLite database.
 
 :::info
 our cache implementation is designed to be easily extendable as you can add as many cache categories as you want. Here we only have one category for token information.

--- a/docs/HyperIndex/Guides/rpc-requests.md
+++ b/docs/HyperIndex/Guides/rpc-requests.md
@@ -1,0 +1,311 @@
+---
+id: rpc-requests
+title: RPC Request for contract state
+sidebar_label: rpc requests
+slug: /rpc-requests
+---
+
+# RPC Requests guide
+
+TLDR; The repo for the code base can be found [here]()
+
+What do you do if a specific event handler doesn't have all the information you want to fetch from the blockchain? You can make RPC requests to fetch the information you need. In this guide, we aim to get token information for every token invovled in a Uniswap V3 pool creation event. For each token we should index its name, symbol and decimals. 
+
+At first glance this may appear to be a simple task as we are only indexing over one event, the [pool created](https://docs.uniswap.org/contracts/v3/reference/core/interfaces/IUniswapV3Factory#poolcreated) event. However, there is one catch, have a look at the event signature: 
+
+```yaml
+PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)
+```
+
+The event only provides the token addresses, not the token name, symbol, and decimals. So how are we to fetch this extra information in our event handler? In order to do this, we need to make RPC requests to the token contract.
+
+### Part 1: Create our Uniswap V3 `poolcreated` indexer
+
+`npx envio init`
+Contract address: `0x1F98431c8aD98523631AE4a59f267346ea31F984`
+
+We then make some light modifications to remove unnecessary events and simplify the schema. The resulting config, schema, and event handlers look as follows:
+
+> config.yaml
+
+:::info
+We remove the `FeeAmountEnabled` and `OwnerChanged` events as they are not relevant to our use case.
+:::
+
+```yaml
+name: envio-indexer
+networks:
+- id: 1
+  start_block: 12369620
+  contracts:
+  - name: UniswapV3Factory
+    address:
+    - 0x1F98431c8aD98523631AE4a59f267346ea31F984
+    handler: src/EventHandlers.ts
+    events:
+    - event: PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)
+rollback_on_reorg: false
+```
+
+> shema.graphql
+
+:::info
+Simply our schema to only include the pool and token information.
+:::
+
+```graphql
+type Token {
+  id: ID! #address
+  name: String!
+  Symbol: String!
+  Decimals: Int!
+}
+
+type Pool {
+  id: ID! # address
+  token0: Token! 
+  token1: Token!
+  fee: BigInt!
+  tickSpacing: BigInt!
+  pool: String!
+}
+```
+
+> src/EventHandlers.ts
+
+```typescript
+import {
+  UniswapV3Factory,
+  Pool,
+} from "generated";
+import { getTokenDetails } from "./tokenDetails";
+
+UniswapV3Factory.PoolCreated.handler(async ({ event, context }) => {
+  const entity: Pool = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    token0_id: event.params.token0,
+    token1_id: event.params.token1,
+    fee: event.params.fee,
+    tickSpacing: event.params.tickSpacing,
+    pool: event.params.pool,
+  };
+
+  const {name: name0, symbol: symbol0, decimals: decimals0} = await getTokenDetails(event.params.token0, event.chainId);
+  const {name: name1, symbol: symbol1, decimals: decimals1} = await getTokenDetails(event.params.token0, event.chainId);
+
+  context.Pool.set(entity)
+  context.Token.set({
+    id: event.params.token0,
+    name: name0,
+    symbol: symbol0,
+    decimals: decimals0
+  })
+  context.Token.set({
+    id: event.params.token1,
+    name: name1,
+    symbol: symbol1,
+    decimals: decimals1,
+  })
+});
+
+```
+
+### Part 2: Fetch token information
+
+This guide assumes basic familiarity with the viem library more making contract calls. Check out the [viem documentation](https://viem.sh/) for more information.
+
+```typescript
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
+import { Cache, CacheCategory } from "./cache"; 
+import { getRpcUrl } from './utils';
+const erc20ABI = require("./ERC20.json");
+
+const client = createPublicClient({ 
+  chain: mainnet, 
+  transport: http('https://eth-mainnet.g.alchemy.com/v2/<alchemy-api-key>'), 
+}) 
+
+export async function getTokenDetails(
+  contractAddress: string,
+  chainId: number
+): Promise<{
+  readonly name: string,
+  readonly symbol: string,
+  readonly decimals: number,
+}> {
+  const cache = await Cache.init(CacheCategory.Token, chainId);
+  const token = await cache.read(contractAddress.toLowerCase());
+
+  if (token) {
+    return token;
+  }
+
+  // RPC URL
+  // const rpcURL = getRpcUrl();
+
+  console.log("attempting to get")
+  console.log(erc20ABI)
+  try {
+    const name = await client.readContract({ 
+      ...erc20ABI, 
+      functionName: 'name',
+    })
+    console.log("got name", name)
+    const symbol = await client.readContract({
+      ...erc20ABI,
+      functionName: 'symbol',
+    })
+  
+    const decimals = await client.readContract({
+      ...erc20ABI,
+      functionName: 'decimals',
+    })
+
+    const entry = {
+      name: name?.toString() || "",
+      symbol: symbol?.toString() || "",
+      decimals: decimals as number,
+    } as const;
+
+    console.log("got")
+
+    cache.add({ [contractAddress.toLowerCase()]: entry as any});
+
+    return entry;
+  } catch (err) {
+    console.error("An error occurred for token ", contractAddress, err);
+    throw err
+  }
+}
+```
+
+### Part 3: Cache token information
+
+Seeing as our token details should not change over time, we can cache the token information to avoid making the same rpc request multiple times. We can do this by creating a simple cache object that stores the token information. In this case, we cache the data in a json file. For use cases with more data, you should consider using a proper database as accessing json data repeatedly can be slow. See [ipfs](add link) for an example of how to cache using a SQLite database.
+
+:::info
+our cache implementation is designed to be easily extendable as you can add as many cache categories as you want. Here we only have one category for token information.
+:::
+
+> src/cache.ts
+
+```typescript
+import * as fs from "fs";
+import * as path from "path";
+
+export const CacheCategory = {
+  Token: "token",
+} as const;
+
+export type CacheCategory = (typeof CacheCategory)[keyof typeof CacheCategory];
+
+type Address = string;
+
+type Shape = Record<string, Record<string, string>>;
+type ShapeRoot = Shape & Record<Address, { hash: string }>;
+
+type ShapeToken = Shape &
+  Record<Address, { decimals: number; name: string; symbol: string }>;
+
+
+export class Cache {
+  static init<C = CacheCategory>(
+    category: C,
+    chainId: number | string | bigint
+  ) {
+    if (!Object.values(CacheCategory).find((c) => c === category)) {
+      throw new Error("Unsupported cache category");
+    }
+
+    type S = C extends "token"
+      ? ShapeToken
+      : ShapeRoot;
+    const entry = new Entry<S>(`${category}-${chainId.toString()}`);
+    return entry;
+  }
+}
+
+export class Entry<T extends Shape> {
+  private memory: Shape = {};
+
+  static encoding = "utf8" as const;
+  static folder = "./.cache" as const;
+
+  public readonly key: string;
+  public readonly file: string;
+
+  constructor(key: string) {
+    this.key = key;
+    this.file = Entry.resolve(key);
+
+    this.preflight();
+    this.load();
+  }
+
+  public read(key: string) {
+    const memory = this.memory || {};
+    return memory[key] as T[typeof key];
+  }
+
+  public load() {
+    try {
+      const data = fs.readFileSync(this.file, Entry.encoding);
+      this.memory = JSON.parse(data) as T;
+    } catch (error) {
+      console.error(error);
+      this.memory = {};
+    }
+  }
+
+  public add<N extends T>(fields: N) {
+    if (!this.memory || Object.values(this.memory).length === 0) {
+      this.memory = fields;
+    } else {
+      Object.keys(fields).forEach((key) => {
+        if (!this.memory[key]) {
+          this.memory[key] = {};
+        }
+        Object.keys(fields[key]).forEach((nested) => {
+          this.memory[key][nested] = fields[key][nested];
+        });
+      });
+    }
+
+    this.publish();
+  }
+
+  private preflight() {
+    /** Ensure cache folder exists */
+    if (!fs.existsSync(Entry.folder)) {
+      fs.mkdirSync(Entry.folder);
+    }
+    if (!fs.existsSync(this.file)) {
+      fs.writeFileSync(this.file, JSON.stringify({}));
+    }
+  }
+
+  private publish() {
+    const prepared = JSON.stringify(this.memory);
+    try {
+      fs.writeFileSync(this.file, prepared);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  static resolve(key: string) {
+    return path.join(Entry.folder, key.toLowerCase().concat(".json"));
+  }
+}
+```
+
+### Part 4: Avoiding rate limiting
+
+See if needed
+
+
+### Challenges
+
+1. **Historical state**: The rpc requests as shown here function as a regular rpc requests that return the current contract state. They do not fetch historical contract state. In other words, normal rpc requests always return current contract state, not the contract state for the block which your indexer is processing. For our use case, this doesn't matter as the name, symbol, and decimals of a token should not change over time. But let's say you want to fetch the ether balance of an account at a specific historical block, you would a need [special rpc request](https://docs.etherscan.io/api-pro/api-pro#get-historical-ether-balance-for-a-single-address-by-blockno) that is able to fetch historical state.
+2. **Rate limiting**: Rate limiting refers to when a server limits the number of requests a client can make in a given amount of time. This is done to prevent abuse of the server. So if you make too many rpc requests in a short period of time to the same server, your requests may be blocked. The simplest way to avoid this is to check the rate limits of the server you are making requests to and adding a sufficient delay between requests. A slightly more complex way is to use multiple RPC URLs and rotate your requests between them.

--- a/sidebarsHyperIndex.js
+++ b/sidebarsHyperIndex.js
@@ -19,6 +19,7 @@ module.exports = {
         "Guides/navigating-hasura",
         "Guides/ipfs",
         "Guides/cli-commands",
+        "Guides/rpc-requests"
       ],
     },
     {


### PR DESCRIPTION
This PR aims to add an article detailing how to make RPC requests in your event handler. 

### Article details

The article largely follows the format of the [IPFS tutorial](https://docs.envio.dev/docs/HyperIndex/ipfs) and demonstrates how to get ERC20 token details inside an event handler in Envio

### Indexer details

It uses a single event handler for uniswap v3 pool created event. Inside the event handler, it fetches the name, symbol, and decimals of each token and caches them. See [here](https://github.com/AlexTheLion123/envio-uniswap-factory-indexer) for the ongoing progress of the indexer. 