### PR TITLE
Fix network filter logic

### DIFF
--- a/scripts/update-endpoints.js
+++ b/scripts/update-endpoints.js
@@ -339,8 +339,8 @@ const generateMarkdownFiles = async () => {
     // Generate HyperSync files
     data.forEach((network) => {
       if (
-        network.tier.toLowerCase() != "HIDDEN".toLowerCase() ||
-        network.tier.toLowerCase() != "INTERNAL".toLowerCase()
+        network.tier.toLowerCase() !== "hidden" &&
+        network.tier.toLowerCase() !== "internal"
       ) {
         const content = generateHyperSyncMarkdownContent(network);
         const filePath = path.join(outputDir, `${network.name}.md`);
@@ -352,8 +352,8 @@ const generateMarkdownFiles = async () => {
 
     // Generate RPC files
     rpcNetworks.forEach(network => {
-      // if network.chainId exists in data, skip it, implies it's now supported in hypersync       
-      if (data.find(item => item.chainId === network.chainId)) {
+      // if network.chainId exists in data, skip it, implies it's now supported in hypersync
+      if (data.find(item => item.chain_id === network.chainId)) {
         return
       }
       const content = generateRPCMarkdownContent(network)


### PR DESCRIPTION
## Summary
- ensure hidden/internal networks are skipped when generating docs
- check network ids correctly when creating RPC docs

## Testing
- `git status --short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved filtering to ensure networks with "hidden" or "internal" tiers are properly excluded from HyperSync documentation.
	- Corrected data matching to prevent supported RPC networks from being incorrectly skipped in HyperSync documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->