### PR TITLE
Fix October 2024 blog: prereg flag deprecated

### DIFF
--- a/blog/2024-10-29-envio-community-update-oct-2024.md
+++ b/blog/2024-10-29-envio-community-update-oct-2024.md
@@ -39,6 +39,8 @@ PoolFactory.CreatePool.contractRegister(
 );
 ```
 
+> **Update:** The `preRegisterDynamicContracts` option was deprecated in version `2.19.0` because default contract registration became significantly faster. You no longer need to enable pre-registration explicitly.
+
 ## Envio Powers Developers on Fuel Ignition
 
 <img src="/blog-assets/envio-developer-community-oct-2024-2.png" alt="Fuel Envio Indexer Partnership" width="100%"/>


### PR DESCRIPTION
## Summary
- note that `preRegisterDynamicContracts` was deprecated in v2.19.0

## Testing
- `yarn build` *(fails: package missing in lockfile)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a note clarifying the deprecation of the `preRegisterDynamicContracts` option, explaining that it is no longer needed due to improvements in contract registration speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->