### PR TITLE
Add note about checksumed addresses in event object

### DIFF
--- a/docs/HyperIndex/Guides/event-handlers.mdx
+++ b/docs/HyperIndex/Guides/event-handlers.mdx
@@ -199,6 +199,12 @@ The event object also contains additional metadata:
 - `event.block` – Block fields (By default: `number`, `timestamp`, `hash`).
 - `event.transaction` – Transaction fields (eg `hash`, `gasUsed`, etc. Empty by default).
 
+:::tip
+All addresses returned in the `event` object, such as `event.transaction.from`,
+`event.transaction.to`, and `event.srcAddress`, are [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksummed.
+Use `.toLowerCase()` if you specifically need lowercase values.
+:::
+
 :::note
 Configure block and transaction fields with [`field_selection`](/docs/HyperIndex/configuration-file#field-selection) in your `config.yaml` file.
 :::


### PR DESCRIPTION
## Summary
- clarify address casing in the Event object docs

## Testing
- `yarn build` *(fails: package not present in lockfile)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a tip explaining that all addresses in event data use the EIP-55 checksum format and suggesting the use of `.toLowerCase()` if lowercase addresses are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->