### PR TITLE
Add address format note

### DIFF
--- a/docs/HyperIndex/Guides/configuration-file.mdx
+++ b/docs/HyperIndex/Guides/configuration-file.mdx
@@ -48,6 +48,11 @@ networks:
 
 Set the address of the smart contract you're indexing.
 
+:::note
+Addresses can be provided in **checksum** format or in **lowercase**.
+Envio accepts both and normalizes them internally.
+:::
+
 **Single address:**
 
 ```yaml


### PR DESCRIPTION
## Summary
- document that contract addresses in `config.yaml` can be checksummed or lower-case

## Testing
- `yarn test` *(fails: package not present)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that smart contract addresses in the configuration file can be provided in either checksum or lowercase format, and both are accepted and normalized internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->