### PR TITLE
Update self-hosting docs to reference Docker example repo

### DIFF
--- a/docs/HyperIndex/Hosted_Service/self-hosting.md
+++ b/docs/HyperIndex/Hosted_Service/self-hosting.md
@@ -36,111 +36,14 @@ Before self-hosting, ensure you have:
 ## Getting Started
 
 In general, if you want to self-host, you will likely use a Docker setup.
+For a working example, check out the [local-docker-example repository](https://github.com/enviodev/local-docker-example).
+It contains a minimal `Dockerfile` and `docker-compose.yaml` that configure the Envio indexer together with PostgreSQL and Hasura.
 
-The following is a `docker-compose.yaml` example showing how the Envio service, PostgreSQL database, and Hasura GraphQL engine can be configured together:
 
-```yaml
-services:
-  envio-postgres:
-    image: postgres:16
-    restart: always
-    ports:
-      - "${ENVIO_PG_PORT:-5433}:5432"
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: ${ENVIO_POSTGRES_PASSWORD:-testing}
-      POSTGRES_USER: ${ENVIO_PG_USER:-postgres}
-      POSTGRES_DB: ${ENVIO_PG_DATABASE:-envio-dev}
-    networks:
-      - my-proxy-net
-
-  graphql-engine:
-    image: hasura/graphql-engine:v2.43.0
-    ports:
-      - "${HASURA_EXTERNAL_PORT:-8080}:8080"
-    user: 1001:1001
-    depends_on:
-      - "envio-postgres"
-    restart: always
-    environment:
-      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:${ENVIO_POSTGRES_PASSWORD:-testing}@envio-postgres:5432/envio-dev
-      HASURA_GRAPHQL_ENABLE_CONSOLE: ${HASURA_GRAPHQL_ENABLE_CONSOLE:-true}
-      HASURA_GRAPHQL_ENABLED_LOG_TYPES:
-        startup, http-log, webhook-log, websocket-log,
-        query-log
-      HASURA_GRAPHQL_NO_OF_RETRIES: 10
-      HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET:-testing}
-      HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES: "true"
-      PORT: 8080
-      HASURA_GRAPHQL_UNAUTHORIZED_ROLE: public
-    healthcheck:
-      test: timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1
-      interval: 5s
-      timeout: 2s
-      retries: 50
-      start_period: 5s
-    networks:
-      - my-proxy-net
-
-  envio-indexer:
-    container_name: envio-indexer
-    build:
-      context: .
-      dockerfile: Dockerfile
-    ports:
-      - "8081:8081"
-    depends_on:
-      graphql-engine:
-        condition: service_healthy
-    deploy:
-      resources:
-        limits:
-          cpus: "0.8" # Limit to 80% of 1 CPU (800m)
-          memory: 800M # Conservative limit, can be increased if needed
-    restart: always
-    environment:
-      ENVIO_POSTGRES_PASSWORD: ${ENVIO_POSTGRES_PASSWORD:-testing}
-      ENVIO_PG_HOST: envio-postgres
-      ENVIO_PG_PORT: 5432
-      ENVIO_PG_USER: ${ENVIO_PG_USER:-postgres}
-      ENVIO_PG_DATABASE: ${ENVIO_PG_DATABASE:-envio-dev}
-      PG_PASSWORD: ${ENVIO_POSTGRES_PASSWORD:-testing}
-      PG_HOST: envio-postgres
-      PG_PORT: 5432
-      PG_USER: ${ENVIO_PG_USER:-postgres}
-      PG_DATABASE: ${ENVIO_PG_DATABASE:-envio-dev}
-      CONFIG_FILE: ${CONFIG_FILE:-config.yaml}
-      LOG_LEVEL: ${LOG_LEVEL:-trace}
-      LOG_STRATEGY: ${LOG_STRATEGY:-console-pretty}
-      MAX_QUEUE_SIZE: 50000
-      MAX_BATCH_SIZE: 10000
-      # These variables can be skipped if Hasura is not necessary
-      HASURA_GRAPHQL_ENDPOINT: http://graphql-engine:8080/v1/metadata
-      HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET:-testing}
-      HASURA_SERVICE_HOST: graphql-engine
-      HASURA_SERVICE_PORT: 8080
-      TUI_OFF: ${TUI_OFF:-true}
-    healthcheck:
-      test: timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1
-      interval: 5s
-      timeout: 2s
-      retries: 50
-      start_period: 5s
-    networks:
-      - my-proxy-net
-
-volumes:
-  db_data:
-
-networks:
-  my-proxy-net:
-    name: local_test_network
-```
 
 ## Configuration Explained
 
-This Docker Compose setup includes three main services:
+The compose file in that repository sets up three main services:
 
 1. **PostgreSQL Database** (`envio-postgres`): Stores your indexed data
 2. **Hasura GraphQL Engine** (`graphql-engine`): Provides the GraphQL API for querying your data


### PR DESCRIPTION
## Summary
- update self-hosting instructions
- link to the `local-docker-example` repo as the canonical setup

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6867bc543aa4832c85433625470d086f