### PR TITLE
Add Block Selection section

### DIFF
--- a/docs/HyperSync/hypersync-query.md
+++ b/docs/HyperSync/hypersync-query.md
@@ -218,6 +218,18 @@ struct TransactionSelection {
 }
 ```
 
+#### Block Selection
+
+```rust
+struct BlockSelection {
+    /// Block hashes to match (empty = match all)
+    hash: Array<Hash>,
+
+    /// Miner/validator addresses to match (empty = match all)
+    miner: Array<Address>,
+}
+```
+
 #### Trace Selection
 
 ```rust


### PR DESCRIPTION
## Summary
- document BlockSelection struct within HyperSync query reference

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_687fc45442ac8327ab952a70fa98c2e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the query structure reference to include a new `BlockSelection` type, allowing users to filter queries by block hashes and miner or validator addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->