### PR TITLE
Document referencing other entities with <field>_id

### DIFF
--- a/docs/HyperIndex/Guides/event-handlers.mdx
+++ b/docs/HyperIndex/Guides/event-handlers.mdx
@@ -285,6 +285,30 @@ context.Entity.set({
 Both `context.Entity.set` and `context.Entity.deleteUnsafe` methods use the In-Memory Storage under the hood and don't require `await` in front of them.
 :::
 
+### Referencing Linked Entities
+
+When your schema defines a field that links to another entity type, set the relationship using `<field>_id` with the referenced entity's `id`. You are storing the ID, not the full entity object.
+
+```graphql
+type A {
+  id: ID!
+  b: B!
+}
+
+type B {
+  id: ID!
+}
+```
+
+```typescript
+context.A.set({
+  id: aId,
+  b_id: bId, // ID of the linked B entity
+});
+```
+
+HyperIndex automatically resolves `A.b` based on the stored `b_id` when querying the API.
+
 ### Deleting Entities (Unsafe)
 
 To delete an entity:

--- a/docs/HyperIndex/Guides/schema-file.md
+++ b/docs/HyperIndex/Guides/schema-file.md
@@ -312,8 +312,8 @@ type Token {
 }
 ```
 
-- The `tokens` field in `NftCollection` is a virtual field, populated automatically when querying the API.
-- Set relationships by referencing the related entity's `id`.
+ - The `tokens` field in `NftCollection` is a virtual field, populated automatically when querying the API.
+ - Set relationships in your handlers by assigning `<field>_id` with the related entity's `id`. For example, create or update a `Token` entity with `collection_id: collectionId`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add section on referencing linked entities in handlers
- clarify relation storage in schema file guide

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_688211626f588327badc90773281d8c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining how to reference linked entities using the `<field>_id` convention in the schema documentation.
  * Updated guidance on setting relationships in event handlers, providing clearer instructions and examples.
  * Improved formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->