### PR TITLE
envio specific env vars

### DIFF
--- a/docs/HyperIndex/Guides/environment-variables.md
+++ b/docs/HyperIndex/Guides/environment-variables.md
@@ -30,7 +30,6 @@ The following variables are used by HyperIndex:
 
 - `ENVIO_API_TOKEN`: API token for HyperSync access (required for continued access in self-hosted deployments)
 - `ENVIO_HASURA`: Set to `false` to disable Hasura integration for self-hosted indexers
-- `ENVIO_SAVE_BENCHMARK_DATA`: When `true`, saves benchmark data during runs for later summary
 
 - `ENVIO_PG_PORT`: Port for the Postgres service used by HyperIndex during local development
 - `ENVIO_PG_PASSWORD`: Postgres password (self-hosted)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Envio-specific environment variables” section to the environment variables guide.
  * Documented variables: ENVIO_API_TOKEN, ENVIO_HASURA, ENVIO_PG_PORT, ENVIO_PG_PASSWORD, ENVIO_PG_USER, ENVIO_PG_DATABASE, ENVIO_PG_PUBLIC_SCHEMA.
  * Clarifies usage for self-hosted setups (access token, disabling Hasura, Postgres credentials), local development (port), and schema overrides.
  * Positioned between the existing Envio API Token section and Example Environment Variables.
  * No functional changes; documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->