### PR TITLE
Add HyperSync DNS troubleshooting docs

### DIFF
--- a/docs/HyperSync/hypersync-troubleshooting.md
+++ b/docs/HyperSync/hypersync-troubleshooting.md
@@ -1,0 +1,142 @@
+---
+id: hypersync-troubleshooting
+title: Troubleshooting
+sidebar_label: Troubleshooting
+slug: /troubleshooting
+description: Solutions for common HyperSync and HyperRPC connectivity issues including DNS resolution failures.
+---
+
+# HyperSync Troubleshooting
+
+This guide covers common connectivity issues with HyperSync and HyperRPC endpoints. If you don't find a solution here, please join our [Discord community](https://discord.gg/DhfFhzuJQh) for additional support.
+
+## DNS Resolution Failures
+
+### Symptoms
+
+- HyperSync or HyperRPC requests hang or timeout intermittently
+- `curl` to HyperSync endpoints is slow on the first request but works after retrying
+- Errors like `Could not resolve host` or `SERVFAIL` when querying `*.hypersync.xyz` or `*.rpc.hypersync.xyz`
+- The issue appears on cold start (first request after a period of inactivity) but resolves after a successful lookup
+
+### Cause
+
+HyperSync and HyperRPC endpoints use geographic load balancing (GSLB) with a multi-step DNS delegation chain. Some ISP and home router DNS resolvers — particularly in regions like South Africa, parts of Asia, and other areas far from US/EU — cannot follow this delegation chain correctly and return `SERVFAIL` instead of resolving the domain.
+
+The issue is made worse by the low TTL (time-to-live) on DNS records, which means your resolver needs to re-resolve the full chain frequently rather than serving from cache.
+
+**This is a client-side DNS resolver issue, not a HyperSync service outage.** Public DNS resolvers like Cloudflare and Google handle the resolution correctly.
+
+### How to verify
+
+You can confirm this is a DNS issue by testing with different resolvers:
+
+```bash
+# This will likely fail or be slow (your system/ISP resolver)
+dig eth.hypersync.xyz A
+
+# These should succeed immediately
+dig eth.hypersync.xyz A @1.1.1.1   # Cloudflare
+dig eth.hypersync.xyz A @8.8.8.8   # Google
+```
+
+If the first command returns `status: SERVFAIL` but the others return `status: NOERROR` with IP addresses, your system DNS resolver is the problem.
+
+### Solution
+
+Configure your system to use public DNS resolvers (Cloudflare and Google) instead of your ISP/router DNS.
+
+#### Linux (systemd-resolved — Ubuntu, Debian, Fedora, etc.)
+
+```bash
+sudo mkdir -p /etc/systemd/resolved.conf.d
+
+echo '[Resolve]
+DNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4
+FallbackDNS=9.9.9.9
+Cache=yes
+CacheFromLocalhost=yes' | sudo tee /etc/systemd/resolved.conf.d/dns.conf
+
+sudo systemctl restart systemd-resolved
+```
+
+To revert:
+
+```bash
+sudo rm /etc/systemd/resolved.conf.d/dns.conf
+sudo systemctl restart systemd-resolved
+```
+
+#### macOS
+
+```bash
+# Replace Wi-Fi with your network interface name if different
+sudo networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4
+```
+
+To revert:
+
+```bash
+sudo networksetup -setdnsservers Wi-Fi Empty
+```
+
+#### Windows
+
+1. Open **Settings > Network & Internet > Wi-Fi > Hardware properties**
+2. Click **Edit** next to DNS server assignment
+3. Set to **Manual** and enter:
+   - Preferred DNS: `1.1.1.1`
+   - Alternate DNS: `8.8.8.8`
+
+#### Docker containers
+
+If running HyperSync clients inside Docker, add DNS configuration to your container or compose file:
+
+```yaml
+# docker-compose.yml
+services:
+  your-service:
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+```
+
+### DNS resolvers reference
+
+| IP | Provider | Notes |
+|---|---|---|
+| `1.1.1.1` / `1.0.0.1` | Cloudflare DNS | Generally the fastest global resolver |
+| `8.8.8.8` / `8.8.4.4` | Google Public DNS | Reliable with good global coverage |
+| `9.9.9.9` | Quad9 | Privacy-focused, blocks known malicious domains |
+
+## Connection Timeouts
+
+### Symptoms
+
+- Requests to HyperSync endpoints timeout after DNS resolves successfully
+- `curl https://<chain>.hypersync.xyz/height` hangs or returns a connection error
+
+### Possible causes
+
+1. **Firewall or corporate network blocking:** Some corporate or university networks block non-standard traffic. Try from a different network to confirm.
+2. **Regional routing issues:** In rare cases, network routing between your region and the HyperSync servers may be degraded. This is typically transient.
+
+### How to verify
+
+```bash
+# Check if the endpoint is reachable
+curl -v --max-time 10 https://eth.hypersync.xyz/height
+
+# Check latency to the resolved IP
+ping -c 5 $(dig +short eth.hypersync.xyz A @1.1.1.1 | head -1)
+```
+
+If `curl` succeeds with a block height number, the service is healthy and the issue is likely on the network path between you and the server.
+
+## Getting Help
+
+If you're still experiencing issues after trying the above solutions:
+
+1. Run the DNS check commands above and note the output
+2. Note your geographic location and ISP
+3. Share these details in our [Discord community](https://discord.gg/DhfFhzuJQh) so we can help debug further

--- a/docs/HyperSync/hypersync-troubleshooting.md
+++ b/docs/HyperSync/hypersync-troubleshooting.md
@@ -3,140 +3,64 @@ id: hypersync-troubleshooting
 title: Troubleshooting
 sidebar_label: Troubleshooting
 slug: /troubleshooting
-description: Solutions for common HyperSync and HyperRPC connectivity issues including DNS resolution failures.
+description: Fixes for common HyperSync and HyperRPC connectivity issues, including DNS resolution failures.
 ---
 
-# HyperSync Troubleshooting
+# Troubleshooting
 
-This guide covers common connectivity issues with HyperSync and HyperRPC endpoints. If you don't find a solution here, please join our [Discord community](https://discord.gg/DhfFhzuJQh) for additional support.
+Common connectivity issues with HyperSync and HyperRPC endpoints. If nothing here helps, ask in our [Discord](https://discord.gg/DhfFhzuJQh).
 
-## DNS Resolution Failures
+## DNS resolution failures
 
-### Symptoms
+**Symptoms:** requests hang or time out intermittently, the first request after idle is slow but retries work, or you see `Could not resolve host` / `SERVFAIL` for `*.hypersync.xyz` or `*.rpc.hypersync.xyz`.
 
-- HyperSync or HyperRPC requests hang or timeout intermittently
-- `curl` to HyperSync endpoints is slow on the first request but works after retrying
-- Errors like `Could not resolve host` or `SERVFAIL` when querying `*.hypersync.xyz` or `*.rpc.hypersync.xyz`
-- The issue appears on cold start (first request after a period of inactivity) but resolves after a successful lookup
+**Cause:** HyperSync endpoints use geographic load balancing with a multi-step DNS delegation chain and short TTLs. Some ISP and home-router resolvers (notably in South Africa and parts of Asia) can't follow the chain and return `SERVFAIL`. This is a client-side resolver issue, not an outage; public resolvers like Cloudflare and Google resolve it correctly.
 
-### Cause
-
-HyperSync and HyperRPC endpoints use geographic load balancing (GSLB) with a multi-step DNS delegation chain. Some ISP and home router DNS resolvers — particularly in regions like South Africa, parts of Asia, and other areas far from US/EU — cannot follow this delegation chain correctly and return `SERVFAIL` instead of resolving the domain.
-
-The issue is made worse by the low TTL (time-to-live) on DNS records, which means your resolver needs to re-resolve the full chain frequently rather than serving from cache.
-
-**This is a client-side DNS resolver issue, not a HyperSync service outage.** Public DNS resolvers like Cloudflare and Google handle the resolution correctly.
-
-### How to verify
-
-You can confirm this is a DNS issue by testing with different resolvers:
+**Verify:**
 
 ```bash
-# This will likely fail or be slow (your system/ISP resolver)
-dig eth.hypersync.xyz A
-
-# These should succeed immediately
-dig eth.hypersync.xyz A @1.1.1.1   # Cloudflare
-dig eth.hypersync.xyz A @8.8.8.8   # Google
+dig eth.hypersync.xyz A           # your system/ISP resolver
+dig eth.hypersync.xyz A @1.1.1.1  # Cloudflare
+dig eth.hypersync.xyz A @8.8.8.8  # Google
 ```
 
-If the first command returns `status: SERVFAIL` but the others return `status: NOERROR` with IP addresses, your system DNS resolver is the problem.
+If the first returns `SERVFAIL` and the others return `NOERROR` with IPs, your resolver is the problem.
 
-### Solution
+**Fix:** switch your system DNS to public resolvers.
 
-Configure your system to use public DNS resolvers (Cloudflare and Google) instead of your ISP/router DNS.
+- **Linux (systemd-resolved):**
 
-#### Linux (systemd-resolved — Ubuntu, Debian, Fedora, etc.)
+  ```bash
+  sudo mkdir -p /etc/systemd/resolved.conf.d
+  printf '[Resolve]\nDNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4\nFallbackDNS=9.9.9.9\n' \
+    | sudo tee /etc/systemd/resolved.conf.d/dns.conf
+  sudo systemctl restart systemd-resolved
+  ```
+
+  Revert by deleting the file and restarting `systemd-resolved`.
+
+- **macOS:** `sudo networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4` (replace `Wi-Fi` with your interface; revert with `... Wi-Fi Empty`).
+
+- **Windows:** Settings > Network & Internet > Wi-Fi > Hardware properties > DNS server assignment > Edit > Manual. Preferred `1.1.1.1`, alternate `8.8.8.8`.
+
+- **Docker:** add `dns: ["1.1.1.1", "8.8.8.8"]` to the service in your compose file, or pass `--dns 1.1.1.1 --dns 8.8.8.8` to `docker run`.
+
+| Resolver | IPs |
+|---|---|
+| Cloudflare | `1.1.1.1`, `1.0.0.1` |
+| Google | `8.8.8.8`, `8.8.4.4` |
+| Quad9 | `9.9.9.9` |
+
+## Connection timeouts
+
+If DNS resolves but requests still hang, check the endpoint directly:
 
 ```bash
-sudo mkdir -p /etc/systemd/resolved.conf.d
-
-echo '[Resolve]
-DNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4
-FallbackDNS=9.9.9.9
-Cache=yes
-CacheFromLocalhost=yes' | sudo tee /etc/systemd/resolved.conf.d/dns.conf
-
-sudo systemctl restart systemd-resolved
-```
-
-To revert:
-
-```bash
-sudo rm /etc/systemd/resolved.conf.d/dns.conf
-sudo systemctl restart systemd-resolved
-```
-
-#### macOS
-
-```bash
-# Replace Wi-Fi with your network interface name if different
-sudo networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4
-```
-
-To revert:
-
-```bash
-sudo networksetup -setdnsservers Wi-Fi Empty
-```
-
-#### Windows
-
-1. Open **Settings > Network & Internet > Wi-Fi > Hardware properties**
-2. Click **Edit** next to DNS server assignment
-3. Set to **Manual** and enter:
-   - Preferred DNS: `1.1.1.1`
-   - Alternate DNS: `8.8.8.8`
-
-#### Docker containers
-
-If running HyperSync clients inside Docker, add DNS configuration to your container or compose file:
-
-```yaml
-# docker-compose.yml
-services:
-  your-service:
-    dns:
-      - 1.1.1.1
-      - 8.8.8.8
-```
-
-### DNS resolvers reference
-
-| IP | Provider | Notes |
-|---|---|---|
-| `1.1.1.1` / `1.0.0.1` | Cloudflare DNS | Generally the fastest global resolver |
-| `8.8.8.8` / `8.8.4.4` | Google Public DNS | Reliable with good global coverage |
-| `9.9.9.9` | Quad9 | Privacy-focused, blocks known malicious domains |
-
-## Connection Timeouts
-
-### Symptoms
-
-- Requests to HyperSync endpoints timeout after DNS resolves successfully
-- `curl https://<chain>.hypersync.xyz/height` hangs or returns a connection error
-
-### Possible causes
-
-1. **Firewall or corporate network blocking:** Some corporate or university networks block non-standard traffic. Try from a different network to confirm.
-2. **Regional routing issues:** In rare cases, network routing between your region and the HyperSync servers may be degraded. This is typically transient.
-
-### How to verify
-
-```bash
-# Check if the endpoint is reachable
 curl -v --max-time 10 https://eth.hypersync.xyz/height
-
-# Check latency to the resolved IP
-ping -c 5 $(dig +short eth.hypersync.xyz A @1.1.1.1 | head -1)
 ```
 
-If `curl` succeeds with a block height number, the service is healthy and the issue is likely on the network path between you and the server.
+If this returns a block height, the service is healthy and the problem is on the network path (typically a corporate/university firewall or transient regional routing). Try from a different network to confirm.
 
-## Getting Help
+## Getting help
 
-If you're still experiencing issues after trying the above solutions:
-
-1. Run the DNS check commands above and note the output
-2. Note your geographic location and ISP
-3. Share these details in our [Discord community](https://discord.gg/DhfFhzuJQh) so we can help debug further
+Share the output of the `dig` and `curl` commands above, plus your location and ISP, in our [Discord](https://discord.gg/DhfFhzuJQh).

--- a/sidebarsHyperSync.js
+++ b/sidebarsHyperSync.js
@@ -24,6 +24,7 @@ module.exports = {
     //     "HyperRPC/hyperrpc-supported-networks",
     //   ],
     // },
+    "hypersync-troubleshooting",
     {
       type: "category",
       label: "HyperFuel",


### PR DESCRIPTION
## Summary

- Adds a new Troubleshooting page to the HyperSync docs covering DNS resolution issues
- Documented root cause: ISP/router DNS forwarders in certain regions (South Africa, parts of Asia) return SERVFAIL when resolving HyperSync GSLB delegation chains
- Includes verified fix (switching to Cloudflare/Google DNS) with instructions for Linux, macOS, Windows, and Docker
- Added to HyperSync sidebar navigation

## Context

Investigated intermittent DNS failures affecting all 90 HyperSync chain endpoints when accessed from South Africa. The issue was traced to consumer/ISP DNS resolvers being unable to follow the `*.global.hypersync.xyz` GSLB nameserver delegation. Switching to public resolvers (1.1.1.1 / 8.8.8.8) completely resolved the problem — verified with automated testing across all 180 endpoints.

Full technical report: https://github.com/enviodev/docs/blob/docs/hypersync-dns-troubleshooting/docs/HyperSync/hypersync-troubleshooting.md

## Test plan

- [ ] Verify the troubleshooting page renders correctly on the docs site
- [ ] Confirm sidebar navigation includes the new page
- [ ] Test the DNS verification commands in the docs are accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a concise HyperSync troubleshooting guide covering DNS resolution issues and connection timeouts.
  * Included updated diagnostic commands, resolver information, platform-specific remediation steps, and network connectivity guidance.
  * Added the troubleshooting guide to the HyperSync documentation navigation for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->