### PR TITLE
fix: generate .md files for all docs so llms.txt links resolve

### DIFF
--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -207,8 +207,10 @@ function GenerateLLMSPlugin(context, options) {
                 fs.writeFileSync(outPath, output, "utf-8");
 
                 // ✅ Only run markdown copy for main config
+                // Write .md copies for ALL collected docs so every link in the
+                // static root text resolves — not just those in includeOrder.
                 if (main) {
-                    writeMarkdownCopies(orderedDocs);
+                    writeMarkdownCopies(collectedDocs);
                 }
             }
         },


### PR DESCRIPTION
## Summary

- All 82 `.md` links in `llms.txt` were returning 404
- `writeMarkdownCopies` was called with `orderedDocs` (filtered by `includeOrder`), but the main config has no `includeOrder` set — so `orderedDocs` was always empty and no `.md` files were ever written at build time
- Fix: pass `collectedDocs` instead, so `.md` copies are written for every doc, matching the static links hardcoded in the `root` text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded documentation file inclusion in build output to ensure all discovered documentation is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->