### PR TITLE
fix: make llms.txt .md generation actually work on Vercel

### DIFF
--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -207,8 +207,10 @@ function GenerateLLMSPlugin(context, options) {
                 fs.writeFileSync(outPath, output, "utf-8");
 
                 // ✅ Only run markdown copy for main config
+                // Write .md copies for ALL collected docs so every link in the
+                // static root text resolves — not just those in includeOrder.
                 if (main) {
-                    writeMarkdownCopies(orderedDocs);
+                    writeMarkdownCopies(collectedDocs);
                 }
             }
         },

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -74,12 +74,16 @@ function GenerateLLMSPlugin(context, options) {
 
             // 1. collect docs metadata
             for (const plugin of plugins) {
-                if (
-                    Array.isArray(plugin) &&
-                    plugin[0] === "@docusaurus/plugin-content-docs"
-                ) {
+                const pluginName = Array.isArray(plugin) ? plugin[0] : null;
+                const isDocsPlugin =
+                    typeof pluginName === "string" &&
+                    (pluginName === "@docusaurus/plugin-content-docs" ||
+                        pluginName.includes("plugin-content-docs"));
+
+                if (isDocsPlugin) {
                     const config = plugin[1];
-                    const docsPath = path.resolve(config.path);
+                    // Resolve relative to siteDir so it works regardless of CWD
+                    const docsPath = path.resolve(context.siteDir, config.path);
                     const routeBasePath = config.routeBasePath || "";
 
                     const allFiles = glob.sync("**/*.{md,mdx}", {
@@ -106,7 +110,7 @@ function GenerateLLMSPlugin(context, options) {
                         )}`;
 
                         collectedDocs.push({
-                            filePath: path.join(config.path, file),
+                            filePath: fullPath, // absolute path, safe across CWD changes
                             title,
                             description,
                             pageUrl,


### PR DESCRIPTION
## Summary

PR #868 fixed the wrong variable (`orderedDocs` → `collectedDocs`) but `collectedDocs` itself was always empty due to two bugs in the plugin detection logic — so `.md` files were still never written.

**Bug 1 — brittle plugin detection:**
`plugin[0] === "@docusaurus/plugin-content-docs"` fails if Docusaurus resolves the module path at build time (e.g. to an absolute path). Changed to also match any plugin name that includes `"plugin-content-docs"`.

**Bug 2 — relative file paths:**
`filePath` was stored as `path.join(config.path, file)` (relative), so `fs.readFileSync` could fail depending on CWD at build time on Vercel. Now stored as the absolute `fullPath`. Docs directory also resolved via `context.siteDir` rather than CWD.

## Test plan

- [ ] Check Vercel preview — `docs/HyperIndex/overview.md` should return 200
- [ ] Spot-check HyperSync and HyperRPC: `docs/HyperSync/overview.md`, `docs/HyperRPC/overview-hyperrpc.md`
- [ ] Confirm all 82 links in `llms.txt` return 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)