### PR TITLE
seo: update homepage title and meta description

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -228,7 +228,7 @@ const redirectsList = [
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Envio",
-  tagline: "Envio's documentation for HyperIndex, HyperSync and HyperRPC. Learn how to index blockchain data, query real-time data and build production-ready applications.",
+  tagline: "Build real-time multichain blockchain indexers. Index, query, and ship production web3 apps across any EVM chain in minutes.",
   favicon: "img/favicon.ico",
   url: "https://docs.envio.dev",
   baseUrl: "/",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
+import Head from "@docusaurus/Head";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import styles from "./index.module.css";
 
@@ -9,9 +10,11 @@ export default function Home() {
 
   return (
     <Layout
-      title={`${siteConfig.title} - Documentation`}
-      description="Envio documentation for HyperIndex, HyperSync, and HyperRPC—learn how to build, deploy, and scale fast blockchain indexers and data APIs."
+      description="Build real-time multichain blockchain indexers. Index, query, and ship production web3 apps across any EVM chain in minutes."
     >
+      <Head>
+        <title>Envio | Real-time Blockchain Indexer</title>
+      </Head>
       <main className={styles.main}>
         <div className={styles.container}>
           <h1 className={styles.title}>Envio Documentation</h1>


### PR DESCRIPTION
Homepage now renders as "Envio | Real-time Blockchain Indexer" in search results, with a tighter meta description that leads with the build action and drops marketing superlatives in favor of factual positioning.