### PR TITLE
Document deployment endpoint + auth-gated indexer list/get

### DIFF
--- a/docs/HyperIndex/Hosted_Service/envio-cloud-cli.md
+++ b/docs/HyperIndex/Hosted_Service/envio-cloud-cli.md
@@ -118,6 +118,9 @@ Context is stored at `~/.envio-cloud/context.json`. Resolution priority:
 
 #### List Indexers
 
+Lists indexers across every organisation you are a member of. Use `--org` to
+scope to a single organisation. Requires authentication.
+
 ```bash
 envio-cloud indexer list
 envio-cloud indexer list --org myorg
@@ -127,7 +130,7 @@ envio-cloud indexer list -o json
 
 | Flag | Description |
 |------|-------------|
-| `--org` | Filter by organization |
+| `--org` | Scope to a single organisation you belong to |
 | `--limit` | Limit number of results |
 | `-o, --output` | Output format (`json`) |
 
@@ -139,7 +142,8 @@ envio-cloud indexer get hyperindex mjyoung114 -o json
 envio-cloud indexer get hyperindex --org mjyoung114
 ```
 
-Organisation can be omitted if set via context.
+Organisation can be omitted if set via context. Requires authentication — you
+can only view indexers in organisations you are a member of.
 
 #### Add an Indexer
 
@@ -283,6 +287,34 @@ envio-cloud deployment status hyperindex b3ead3a mjyoung114 --watch-till-synced
 ```bash
 envio-cloud deployment info <indexer> <commit> [organisation]
 ```
+
+#### Get Query Endpoint
+
+Returns the GraphQL query endpoint URL for a deployment. The endpoint is
+computed from deployment parameters and the cluster is resolved from the
+deployment tier via the API. Output is a bare URL, so it composes cleanly with
+shell scripting.
+
+```bash
+envio-cloud deployment endpoint <indexer> <commit> [organisation]
+envio-cloud deployment endpoint hyperindex b3ead3a mjyoung114
+envio-cloud deployment endpoint hyperindex b3ead3a mjyoung114 -o json
+```
+
+Use the URL directly in a `curl` query:
+
+```bash
+curl "$(envio-cloud deployment endpoint hyperindex b3ead3a mjyoung114)" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ _meta { chainMetadata { chainId } } }"}'
+```
+
+| Flag | Description |
+|------|-------------|
+| `--cluster` | Override cluster (`hyper`, `hypertierchicago`, `ip-projects`, `prodaws`, `staging`) |
+| `-o, --output` | Output format (`json`) |
+
+The `ep` alias is also available: `envio-cloud deployment ep <indexer> <commit>`.
 
 #### Promote a Deployment
 


### PR DESCRIPTION
## Summary

- Adds a new **Get Query Endpoint** section to the `envio-cloud` CLI docs covering `envio-cloud deployment endpoint`: the curl scripting pattern, the `--cluster` override, and the `ep` alias.
- Updates the **List Indexers** and **Get Indexer Details** sections to note that both commands now require authentication and only return indexers in organisations you are a member of.

Pairs with enviodev/hosted-service-cli#3, which is the code change making `indexer list` / `indexer get` auth-gated.

## Test plan

- [ ] Preview the Hosted Service → Envio Cloud CLI page and verify the new **Get Query Endpoint** block renders after **Deployment Info**
- [ ] Verify the updated auth notes on **List Indexers** / **Get Indexer Details** read correctly
- [ ] Sanity-check no other CLI doc pages contradict the new auth requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)