### PR TITLE
chore: address CodeRabbit review on #880

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/about-code-owners
 
 # llms.txt and related AI-discoverability content
-docusaurus.config.js                  @Jordy-baby @nikbhintade
-plugins/plugin-generate-llms.js       @Jordy-baby @nikbhintade
+docusaurus.config.js                  @Jordy-Baby @nikbhintade
+plugins/plugin-generate-llms.js       @Jordy-Baby @nikbhintade

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -552,7 +552,7 @@ This file contains links to documentation sections following the llmstxt.org sta
 - [HyperIndex repo](https://github.com/enviodev/hyperindex): Source and issues.
 - [Releases](https://github.com/enviodev/hyperindex/releases): HyperIndex changelog.
 - [Quickstart with AI](https://docs.envio.dev/docs/HyperIndex/quickstart-with-ai.md): End-to-end guide for building an indexer with Claude Code, Cursor, or any MCP-compatible AI coding assistant.
-- [MCP Server](https://docs.envio.dev/docs/HyperIndex/mcp-server.md): Model Context Protocol server for AI coding assistants; endpoint at https://docs.envio.dev/mcp.
+- [MCP Server](https://docs.envio.dev/docs/HyperIndex/mcp-server.md): Model Context Protocol server for AI coding assistants. Endpoint: https://docs.envio.dev/mcp
 - [X](https://x.com/envio_indexer): Social updates.
 - [Telegram](https://t.me/+5mI61oZibEM5OGQ8): Community chat.
 - [Discord](https://discord.gg/envio): Community support.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -421,7 +421,7 @@ const config = {
             root: `
 # Envio: Fast, Multi-Chain Blockchain Indexer
 
-> Envio is a real-time multichain blockchain indexer. HyperIndex is a multichain indexer supporting any EVM chain, plus Solana and Fuel. HyperSync is a high-throughput data layer natively available on 70+ EVM chains and Fuel, and supports any EVM chain via RPC. HyperRPC is a read-only JSON-RPC endpoint powered by HyperSync, up to 5x faster than traditional nodes. Benchmark: Envio 1 min vs The Graph 143 min (Uniswap V2 Factory, Sentio, May 2025).
+> Envio is a real-time multichain blockchain indexer. HyperIndex is a multichain indexer supporting any EVM chain, plus Solana and Fuel. HyperSync is a high-throughput data layer natively available on 70+ EVM chains and Fuel, and supports any EVM chain via RPC. HyperRPC is a read-only JSON-RPC endpoint powered by HyperSync, up to 5x faster than traditional nodes. Benchmark: Envio 1 min vs The Graph 143 min (Uniswap V2 Factory, [Sentio, May 2025](https://docs.envio.dev/docs/HyperIndex/benchmarks.md)).
 
 This file contains links to documentation sections following the llmstxt.org standard.
 


### PR DESCRIPTION
## Summary

Follow-up to #880 addressing CodeRabbit review:

- Correct CODEOWNERS handle casing to `@Jordy-Baby` (canonical).
- Add source link to the benchmark citation in the llms.txt blockquote so LLMs have provenance when quoting the 143x figure.

## Test plan

- [ ] Build runs clean.
- [ ] `curl https://docs.envio.dev/llms.txt` post-deploy shows the linked benchmark citation.

Left out of scope: the Discord invite URL inconsistency CodeRabbit flagged (`discord.gg/envio` vs `discord.gg/Q9qt8gZ2fX`). That's a repo-wide cleanup touching footer config and other places, better handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)