### PR TITLE
feat: generate llms-full.txt for AI knowledge-base ingestion

### DIFF
--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -110,6 +110,7 @@ function GenerateLLMSPlugin(context, options) {
                             title,
                             description,
                             pageUrl,
+                            source: "docs",
                         });
                     }
                 }
@@ -175,6 +176,7 @@ function GenerateLLMSPlugin(context, options) {
                             title,
                             description,
                             pageUrl,
+                            source: "blog",
                         });
                     }
                 }
@@ -224,6 +226,26 @@ function GenerateLLMSPlugin(context, options) {
                     output += `- [${doc.title}](${doc.pageUrl}.md): ${desc}\n`;
                 }
                 return output;
+            }
+
+            // Concatenate every item's stripped markdown content into a single
+            // file with source URL delimiters. Agents (Claude Projects, Cursor)
+            // can paste the whole file in as knowledge-base context.
+            function renderLLMSFull(items, header) {
+                const parts = [header.trim(), ""];
+                for (const item of items) {
+                    const raw = fs.readFileSync(item.filePath, "utf-8");
+                    const body = matter(raw).content.trimStart();
+                    parts.push(`<!-- source: ${item.pageUrl} -->`);
+                    parts.push(`# ${item.title}`);
+                    if (item.description) parts.push(`\n> ${item.description}`);
+                    parts.push("");
+                    parts.push(body.trimEnd());
+                    parts.push("");
+                    parts.push("---");
+                    parts.push("");
+                }
+                return parts.join("\n");
             }
 
             // --- NEW: write .md copies into build folder ---
@@ -276,6 +298,46 @@ function GenerateLLMSPlugin(context, options) {
                 // static root text resolves — not just those in includeOrder.
                 if (main) {
                     writeMarkdownCopies(collectedDocs);
+
+                    // Generate llms-full variants: one for docs, one for blog.
+                    // Agents that cannot browse mid-conversation (Claude Projects,
+                    // Cursor) paste these into their context window for full recall.
+                    const docsItems = collectedDocs.filter(
+                        (d) => d.source === "docs"
+                    );
+                    const blogItems = collectedDocs.filter(
+                        (d) => d.source === "blog"
+                    );
+
+                    if (docsItems.length > 0) {
+                        const header =
+                            `# Envio: Full Documentation for LLMs\n\n` +
+                            `> Every page of docs.envio.dev concatenated as markdown, ` +
+                            `with per-page source URLs, for direct ingestion into ` +
+                            `LLM context windows. Pair with https://docs.envio.dev/llms.txt ` +
+                            `for the navigational index.`;
+                        const content = renderLLMSFull(docsItems, header);
+                        fs.writeFileSync(
+                            path.join(context.outDir, "llms-full.txt"),
+                            content,
+                            "utf-8"
+                        );
+                    }
+
+                    if (blogItems.length > 0) {
+                        const header =
+                            `# Envio: Full Blog and Case Studies for LLMs\n\n` +
+                            `> Every blog post and case study on docs.envio.dev ` +
+                            `concatenated as markdown, with per-page source URLs. ` +
+                            `Pair with https://docs.envio.dev/llms-full.txt for ` +
+                            `technical documentation.`;
+                        const content = renderLLMSFull(blogItems, header);
+                        fs.writeFileSync(
+                            path.join(context.outDir, "llms-full-blog.txt"),
+                            content,
+                            "utf-8"
+                        );
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary

- Extends `plugins/plugin-generate-llms.js` to emit two additional files at build time
- `llms-full.txt` (~1.7 MB, 325 doc pages): every docs page concatenated with source URL delimiters
- `llms-full-blog.txt` (~0.5 MB, 55 posts): every blog post and case study concatenated
- Existing `llms.txt` navigational index is unchanged
- Target use cases: Claude Projects and Cursor users who paste the file into context for full-recall Q&A without mid-conversation browsing

## Test plan

- [x] Local build succeeds, both files written to `build/`
- [x] Page count matches source tree (325 docs + 55 blog = 380)
- [x] Source URL delimiter present for every page
- [ ] Verify preview deploy serves `/llms-full.txt` and `/llms-full-blog.txt` with 200
- [ ] Paste `llms-full.txt` into Claude Projects and run a few sample doc queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Items are now tagged by source type (docs or blog)
  * Generated output files consolidate all documentation and blog content with proper formatting, source URLs, and headers for unified content ingestion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->