### PR TITLE
fix: regenerate OG image when frontmatter ref is stale

### DIFF
--- a/scripts/generate-og-images.js
+++ b/scripts/generate-og-images.js
@@ -359,8 +359,9 @@ async function processFile(filePath) {
   const outputPath = getOutputPath(filePath);
   const staticUrl = toStaticUrl(outputPath);
 
-  // Skip if image already set and not forcing
-  if (fm.image && !FORCE) {
+  // Skip only if frontmatter has image AND the PNG actually exists on disk.
+  // Otherwise regenerate so a stale frontmatter ref doesn't leave the site 404ing.
+  if (fm.image && fs.existsSync(outputPath) && !FORCE) {
     console.log(`  SKIP (has image): ${path.relative(REPO_ROOT, filePath)}`);
     return { status: "skip" };
   }


### PR DESCRIPTION
## Summary
- Removes the manually committed PNG (wrong — images are build artifacts).
- Patches `scripts/generate-og-images.js` to skip generation only when both the frontmatter `image:` ref AND the PNG on disk exist. Previously it skipped whenever frontmatter was set, so a stale ref (like the one shipped in #877 for quickstart-with-ai) left the page 404ing on every build.

## Why this works
Next Vercel build walks docs, sees `quickstart-with-ai.md` has `image:` set but no PNG in the build output → regenerates and writes it to `static/docs-assets/og/HyperIndex/quickstart-with-ai.png`.

## Test plan
- [ ] After deploy, confirm `https://docs.envio.dev/docs-assets/og/HyperIndex/quickstart-with-ai.png` resolves (200).
- [ ] Check link unfurl for the page in Slack / Twitter shows the correct card.

cc @nikbhintade @DenhamPreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)