### PR TITLE
chore: consolidate Discord invites to vanity URL

### DIFF
--- a/blog/2023-08-08-methods-to-query-blockchain-data.md
+++ b/blog/2023-08-08-methods-to-query-blockchain-data.md
@@ -130,4 +130,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
+++ b/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
@@ -121,7 +121,7 @@ A few of the most frequent issues and their fixes:
 - **RPC errors or timeouts**: Switch to HyperSync if your network is supported, which eliminates RPC rate limiting entirely
 - **Tables missing from Hasura**: Run `pnpm envio stop` then `pnpm dev` to resync the schema
 
-For issues not covered here, the [Envio Discord](https://discord.com/invite/gt7yEUZKeB) has an active support channel with the core team.
+For issues not covered here, the [Envio Discord](https://discord.gg/envio) has an active support channel with the core team.
 
 ## Frequently asked questions
 
@@ -153,4 +153,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2023-10-04-how-to-become-a-blockchain-dapp-developer.md
+++ b/blog/2023-10-04-how-to-become-a-blockchain-dapp-developer.md
@@ -144,4 +144,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2023-10-24-indexer-benchmarking-results.md
+++ b/blog/2023-10-24-indexer-benchmarking-results.md
@@ -144,4 +144,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2023-11-09-powers-of-dedicated-hosting-for-web3-apps.md
+++ b/blog/2023-11-09-powers-of-dedicated-hosting-for-web3-apps.md
@@ -101,4 +101,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2023-11-15-simplify-data-retrieval-multi-chain-dapps.md
+++ b/blog/2023-11-15-simplify-data-retrieval-multi-chain-dapps.md
@@ -135,4 +135,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-02-20-envio-data-indexing-on-lukso.md
+++ b/blog/2024-02-20-envio-data-indexing-on-lukso.md
@@ -123,4 +123,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-07-17-case-study-gblast.md
+++ b/blog/2024-07-17-case-study-gblast.md
@@ -101,4 +101,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-07-18-data-indexing-on-fuel.md
+++ b/blog/2024-07-18-data-indexing-on-fuel.md
@@ -95,4 +95,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-08-13-case-study-sablier.md
+++ b/blog/2024-08-13-case-study-sablier.md
@@ -135,4 +135,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-08-19-building-chaindensity.md
+++ b/blog/2024-08-19-building-chaindensity.md
@@ -143,7 +143,7 @@ Why not head over to the [repo](https://github.com/enviodev/chain-density) and m
 
 ## Use HyperSync yourself
 
-Explore [ChainDensity](https://chaindensity.xyz) to experience the power of [HyperSync](https://docs.envio.dev/docs/HyperSync/overview) firsthand. If you're looking to leverage HyperSync for your project, visit our documentation or hop in our [Discord](https://discord.com/invite/gt7yEUZKeB) for support.
+Explore [ChainDensity](https://chaindensity.xyz) to experience the power of [HyperSync](https://docs.envio.dev/docs/HyperSync/overview) firsthand. If you're looking to leverage HyperSync for your project, visit our documentation or hop in our [Discord](https://discord.gg/envio) for support.
 
 ## Build With Envio
 
@@ -153,4 +153,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-09-27-case-study-limitless.md
+++ b/blog/2024-09-27-case-study-limitless.md
@@ -113,4 +113,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-10-02-envio-community-update-sep-2024.md
+++ b/blog/2024-10-02-envio-community-update-sep-2024.md
@@ -144,4 +144,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-10-09-case-study-bridgg-op-superchain.md
+++ b/blog/2024-10-09-case-study-bridgg-op-superchain.md
@@ -84,4 +84,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-10-15-ethonline24-envio-hackathon-winners.md
+++ b/blog/2024-10-15-ethonline24-envio-hackathon-winners.md
@@ -71,4 +71,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-10-29-envio-community-update-oct-2024.md
+++ b/blog/2024-10-29-envio-community-update-oct-2024.md
@@ -158,4 +158,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-11-08-hosted-service-v2.md
+++ b/blog/2024-11-08-hosted-service-v2.md
@@ -57,7 +57,7 @@ Deployment on Envio Cloud requires at least version `2.21.5`. Always check the [
 
 ### Where can I get help with Envio Cloud?
 
-Join the [Discord](https://discord.com/invite/gt7yEUZKeB) for support, or reach out via an existing connection for production plan inquiries.
+Join the [Discord](https://discord.gg/envio) for support, or reach out via an existing connection for production plan inquiries.
 
 ## Build With Envio
 
@@ -67,4 +67,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-11-13-how-to-cut-aws-cloud-costs.md
+++ b/blog/2024-11-13-how-to-cut-aws-cloud-costs.md
@@ -129,4 +129,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-11-26-indexing-and-reorgs.md
+++ b/blog/2024-11-26-indexing-and-reorgs.md
@@ -152,4 +152,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-11-28-envio-community-update-november-2024.md
+++ b/blog/2024-11-28-envio-community-update-november-2024.md
@@ -176,4 +176,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-12-09-tokenizing-real-world-assets.md
+++ b/blog/2024-12-09-tokenizing-real-world-assets.md
@@ -99,4 +99,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-12-18-case-study-zkpass.md
+++ b/blog/2024-12-18-case-study-zkpass.md
@@ -113,4 +113,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2024-12-24-envio-community-update-december.md
+++ b/blog/2024-12-24-envio-community-update-december.md
@@ -154,4 +154,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-01-21-what-is-a-blockchain-indexer.md
+++ b/blog/2025-01-21-what-is-a-blockchain-indexer.md
@@ -141,4 +141,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-01-30-envio-developer-update-january.md
+++ b/blog/2025-01-30-envio-developer-update-january.md
@@ -145,4 +145,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-02-27-envio-dev-update-feb.md
+++ b/blog/2025-02-27-envio-dev-update-feb.md
@@ -174,4 +174,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-03-17-what-is-multi-chain-indexing.md
+++ b/blog/2025-03-17-what-is-multi-chain-indexing.md
@@ -134,4 +134,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-03-26-envio-supports-70-networks.md
+++ b/blog/2025-03-26-envio-supports-70-networks.md
@@ -39,7 +39,7 @@ Envio supports any EVM chain and Fuel with an expanding list of networks, includ
 
 See the full list of supported networks in the [documentation](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks).
 
-We are rapidly adding new supported networks. If your network is not listed or you would like HyperSync support added, pop us a message in our [Discord](https://discord.com/invite/gt7yEUZKeB).
+We are rapidly adding new supported networks. If your network is not listed or you would like HyperSync support added, pop us a message in our [Discord](https://discord.gg/envio).
 
 ## Why use Envio?
 
@@ -57,7 +57,7 @@ Envio HyperIndex offers a developer-centric blockchain data indexing solution, e
 - [Getting started](https://docs.envio.dev/docs/HyperIndex/getting-started)
 - [Guides](https://docs.envio.dev/docs/HyperIndex/configuration-file)
 - [Tutorials](https://docs.envio.dev/docs/HyperIndex/tutorial-op-bridge-deposits)
-- [Get support](https://discord.com/invite/gt7yEUZKeB)
+- [Get support](https://discord.gg/envio)
 
 ## Conclusion
 
@@ -67,7 +67,7 @@ Envio is a powerful alternative to traditional blockchain indexing methods. Its 
 
 ### How do I check if my network is supported by Envio HyperSync?
 
-Visit the [HyperSync supported networks page](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks) in the documentation. If your network is not listed, you can request support by opening a message in the [Discord](https://discord.com/invite/gt7yEUZKeB).
+Visit the [HyperSync supported networks page](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks) in the documentation. If your network is not listed, you can request support by opening a message in the [Discord](https://discord.gg/envio).
 
 ### Can I use Envio on a network that HyperSync does not yet support?
 
@@ -93,4 +93,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-03-31-envio-dev-update-march-2025.md
+++ b/blog/2025-03-31-envio-dev-update-march-2025.md
@@ -305,4 +305,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-04-15-oracle-wars.md
+++ b/blog/2025-04-15-oracle-wars.md
@@ -125,4 +125,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-04-25-developer-update-april-2025.md
+++ b/blog/2025-04-25-developer-update-april-2025.md
@@ -228,4 +228,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-05-16-monad-hackathon-winners-2025.md
+++ b/blog/2025-05-16-monad-hackathon-winners-2025.md
@@ -70,4 +70,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-05-29-developer-update-may-2025.md
+++ b/blog/2025-05-29-developer-update-may-2025.md
@@ -193,4 +193,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-06-12-how-to-index-monad-data-using-envio.md
+++ b/blog/2025-06-12-how-to-index-monad-data-using-envio.md
@@ -117,4 +117,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
+++ b/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
@@ -122,4 +122,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
+++ b/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
@@ -177,4 +177,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-06-24-dev-update-june-2025.md
+++ b/blog/2025-06-24-dev-update-june-2025.md
@@ -202,4 +202,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-07-30-dev-update-july-2025.md
+++ b/blog/2025-07-30-dev-update-july-2025.md
@@ -142,4 +142,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-08-29-dev-update-august-2025.md
+++ b/blog/2025-08-29-dev-update-august-2025.md
@@ -228,4 +228,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-09-30-dev-update-september-2025.md
+++ b/blog/2025-09-30-dev-update-september-2025.md
@@ -225,4 +225,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-10-28-dev-update-october-2025.md
+++ b/blog/2025-10-28-dev-update-october-2025.md
@@ -205,4 +205,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-11-12-encode-london-2025.md
+++ b/blog/2025-11-12-encode-london-2025.md
@@ -80,4 +80,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-11-13-metamask-smart-accounts-hackathon-winners.md
+++ b/blog/2025-11-13-metamask-smart-accounts-hackathon-winners.md
@@ -66,4 +66,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-11-26-dev-update-november-2025.md
+++ b/blog/2025-11-26-dev-update-november-2025.md
@@ -96,7 +96,7 @@ Star us on [GitHub](https://github.com/enviodev/hyperindex)
 
 Envio is live on [Monad](https://www.monad.xyz) Mainnet. Get easy access to real-time and historical data on Monad through performant syncing and a smooth, high performance indexing experience from day one. We supported teams throughout testnet and continue to provide the same fast, reliable indexing setup for a growing ecosystem on Mainnet.
 
-If you are live or going live on Monad and need help getting set up, chat to us about your data needs in [Discord](https://discord.com/invite/gt7yEUZKeB). For more on how to index data on Monad, read our [blog article](https://docs.envio.dev/blog/how-to-index-monad-data-using-envio).
+If you are live or going live on Monad and need help getting set up, chat to us about your data needs in [Discord](https://discord.gg/envio). For more on how to index data on Monad, read our [blog article](https://docs.envio.dev/blog/how-to-index-monad-data-using-envio).
 
 
 ## How to Migrate Alchemy Subgraphs to Envio
@@ -236,4 +236,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-12-16-dev-update-december-2025.md
+++ b/blog/2025-12-16-dev-update-december-2025.md
@@ -173,7 +173,7 @@ For Envio users indexing Monad, this means indexers need to reindex from block 1
 
 This update removes legacy behaviours from early testnet phases and is expected to reduce state sync time going forward. Teams indexing Monad can continue building against the refreshed testnet.
 
-If you need support reindexing or redeploying after the re-genesis, feel free to reach out to the Envio team in our [Discord](https://discord.com/invite/gt7yEUZKeB).
+If you need support reindexing or redeploying after the re-genesis, feel free to reach out to the Envio team in our [Discord](https://discord.gg/envio).
 
 
 ## Envio at Solana Breakpoint 2025 in Abu Dhabi
@@ -305,4 +305,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
+++ b/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
@@ -78,7 +78,7 @@ Envio has a dedicated migration cursor flow so you do not have to replay your en
 
 After this, you can run the indexer locally with Docker or deploy directly to [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service). Once deployed, your indexer will sync with HyperSync-level speed.
 
-If you prefer hands-on help, or would like the team to check your setup, you can book a free migration call [here](https://envio.dev/alchemy-migration). Alternatively, reach out in [Discord](https://discord.com/invite/gt7yEUZKeB).
+If you prefer hands-on help, or would like the team to check your setup, you can book a free migration call [here](https://envio.dev/alchemy-migration). Alternatively, reach out in [Discord](https://discord.gg/envio).
 
 ## What changes when you leave Alchemy?
 
@@ -127,4 +127,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-01-28-blockchain-indexer-app-backends.md
+++ b/blog/2026-01-28-blockchain-indexer-app-backends.md
@@ -147,4 +147,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-01-28-dev-update-january-2026.md
+++ b/blog/2026-01-28-dev-update-january-2026.md
@@ -259,4 +259,4 @@ Stay tuned for more monthly updates by subscribing to our newsletter, following 
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌 
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-02-25-dev-update-february-2026.md
+++ b/blog/2026-02-25-dev-update-february-2026.md
@@ -258,4 +258,4 @@ Stay tuned for more monthly updates by subscribing to our newsletter, following 
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌 
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -188,4 +188,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -330,7 +330,7 @@ A custom indexing framework (HyperIndex, The Graph, Ponder, etc.) lets you defin
 
 ### How do I migrate from The Graph to Envio HyperIndex?
 
-HyperIndex has a [dedicated migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide) that walks you through it in 3 simple steps. Envio also offers white glove migration support for teams moving from any stack. Reach out to us via [Discord](https://discord.com/invite/envio) for support.
+HyperIndex has a [dedicated migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide) that walks you through it in 3 simple steps. Envio also offers white glove migration support for teams moving from any stack. Reach out to us via [Discord](https://discord.gg/envio) for support.
 
 
 ### What is HyperSync?
@@ -363,4 +363,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-03-23-dev-update-march-2026.md
+++ b/blog/2026-03-23-dev-update-march-2026.md
@@ -119,7 +119,7 @@ Migrate your existing subgraphs and keep the same API, with faster sync, quicker
 The process is handled end-to-end, converting your subgraph to HyperIndex and getting it up and running without needing to manage infrastructure.
 
 Learn more here: [https://envio.dev/pricing/subgraphs](https://envio.dev/pricing/subgraphs)  
-Get started on Discord - open a support ticket: [https://discord.com/invite/envio](https://discord.com/invite/envio)
+Get started on Discord - open a support ticket: [https://discord.gg/envio](https://discord.gg/envio)
 
 ## Heatbook: Polymarket Orderbooks as Heatmaps
 
@@ -235,4 +235,4 @@ Stay tuned for more monthly updates by subscribing to our newsletter, following 
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-03-24-track-polymarket-trades-hypersync.md
+++ b/blog/2026-03-24-track-polymarket-trades-hypersync.md
@@ -434,4 +434,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-03-25-polymarket-hyperindex-case-study.md
+++ b/blog/2026-03-25-polymarket-hyperindex-case-study.md
@@ -192,7 +192,7 @@ The Polymarket indexer is fully open source and available as a production refere
 - Repo: [https://github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer)
 - Live deployment: [https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad](https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad)
 - Envio docs: [https://docs.envio.dev/](https://docs.envio.dev/)
-- Discord: [https://discord.com/invite/gt7yEUZKeB](https://discord.com/invite/gt7yEUZKeB)
+- Discord: [https://discord.gg/envio](https://discord.gg/envio)
 - Telegram: [https://t.me/+kAIGElzPjApiMjI0](https://t.me/+kAIGElzPjApiMjI0)
 - Follow us on X: [https://x.com/envio_indexer](https://x.com/envio_indexer)
 
@@ -202,4 +202,4 @@ Envio HyperIndex is independently benchmarked as the fastest EVM blockchain inde
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/blog/2026-04-14-docs-mcp-server.md
+++ b/blog/2026-04-14-docs-mcp-server.md
@@ -113,4 +113,4 @@ Stay tuned for more updates by subscribing to our newsletter, following us on X,
 
 [Subscribe to our newsletter](https://envio.beehiiv.com/subscribe?utm_source=envio.beehiiv.com&utm_medium=newsletter&utm_campaign=new-post) 💌
 
-[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.com/invite/gt7yEUZKeB) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)
+[Website](https://envio.dev/) | [X](https://twitter.com/envio_indexer) | [Discord](https://discord.gg/envio) | [Telegram](https://t.me/+5mI61oZibEM5OGQ8) | [GitHub](https://github.com/enviodev) | [YouTube](https://www.youtube.com/channel/UCR7nZ2yzEtc5SZNM0dhrkhA) | [Reddit](https://www.reddit.com/user/Envio_indexer)

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -83,7 +83,7 @@ For more details about API tokens, including how to generate and implement them,
 ## 🔗 Quick Links
 
 - [GitHub Repository](https://github.com/enviodev/hyperindex) ⭐
-- Join our [Discord Community](https://discord.com/invite/envio)
+- Join our [Discord Community](https://discord.gg/envio)
 
 ---
 

--- a/docs/HyperIndex/Guides/testing.mdx
+++ b/docs/HyperIndex/Guides/testing.mdx
@@ -581,4 +581,4 @@ open Belt
   );
   ```
 
-If you encounter any issues or have questions, please reach out to us on [Discord](https://discord.gg/Q9qt8gZ2fX)
+If you encounter any issues or have questions, please reach out to us on [Discord](https://discord.gg/envio)

--- a/docs/HyperIndex/Hosted_Service/envio-cloud-cli.md
+++ b/docs/HyperIndex/Hosted_Service/envio-cloud-cli.md
@@ -11,7 +11,7 @@ description: Command-line interface for managing and monitoring your indexers on
 :::warning Alpha Release
 The `envio-cloud` CLI is currently in **alpha**. The tool is under active development and will be iterated on before a stable version 1 release once the final form of the tool's interaction is finalized.
 
-For feature requests, please reach out to us on [Telegram](https://t.me/envaborations) or [Discord](https://discord.gg/Q9qt8gZ2fX).
+For feature requests, please reach out to us on [Telegram](https://t.me/envaborations) or [Discord](https://discord.gg/envio).
 :::
 
 The `envio-cloud` CLI is a command-line tool for interacting with Envio Cloud. It enables you to deploy, manage, and monitor your blockchain indexers directly from the terminal — making it particularly useful for CI/CD pipelines, scripting, and agentic workflows.

--- a/docs/HyperIndex/Troubleshoot/common-issues.md
+++ b/docs/HyperIndex/Troubleshoot/common-issues.md
@@ -8,7 +8,7 @@ description: Discover quick fixes and proven solutions for setup, runtime, and c
 
 # Common Issues and Troubleshooting
 
-This guide helps you identify and resolve common issues you might encounter when working with Envio HyperIndex. If you don't find a solution to your problem here, please join our [Discord community](https://discord.gg/DhfFhzuJQh) for additional support.
+This guide helps you identify and resolve common issues you might encounter when working with Envio HyperIndex. If you don't find a solution to your problem here, please join our [Discord community](https://discord.gg/envio) for additional support.
 
 ## Table of Contents
 

--- a/docs/HyperIndex/Troubleshoot/error-codes.md
+++ b/docs/HyperIndex/Troubleshoot/error-codes.md
@@ -18,7 +18,7 @@ When encountering an error in Envio, you'll receive an error code (like `EE101`)
 2. Read the explanation to understand what caused the error
 3. Follow the recommended steps to resolve the issue
 
-If you can't resolve an error after following the suggestions, please reach out for support on our [Discord community](https://discord.gg/DhfFhzuJQh).
+If you can't resolve an error after following the suggestions, please reach out for support on our [Discord community](https://discord.gg/envio).
 
 ## Error Categories
 
@@ -393,7 +393,7 @@ contracts:
 
 - Check your event handler logic for errors
 - Review recent changes to your blockchain indexer
-- If unable to resolve, contact support through [Discord](https://discord.gg/Q9qt8gZ2fX) with error details
+- If unable to resolve, contact support through [Discord](https://discord.gg/envio) with error details
 
 ## Database-Related Errors
 
@@ -501,7 +501,7 @@ pnpm envio local db-migrate setup
 
 **Issue**: Contract name not found in interface mapping (unexpected internal error).
 
-**Solution**: Contact support through [Discord](https://discord.gg/Q9qt8gZ2fX) for assistance.
+**Solution**: Contact support through [Discord](https://discord.gg/envio) for assistance.
 
 ## Network-Related Errors
 
@@ -526,6 +526,6 @@ pnpm envio local db-migrate setup
 - Check network connectivity
 - Verify RPC endpoint performance
 - Consider increasing timeouts if possible
-- If persists, contact support through [Discord](https://discord.gg/Q9qt8gZ2fX)
+- If persists, contact support through [Discord](https://discord.gg/envio)
 
 ---

--- a/docs/HyperIndex/Troubleshoot/logging.mdx
+++ b/docs/HyperIndex/Troubleshoot/logging.mdx
@@ -136,7 +136,7 @@ LOG_STRATEGY="both-prettyconsole"  # Pretty logs to console, Pino format to file
 LOG_FILE="<path-to-log-file>"
 ```
 
-For production environments or detailed analytics, consider integrating logs with Kibana or similar tools. We're developing Kibana dashboards for self-hosting and UI dashboards for our hosting solution. If you have specific dashboard requirements, please [contact us on Discord](https://discord.gg/DhfFhzuJQh).
+For production environments or detailed analytics, consider integrating logs with Kibana or similar tools. We're developing Kibana dashboards for self-hosting and UI dashboards for our hosting solution. If you have specific dashboard requirements, please [contact us on Discord](https://discord.gg/envio).
 
 ## Developer Logging
 

--- a/docs/HyperIndex/Troubleshoot/reserved-words.md
+++ b/docs/HyperIndex/Troubleshoot/reserved-words.md
@@ -136,6 +136,6 @@ CONTRACT_TYPE
 3. **Run validation early** with `pnpm codegen` to catch issues before spending time on implementation
 4. **Use prefixes for domain entities** (e.g., `TokenTransfer` instead of `Transfer`)
 
-If you encounter persistent issues with reserved words or need help refactoring your schema to avoid them, please reach out for support on our [Discord community](https://discord.gg/DhfFhzuJQh).
+If you encounter persistent issues with reserved words or need help refactoring your schema to avoid them, please reach out for support on our [Discord community](https://discord.gg/envio).
 
 ---

--- a/docs/HyperIndex/Tutorials/tutorial-indexing-fuel.md
+++ b/docs/HyperIndex/Tutorials/tutorial-indexing-fuel.md
@@ -318,4 +318,4 @@ Navigate to the [Envio Cloud](https://envio.dev/app/login) to start deploying yo
 
 Once you have successfully finished the tutorial, you are ready to become a blockchain indexing wizard!
 
-Join our [Discord](https://discord.com/invite/gt7yEUZKeB) channel to make sure you catch all new releases.
+Join our [Discord](https://discord.gg/envio) channel to make sure you catch all new releases.

--- a/docs/HyperIndex/fuel/fuel.md
+++ b/docs/HyperIndex/fuel/fuel.md
@@ -209,5 +209,5 @@ Powered by the FuelVM, Fuel expands Ethereum's capabilities without compromising
 If you encounter any issues with Fuel indexing, please:
 
 1. Check our [Troubleshooting](../Troubleshoot/common-issues.md) guides
-2. Join our [Discord](https://discord.com/invite/gt7yEUZKeB) for community support
+2. Join our [Discord](https://discord.gg/envio) for community support
 3. Create an issue in our [GitHub repository](https://github.com/enviodev/hyperindex)

--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -111,7 +111,7 @@ networks:
 </div>
 </div>
 
-If you hit any issues, check the [Configuration File](https://docs.envio.dev/docs/HyperIndex/configuration-file) docs or reach out to our team in [Discord](https://discord.com/invite/envio).
+If you hit any issues, check the [Configuration File](https://docs.envio.dev/docs/HyperIndex/configuration-file) docs or reach out to our team in [Discord](https://discord.gg/envio).
 
 ### schema.graphql Migration
 
@@ -186,4 +186,4 @@ If you come across anything useful during your migration, please feel free to co
 
 ## Getting Help
 
-Join our [Discord](https://discord.com/invite/envio) if you need support. It is the fastest way to get direct help from the team and the community.
+Join our [Discord](https://discord.gg/envio) if you need support. It is the fastest way to get direct help from the team and the community.

--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -55,7 +55,7 @@ HyperSync (the data engine powering HyperIndex) implements rate limits for reque
 - **Local Development**: An API token will be required. An automatic login feature from the CLI will be available to make this smoother.
 - **Self-Hosted Deployments**: API tokens are required for HyperSync access in self-hosted deployments. The token can be set via the `ENVIO_API_TOKEN` environment variable in your indexer configuration. This can be read from the `.env` file in the root of your HyperIndex project.
 - **Envio Cloud**: Indexers deployed to Envio Cloud will have special access that doesn't require a custom API token.
-- **Future Pricing**: From mid-November 2025 onwards, we will introduce tiered packages for those self-hosting HyperIndex and wishing to use HyperSync. For preferred introductory pricing based on your specific use case, reach out to us on [Discord](https://discord.gg/Q9qt8gZ2fX).
+- **Future Pricing**: From mid-November 2025 onwards, we will introduce tiered packages for those self-hosting HyperIndex and wishing to use HyperSync. For preferred introductory pricing based on your specific use case, reach out to us on [Discord](https://discord.gg/envio).
 
 For more details about API tokens, including how to generate and implement them, see our [API Tokens documentation](/docs/HyperSync/api-tokens).
 
@@ -76,4 +76,4 @@ Upcoming features on our development roadmap:
 ## 🔗 Quick Links
 
 - [GitHub Repository](https://github.com/enviodev/hyperindex) ⭐
-- [Join our Discord Community](https://discord.gg/Q9qt8gZ2fX)
+- [Join our Discord Community](https://discord.gg/envio)

--- a/docs/HyperIndex/supported-networks/0g-newton-testnet.md
+++ b/docs/HyperIndex/supported-networks/0g-newton-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for 0G Newton Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for 0G Newton Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/ab.md
+++ b/docs/HyperIndex/supported-networks/ab.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/abstract.md
+++ b/docs/HyperIndex/supported-networks/abstract.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/aleph-zero-evm.md
+++ b/docs/HyperIndex/supported-networks/aleph-zero-evm.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Aleph Zero EVM? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Aleph Zero EVM? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/altlayer-op-demo-testnet.md
+++ b/docs/HyperIndex/supported-networks/altlayer-op-demo-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Altlayer OP Demo Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Altlayer OP Demo Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/ancient8.md
+++ b/docs/HyperIndex/supported-networks/ancient8.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Ancient8? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Ancient8? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/any-evm-with-rpc.md
+++ b/docs/HyperIndex/supported-networks/any-evm-with-rpc.md
@@ -34,7 +34,7 @@ networks:
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 :::info
 The backbone of HyperIndex’s blazing-fast indexing speed lies in using HyperSync as a more performant and cost-effective data source to RPC for data retrieval. While RPCs are functional, and can be used in HyperIndex as a data source, they are far from efficient when it comes to querying large amounts of data (a time-consuming and resource-intensive endeavour).

--- a/docs/HyperIndex/supported-networks/arbitrum-blueberry.md
+++ b/docs/HyperIndex/supported-networks/arbitrum-blueberry.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Arbitrum Blueberry? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Arbitrum Blueberry? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/arbitrum-nova.md
+++ b/docs/HyperIndex/supported-networks/arbitrum-nova.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/arbitrum-sepolia.md
+++ b/docs/HyperIndex/supported-networks/arbitrum-sepolia.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/arbitrum.md
+++ b/docs/HyperIndex/supported-networks/arbitrum.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/arc-testnet.md
+++ b/docs/HyperIndex/supported-networks/arc-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/artela-testnet.md
+++ b/docs/HyperIndex/supported-networks/artela-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Artela Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Artela Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/arthera-mainnet.md
+++ b/docs/HyperIndex/supported-networks/arthera-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Arthera Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Arthera Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/asset-chain-mainnet.md
+++ b/docs/HyperIndex/supported-networks/asset-chain-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Asset Chain Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Asset Chain Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/astar-zkevm.md
+++ b/docs/HyperIndex/supported-networks/astar-zkevm.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Astar zkEVM? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Astar zkEVM? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/astar-zkyoto.md
+++ b/docs/HyperIndex/supported-networks/astar-zkyoto.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Astar zKyoto? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Astar zKyoto? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/aurora-turbo.md
+++ b/docs/HyperIndex/supported-networks/aurora-turbo.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/aurora.md
+++ b/docs/HyperIndex/supported-networks/aurora.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/avalanche.md
+++ b/docs/HyperIndex/supported-networks/avalanche.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/b2-hub-testnet.md
+++ b/docs/HyperIndex/supported-networks/b2-hub-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for B2 Hub Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for B2 Hub Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/b2-testnet.md
+++ b/docs/HyperIndex/supported-networks/b2-testnet.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/b3-sepolia-testnet.md
+++ b/docs/HyperIndex/supported-networks/b3-sepolia-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for B3 Sepolia Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for B3 Sepolia Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/b3.md
+++ b/docs/HyperIndex/supported-networks/b3.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for B3? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for B3? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/base-sepolia.md
+++ b/docs/HyperIndex/supported-networks/base-sepolia.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/base.md
+++ b/docs/HyperIndex/supported-networks/base.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/beam.md
+++ b/docs/HyperIndex/supported-networks/beam.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Beam? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Beam? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/berachain-artio-testnet.md
+++ b/docs/HyperIndex/supported-networks/berachain-artio-testnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Berachain Artio Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Berachain Artio Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/berachain-bartio.md
+++ b/docs/HyperIndex/supported-networks/berachain-bartio.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/berachain.md
+++ b/docs/HyperIndex/supported-networks/berachain.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/bevm-mainnet.md
+++ b/docs/HyperIndex/supported-networks/bevm-mainnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for BEVM Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for BEVM Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bevm-testnet.md
+++ b/docs/HyperIndex/supported-networks/bevm-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for BEVM Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for BEVM Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bitfinity-mainnet.md
+++ b/docs/HyperIndex/supported-networks/bitfinity-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Bitfinity Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Bitfinity Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bitfinity-testnet.md
+++ b/docs/HyperIndex/supported-networks/bitfinity-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Bitfinity Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Bitfinity Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bitgert-mainnet.md
+++ b/docs/HyperIndex/supported-networks/bitgert-mainnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Bitgert Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Bitgert Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bitlayer.md
+++ b/docs/HyperIndex/supported-networks/bitlayer.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Bitlayer? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Bitlayer? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/blast-sepolia.md
+++ b/docs/HyperIndex/supported-networks/blast-sepolia.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/blast.md
+++ b/docs/HyperIndex/supported-networks/blast.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/bnb-smart-chain-testnet.md
+++ b/docs/HyperIndex/supported-networks/bnb-smart-chain-testnet.md
@@ -48,4 +48,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for BNB Smart Chain Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for BNB Smart Chain Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bnb-smart-chain.md
+++ b/docs/HyperIndex/supported-networks/bnb-smart-chain.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for BNB Smart Chain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for BNB Smart Chain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bob-mainnet.md
+++ b/docs/HyperIndex/supported-networks/bob-mainnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for BOB Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for BOB Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/boba-bnb-mainnet.md
+++ b/docs/HyperIndex/supported-networks/boba-bnb-mainnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Boba BNB Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Boba BNB Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/boba.md
+++ b/docs/HyperIndex/supported-networks/boba.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/botanix-testnet.md
+++ b/docs/HyperIndex/supported-networks/botanix-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Botanix Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Botanix Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/bsc-testnet.md
+++ b/docs/HyperIndex/supported-networks/bsc-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/bsc.md
+++ b/docs/HyperIndex/supported-networks/bsc.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/c1-milkomeda.md
+++ b/docs/HyperIndex/supported-networks/c1-milkomeda.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/canto-testnet.md
+++ b/docs/HyperIndex/supported-networks/canto-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Canto Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Canto Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/canto.md
+++ b/docs/HyperIndex/supported-networks/canto.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Canto? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Canto? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/celo-alfajores-testnet.md
+++ b/docs/HyperIndex/supported-networks/celo-alfajores-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Celo Alfajores Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Celo Alfajores Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/celo.md
+++ b/docs/HyperIndex/supported-networks/celo.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/chainweb-testnet-20.md
+++ b/docs/HyperIndex/supported-networks/chainweb-testnet-20.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/chainweb-testnet-21.md
+++ b/docs/HyperIndex/supported-networks/chainweb-testnet-21.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/chainweb-testnet-22.md
+++ b/docs/HyperIndex/supported-networks/chainweb-testnet-22.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/chainweb-testnet-23.md
+++ b/docs/HyperIndex/supported-networks/chainweb-testnet-23.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/chainweb-testnet-24.md
+++ b/docs/HyperIndex/supported-networks/chainweb-testnet-24.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/chiliz-testnet-spicy.md
+++ b/docs/HyperIndex/supported-networks/chiliz-testnet-spicy.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Chiliz Testnet Spicy? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Chiliz Testnet Spicy? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/chiliz.md
+++ b/docs/HyperIndex/supported-networks/chiliz.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/citrea-devnet.md
+++ b/docs/HyperIndex/supported-networks/citrea-devnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Citrea Devnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Citrea Devnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/citrea-testnet.md
+++ b/docs/HyperIndex/supported-networks/citrea-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/citrea.md
+++ b/docs/HyperIndex/supported-networks/citrea.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/core.md
+++ b/docs/HyperIndex/supported-networks/core.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Core? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Core? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/crab.md
+++ b/docs/HyperIndex/supported-networks/crab.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/creator-testnet.md
+++ b/docs/HyperIndex/supported-networks/creator-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Creator Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Creator Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/cronos-zkevm-testnet.md
+++ b/docs/HyperIndex/supported-networks/cronos-zkevm-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Cronos ZKEVM Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Cronos ZKEVM Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/cronos-zkevm.md
+++ b/docs/HyperIndex/supported-networks/cronos-zkevm.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Cronos ZKEVM? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Cronos ZKEVM? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/crossfi-mainnet.md
+++ b/docs/HyperIndex/supported-networks/crossfi-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for CrossFi Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for CrossFi Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/crossfi-testnet.md
+++ b/docs/HyperIndex/supported-networks/crossfi-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for CrossFi Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for CrossFi Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/curtis.md
+++ b/docs/HyperIndex/supported-networks/curtis.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/cyber.md
+++ b/docs/HyperIndex/supported-networks/cyber.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/damon.md
+++ b/docs/HyperIndex/supported-networks/damon.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/darwinia.md
+++ b/docs/HyperIndex/supported-networks/darwinia.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/degen-chain.md
+++ b/docs/HyperIndex/supported-networks/degen-chain.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Degen Chain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Degen Chain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/dfk-chain.md
+++ b/docs/HyperIndex/supported-networks/dfk-chain.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for DFK Chain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for DFK Chain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/dogechain-mainnet.md
+++ b/docs/HyperIndex/supported-networks/dogechain-mainnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Dogechain Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Dogechain Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/dogechain-testnet.md
+++ b/docs/HyperIndex/supported-networks/dogechain-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Dogechain Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Dogechain Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/dos-chain.md
+++ b/docs/HyperIndex/supported-networks/dos-chain.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for DOS Chain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for DOS Chain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/energy-web.md
+++ b/docs/HyperIndex/supported-networks/energy-web.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Energy Web? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Energy Web? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/eos.md
+++ b/docs/HyperIndex/supported-networks/eos.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for EOS? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for EOS? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/eth.md
+++ b/docs/HyperIndex/supported-networks/eth.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/etherlink-testnet.md
+++ b/docs/HyperIndex/supported-networks/etherlink-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Etherlink Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Etherlink Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/etherlink.md
+++ b/docs/HyperIndex/supported-networks/etherlink.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/exosama.md
+++ b/docs/HyperIndex/supported-networks/exosama.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Exosama? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Exosama? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/extrabud.md
+++ b/docs/HyperIndex/supported-networks/extrabud.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/fantom-testnet.md
+++ b/docs/HyperIndex/supported-networks/fantom-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Fantom Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Fantom Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/fantom.md
+++ b/docs/HyperIndex/supported-networks/fantom.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/flare-songbird.md
+++ b/docs/HyperIndex/supported-networks/flare-songbird.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Flare Songbird? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Flare Songbird? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/flare.md
+++ b/docs/HyperIndex/supported-networks/flare.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/flow-testnet.md
+++ b/docs/HyperIndex/supported-networks/flow-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Flow Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Flow Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/flow.md
+++ b/docs/HyperIndex/supported-networks/flow.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Flow? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Flow? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/fraxtal.md
+++ b/docs/HyperIndex/supported-networks/fraxtal.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/fuel-mainnet.md
+++ b/docs/HyperIndex/supported-networks/fuel-mainnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/fuel-testnet.md
+++ b/docs/HyperIndex/supported-networks/fuel-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/fuji.md
+++ b/docs/HyperIndex/supported-networks/fuji.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/galadriel-devnet.md
+++ b/docs/HyperIndex/supported-networks/galadriel-devnet.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/gnosis-chiado.md
+++ b/docs/HyperIndex/supported-networks/gnosis-chiado.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/gnosis.md
+++ b/docs/HyperIndex/supported-networks/gnosis.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/goerli.md
+++ b/docs/HyperIndex/supported-networks/goerli.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/gravity-alpha-mainnet.md
+++ b/docs/HyperIndex/supported-networks/gravity-alpha-mainnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Gravity Alpha Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Gravity Alpha Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/harmony-shard-0.md
+++ b/docs/HyperIndex/supported-networks/harmony-shard-0.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/heco-chain.md
+++ b/docs/HyperIndex/supported-networks/heco-chain.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Heco Chain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Heco Chain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/holesky-token-test.md
+++ b/docs/HyperIndex/supported-networks/holesky-token-test.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/holesky.md
+++ b/docs/HyperIndex/supported-networks/holesky.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/hoodi.md
+++ b/docs/HyperIndex/supported-networks/hoodi.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/hyperliquid-temp.md
+++ b/docs/HyperIndex/supported-networks/hyperliquid-temp.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/hyperliquid.md
+++ b/docs/HyperIndex/supported-networks/hyperliquid.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/immutable-zkevm-testnet.md
+++ b/docs/HyperIndex/supported-networks/immutable-zkevm-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Immutable zkEVM Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Immutable zkEVM Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/immutable-zkevm.md
+++ b/docs/HyperIndex/supported-networks/immutable-zkevm.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Immutable zkEVM? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Immutable zkEVM? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/incentiv.md
+++ b/docs/HyperIndex/supported-networks/incentiv.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/index.md
+++ b/docs/HyperIndex/supported-networks/index.md
@@ -19,6 +19,6 @@ If a [network is supported](/docs/HyperSync/hypersync-supported-networks) on Hyp
 
 If the network that you want to index is not supported on HyperSync, please navigate to [RPC Data Source](/docs/HyperIndex/Advanced/rpc-sync.md) for more information to use RPC as a data source.
 
-You can also request a network to be added to HyperSync in the [Discord](https://discord.gg/Q9qt8gZ2fX).
+You can also request a network to be added to HyperSync in the [Discord](https://discord.gg/envio).
 
 ---

--- a/docs/HyperIndex/supported-networks/injective.md
+++ b/docs/HyperIndex/supported-networks/injective.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/ink.md
+++ b/docs/HyperIndex/supported-networks/ink.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/internal-test-chain.md
+++ b/docs/HyperIndex/supported-networks/internal-test-chain.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/iotex-network.md
+++ b/docs/HyperIndex/supported-networks/iotex-network.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Iotex Network? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Iotex Network? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/japan-open-chain.md
+++ b/docs/HyperIndex/supported-networks/japan-open-chain.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Japan Open Chain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Japan Open Chain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/kaia.md
+++ b/docs/HyperIndex/supported-networks/kaia.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Kaia? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Kaia? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/kakarot-starknet-sepolia.md
+++ b/docs/HyperIndex/supported-networks/kakarot-starknet-sepolia.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Kakarot Starknet Sepolia? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Kakarot Starknet Sepolia? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/kroma.md
+++ b/docs/HyperIndex/supported-networks/kroma.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/layeredge-testnet.md
+++ b/docs/HyperIndex/supported-networks/layeredge-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for LayerEdge Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for LayerEdge Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/lightlink-pegasus-testnet.md
+++ b/docs/HyperIndex/supported-networks/lightlink-pegasus-testnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Lightlink Pegasus Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Lightlink Pegasus Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/lightlink-phoenix.md
+++ b/docs/HyperIndex/supported-networks/lightlink-phoenix.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Lightlink Phoenix? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Lightlink Phoenix? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/lightlink.md
+++ b/docs/HyperIndex/supported-networks/lightlink.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/linea.md
+++ b/docs/HyperIndex/supported-networks/linea.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/lisk.md
+++ b/docs/HyperIndex/supported-networks/lisk.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/lukso-testnet.md
+++ b/docs/HyperIndex/supported-networks/lukso-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/lukso.md
+++ b/docs/HyperIndex/supported-networks/lukso.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/manta-pacific-sepolia.md
+++ b/docs/HyperIndex/supported-networks/manta-pacific-sepolia.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Manta Pacific Sepolia? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Manta Pacific Sepolia? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/manta.md
+++ b/docs/HyperIndex/supported-networks/manta.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/mantle.md
+++ b/docs/HyperIndex/supported-networks/mantle.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/megaeth-testnet.md
+++ b/docs/HyperIndex/supported-networks/megaeth-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/megaeth-testnet1.md
+++ b/docs/HyperIndex/supported-networks/megaeth-testnet1.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/megaeth-testnet2.md
+++ b/docs/HyperIndex/supported-networks/megaeth-testnet2.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/megaeth.md
+++ b/docs/HyperIndex/supported-networks/megaeth.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/merlin.md
+++ b/docs/HyperIndex/supported-networks/merlin.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/metall2.md
+++ b/docs/HyperIndex/supported-networks/metall2.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/meter-mainnet.md
+++ b/docs/HyperIndex/supported-networks/meter-mainnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Meter Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Meter Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/meter-testnet.md
+++ b/docs/HyperIndex/supported-networks/meter-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Meter Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Meter Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/metis.md
+++ b/docs/HyperIndex/supported-networks/metis.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/mev-commit.md
+++ b/docs/HyperIndex/supported-networks/mev-commit.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/mint-mainnet.md
+++ b/docs/HyperIndex/supported-networks/mint-mainnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Mint Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Mint Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/mode.md
+++ b/docs/HyperIndex/supported-networks/mode.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/monad-testnet-backup.md
+++ b/docs/HyperIndex/supported-networks/monad-testnet-backup.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/monad-testnet.md
+++ b/docs/HyperIndex/supported-networks/monad-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/monad.md
+++ b/docs/HyperIndex/supported-networks/monad.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/moonbase-alpha.md
+++ b/docs/HyperIndex/supported-networks/moonbase-alpha.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/moonbeam.md
+++ b/docs/HyperIndex/supported-networks/moonbeam.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/morph-holesky.md
+++ b/docs/HyperIndex/supported-networks/morph-holesky.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/morph-testnet.md
+++ b/docs/HyperIndex/supported-networks/morph-testnet.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/morph.md
+++ b/docs/HyperIndex/supported-networks/morph.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/mosaic-matrix.md
+++ b/docs/HyperIndex/supported-networks/mosaic-matrix.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/nautilus.md
+++ b/docs/HyperIndex/supported-networks/nautilus.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Nautilus? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Nautilus? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/neo-x-testnet.md
+++ b/docs/HyperIndex/supported-networks/neo-x-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Neo X Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Neo X Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/neon-evm.md
+++ b/docs/HyperIndex/supported-networks/neon-evm.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/nibiru-testnet.md
+++ b/docs/HyperIndex/supported-networks/nibiru-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Nibiru Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Nibiru Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/now-chaint.md
+++ b/docs/HyperIndex/supported-networks/now-chaint.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Now Chaint? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Now Chaint? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/oasis-emerald.md
+++ b/docs/HyperIndex/supported-networks/oasis-emerald.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Oasis Emerald? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Oasis Emerald? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/oasis-sapphire.md
+++ b/docs/HyperIndex/supported-networks/oasis-sapphire.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Oasis Sapphire? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Oasis Sapphire? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/onigiri-subnet.md
+++ b/docs/HyperIndex/supported-networks/onigiri-subnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for ONIGIRI Subnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for ONIGIRI Subnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/onigiri-test-subnet.md
+++ b/docs/HyperIndex/supported-networks/onigiri-test-subnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for ONIGIRI Test Subnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for ONIGIRI Test Subnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/ontology-mainnet.md
+++ b/docs/HyperIndex/supported-networks/ontology-mainnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Ontology Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Ontology Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/ontology-testnet.md
+++ b/docs/HyperIndex/supported-networks/ontology-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Ontology Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Ontology Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/op-celestia-raspberry.md
+++ b/docs/HyperIndex/supported-networks/op-celestia-raspberry.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for OP Celestia Raspberry? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for OP Celestia Raspberry? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/opbnb-mainnet.md
+++ b/docs/HyperIndex/supported-networks/opbnb-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for opBNB Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for opBNB Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/opbnb.md
+++ b/docs/HyperIndex/supported-networks/opbnb.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/optimism-sepolia.md
+++ b/docs/HyperIndex/supported-networks/optimism-sepolia.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/optimism.md
+++ b/docs/HyperIndex/supported-networks/optimism.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/optopia.md
+++ b/docs/HyperIndex/supported-networks/optopia.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Optopia? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Optopia? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/others.md
+++ b/docs/HyperIndex/supported-networks/others.md
@@ -70,7 +70,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About The B² Testnet 
@@ -156,7 +156,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About Base
@@ -234,7 +234,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About Berachain
@@ -319,7 +319,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About Blast
@@ -397,7 +397,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About Boba
@@ -482,7 +482,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About BSC
@@ -560,7 +560,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About Celo
@@ -638,7 +638,7 @@ The full list of HyperSync supported networks can be found [here](https://docs.e
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 
 ### About Chiliz

--- a/docs/HyperIndex/supported-networks/peaq.md
+++ b/docs/HyperIndex/supported-networks/peaq.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Peaq? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Peaq? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/pharos-devnet.md
+++ b/docs/HyperIndex/supported-networks/pharos-devnet.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/plasma.md
+++ b/docs/HyperIndex/supported-networks/plasma.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/plume.md
+++ b/docs/HyperIndex/supported-networks/plume.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/polygon-amoy.md
+++ b/docs/HyperIndex/supported-networks/polygon-amoy.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/polygon-zkevm-cardona-testnet.md
+++ b/docs/HyperIndex/supported-networks/polygon-zkevm-cardona-testnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Polygon zkEVM Cardona Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Polygon zkEVM Cardona Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/polygon-zkevm.md
+++ b/docs/HyperIndex/supported-networks/polygon-zkevm.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/polygon.md
+++ b/docs/HyperIndex/supported-networks/polygon.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/public-goods-network.md
+++ b/docs/HyperIndex/supported-networks/public-goods-network.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Public Goods Network? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Public Goods Network? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/pulsechain.md
+++ b/docs/HyperIndex/supported-networks/pulsechain.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for PulseChain? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for PulseChain? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/puppynet-shibarium.md
+++ b/docs/HyperIndex/supported-networks/puppynet-shibarium.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Puppynet Shibarium? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Puppynet Shibarium? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/ronin.md
+++ b/docs/HyperIndex/supported-networks/ronin.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Ronin? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Ronin? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/rootstock.md
+++ b/docs/HyperIndex/supported-networks/rootstock.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/saakuru.md
+++ b/docs/HyperIndex/supported-networks/saakuru.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/satoshivm.md
+++ b/docs/HyperIndex/supported-networks/satoshivm.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for SatoshiVM? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for SatoshiVM? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/scroll-sepolia.md
+++ b/docs/HyperIndex/supported-networks/scroll-sepolia.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Scroll Sepolia? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Scroll Sepolia? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/scroll.md
+++ b/docs/HyperIndex/supported-networks/scroll.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sei-testnet.md
+++ b/docs/HyperIndex/supported-networks/sei-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sei.md
+++ b/docs/HyperIndex/supported-networks/sei.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sentient-testnet.md
+++ b/docs/HyperIndex/supported-networks/sentient-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sentient.md
+++ b/docs/HyperIndex/supported-networks/sentient.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sepolia-temp-eip-7702.md
+++ b/docs/HyperIndex/supported-networks/sepolia-temp-eip-7702.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sepolia.md
+++ b/docs/HyperIndex/supported-networks/sepolia.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/shibarium.md
+++ b/docs/HyperIndex/supported-networks/shibarium.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Shibarium? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Shibarium? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/shimmer-evm.md
+++ b/docs/HyperIndex/supported-networks/shimmer-evm.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/skale-europa.md
+++ b/docs/HyperIndex/supported-networks/skale-europa.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Skale Europa? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Skale Europa? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/soneium.md
+++ b/docs/HyperIndex/supported-networks/soneium.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sonic-testnet.md
+++ b/docs/HyperIndex/supported-networks/sonic-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sonic.md
+++ b/docs/HyperIndex/supported-networks/sonic.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sophon-testnet.md
+++ b/docs/HyperIndex/supported-networks/sophon-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/sophon.md
+++ b/docs/HyperIndex/supported-networks/sophon.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/status-sepolia.md
+++ b/docs/HyperIndex/supported-networks/status-sepolia.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/stratovm-testnet.md
+++ b/docs/HyperIndex/supported-networks/stratovm-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for StratoVM Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for StratoVM Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/superseed-sepolia-testnet.md
+++ b/docs/HyperIndex/supported-networks/superseed-sepolia-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Superseed Sepolia Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Superseed Sepolia Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/superseed.md
+++ b/docs/HyperIndex/supported-networks/superseed.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/swell.md
+++ b/docs/HyperIndex/supported-networks/swell.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/taiko.md
+++ b/docs/HyperIndex/supported-networks/taiko.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Taiko? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Taiko? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/tangle.md
+++ b/docs/HyperIndex/supported-networks/tangle.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/tanssi-demo.md
+++ b/docs/HyperIndex/supported-networks/tanssi-demo.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Tanssi Demo? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Tanssi Demo? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/taraxa.md
+++ b/docs/HyperIndex/supported-networks/taraxa.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/telos-evm-mainnet.md
+++ b/docs/HyperIndex/supported-networks/telos-evm-mainnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Telos EVM Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Telos EVM Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/telos-evm-testnet.md
+++ b/docs/HyperIndex/supported-networks/telos-evm-testnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Telos EVM Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Telos EVM Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/tempo-testnet-(andantino).md
+++ b/docs/HyperIndex/supported-networks/tempo-testnet-(andantino).md
@@ -48,4 +48,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Tempo Testnet (Andantino)? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Tempo Testnet (Andantino)? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/tempo-testnet.md
+++ b/docs/HyperIndex/supported-networks/tempo-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Tempo Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Tempo Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/tempo.md
+++ b/docs/HyperIndex/supported-networks/tempo.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/torus-mainnet.md
+++ b/docs/HyperIndex/supported-networks/torus-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Torus Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Torus Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/torus-testnet.md
+++ b/docs/HyperIndex/supported-networks/torus-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Torus Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Torus Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/unichain-sepolia.md
+++ b/docs/HyperIndex/supported-networks/unichain-sepolia.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/unichain.md
+++ b/docs/HyperIndex/supported-networks/unichain.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/unicorn-ultra-nebulas-testnet.md
+++ b/docs/HyperIndex/supported-networks/unicorn-ultra-nebulas-testnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Unicorn Ultra Nebulas Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Unicorn Ultra Nebulas Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/velas-mainnet.md
+++ b/docs/HyperIndex/supported-networks/velas-mainnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Velas Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Velas Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/viction.md
+++ b/docs/HyperIndex/supported-networks/viction.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Viction? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Viction? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/worldchain.md
+++ b/docs/HyperIndex/supported-networks/worldchain.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/x-layer-mainnet.md
+++ b/docs/HyperIndex/supported-networks/x-layer-mainnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for X Layer Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for X Layer Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/x-layer-testnet.md
+++ b/docs/HyperIndex/supported-networks/x-layer-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for X Layer Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for X Layer Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/x-layer.md
+++ b/docs/HyperIndex/supported-networks/x-layer.md
@@ -58,6 +58,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/xdc-apothem-testnet.md
+++ b/docs/HyperIndex/supported-networks/xdc-apothem-testnet.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for XDC Apothem Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for XDC Apothem Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/xdc-network.md
+++ b/docs/HyperIndex/supported-networks/xdc-network.md
@@ -50,4 +50,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for XDC Network? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for XDC Network? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/xdc-testnet.md
+++ b/docs/HyperIndex/supported-networks/xdc-testnet.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/xdc.md
+++ b/docs/HyperIndex/supported-networks/xdc.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/zeta-testnet.md
+++ b/docs/HyperIndex/supported-networks/zeta-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Zeta Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Zeta Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/zeta.md
+++ b/docs/HyperIndex/supported-networks/zeta.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/zircuit.md
+++ b/docs/HyperIndex/supported-networks/zircuit.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/zklink-nova-mainnet.md
+++ b/docs/HyperIndex/supported-networks/zklink-nova-mainnet.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for ZkLink Nova Mainnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for ZkLink Nova Mainnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/zksync-sepolia-testnet.md
+++ b/docs/HyperIndex/supported-networks/zksync-sepolia-testnet.md
@@ -51,4 +51,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for ZkSync Sepolia Testnet? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for ZkSync Sepolia Testnet? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/zksync.md
+++ b/docs/HyperIndex/supported-networks/zksync.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperIndex/supported-networks/zora-sepolia.md
+++ b/docs/HyperIndex/supported-networks/zora-sepolia.md
@@ -49,4 +49,4 @@ networks:
           - event: Event
 ```
 
-Want HyperSync for Zora Sepolia? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+Want HyperSync for Zora Sepolia? Request network support here [Discord](https://discord.gg/envio)!

--- a/docs/HyperIndex/supported-networks/zora.md
+++ b/docs/HyperIndex/supported-networks/zora.md
@@ -59,6 +59,6 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---

--- a/docs/HyperRPC/hyperrpc-supported-networks.md
+++ b/docs/HyperRPC/hyperrpc-supported-networks.md
@@ -7,7 +7,7 @@ description: See all networks currently supported by HyperRPC, including their e
 ---
 
 :::note
-Please note we are rapidly adding new supported networks. If you don't see your network here or would like us to add a network to HyperRPC, pop us a message in [Discord](https://discord.gg/Q9qt8gZ2fX).
+Please note we are rapidly adding new supported networks. If you don't see your network here or would like us to add a network to HyperRPC, pop us a message in [Discord](https://discord.gg/envio).
 :::
 
 :::caution API Tokens Recommended

--- a/docs/HyperRPC/overview-hyperrpc.md
+++ b/docs/HyperRPC/overview-hyperrpc.md
@@ -118,7 +118,7 @@ To start using HyperRPC:
    ```
 
 4. **Provide Feedback**:
-   Your testing and feedback are incredibly valuable as we continue to improve HyperRPC. Let us know about your experience in our [Discord](https://discord.gg/Q9qt8gZ2fX).
+   Your testing and feedback are incredibly valuable as we continue to improve HyperRPC. Let us know about your experience in our [Discord](https://discord.gg/envio).
 
 ## Development Status
 
@@ -127,7 +127,7 @@ To start using HyperRPC:
 - HyperRPC is under active development to further improve performance and stability
 - It is designed for read-only operations and does not support all standard RPC methods
 - It has not yet undergone formal security audits
-- We welcome questions and feedback in our [Discord](https://discord.gg/Q9qt8gZ2fX)
+- We welcome questions and feedback in our [Discord](https://discord.gg/envio)
   :::
 
 ---

--- a/docs/HyperSync/hypersync-clients.md
+++ b/docs/HyperSync/hypersync-clients.md
@@ -172,7 +172,7 @@ Choose the client that best fits your use case:
 
 Need help getting started or have questions about our clients? Connect with our community:
 
-- [Discord Community](https://discord.gg/Q9qt8gZ2fX)
+- [Discord Community](https://discord.gg/envio)
 - [GitHub Issues](https://github.com/enviodev)
 - [Documentation Feedback](https://github.com/enviodev/docs/issues)
 

--- a/docs/HyperSync/hypersync-supported-networks.md
+++ b/docs/HyperSync/hypersync-supported-networks.md
@@ -7,7 +7,7 @@ description: See all networks currently supported by HyperSync, including covera
 ---
 
 :::note
-We are rapidly adding new supported networks. If you don't see your network here or would like us to add a network to HyperSync, pop us a message in our [Discord](https://discord.gg/Q9qt8gZ2fX).
+We are rapidly adding new supported networks. If you don't see your network here or would like us to add a network to HyperSync, pop us a message in our [Discord](https://discord.gg/envio).
 :::
 
 :::info
@@ -26,7 +26,7 @@ Currently, tiers relate to various service quality aspects including:
 While detailed tier specifications are still being finalized, we're committed to providing transparent service level information in the near future.
 
 
-If you are a network operator or user and would like improved service support or to discuss upgrading a chain's level of support, please reach out to us in [Discord](https://discord.gg/Q9qt8gZ2fX).
+If you are a network operator or user and would like improved service support or to discuss upgrading a chain's level of support, please reach out to us in [Discord](https://discord.gg/envio).
 :::
 | Network Name              | Network ID      | HyperSync URL                                                                            | HyperRPC URL                                                                             | Tier |
 | ------------------------- | --------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---- |

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -93,8 +93,8 @@ HyperSync powers a wide range of blockchain applications, enabling developers to
 - [Get an API Token](/docs/HyperSync/api-tokens) to access HyperSync services
 - [View Supported Networks](/docs/HyperSync/hypersync-supported-networks) to see available chains
 - [Check Client Documentation](/docs/HyperSync/hypersync-clients) for language-specific guides
-- [Join our Discord](https://discord.gg/Q9qt8gZ2fX) for support and updates
+- [Join our Discord](https://discord.gg/envio) for support and updates
 
 :::note
-Our documentation is continuously improving! If you have questions or need assistance, please reach out in our [Discord community](https://discord.gg/Q9qt8gZ2fX).
+Our documentation is continuously improving! If you have questions or need assistance, please reach out in our [Discord community](https://discord.gg/envio).
 :::

--- a/docs/HyperSync/tutorial-address-transactions.md
+++ b/docs/HyperSync/tutorial-address-transactions.md
@@ -93,4 +93,4 @@ Other use cases include:
 - Try modifying the scripts for your specific use cases
 - Learn more about [HyperSync's capabilities](/docs/HyperSync/hypersync-query) for blockchain data analysis
 
-For any questions or support, join our [Discord community](https://discord.gg/Q9qt8gZ2fX) or create an issue on the GitHub repository.
+For any questions or support, join our [Discord community](https://discord.gg/envio) or create an issue on the GitHub repository.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -351,7 +351,7 @@ const config = {
             items: [
               {
                 label: "Discord",
-                href: "https://discord.gg/Q9qt8gZ2fX",
+                href: "https://discord.gg/envio",
               },
               {
                 label: "Twitter",

--- a/docusaurus.config.llm.js
+++ b/docusaurus.config.llm.js
@@ -99,7 +99,7 @@ const config = {
           {
             title: "Community",
             items: [
-              { label: "Discord", href: "https://discord.gg/Q9qt8gZ2fX" },
+              { label: "Discord", href: "https://discord.gg/envio" },
               { label: "Twitter", href: "https://twitter.com/envio_indexer" },
             ],
           },

--- a/scripts/update-endpoints.js
+++ b/scripts/update-endpoints.js
@@ -308,7 +308,7 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.com/invite/Q9qt8gZ2fX); we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---
 `;
@@ -381,7 +381,7 @@ networks:
 \`\`\`
 
 Want HyperSync for ${network.name
-    }? Request network support here [Discord](https://discord.gg/fztEvj79m3)!
+    }? Request network support here [Discord](https://discord.gg/envio)!
 `;
 };
 


### PR DESCRIPTION
## Summary

- Standardizes every Envio Discord reference to `https://discord.gg/envio` across docs, blog, config, and scripts
- Preserves third-party Discord links (Fuel, Monad, ETHGlobal, LUKSO) unchanged
- Fixes the endpoints generator script so future regenerations stay consistent

## Invites replaced with `envio`

- `discord.gg/Q9qt8gZ2fX` (~130 hits, network-support docs)
- `discord.com/invite/Q9qt8gZ2fX` (generator script)
- `discord.gg/DhfFhzuJQh` (troubleshoot docs)
- `discord.gg/fztEvj79m3` (generator script + network-support blocks)
- `discord.com/invite/gt7yEUZKeB` (blog post footers)
- `discord.com/invite/envio` (format normalization)

## Test plan

- [x] `docusaurus.config.js` and `.llm.js` parse cleanly
- [x] Generator script syntactically valid
- [x] `discord.gg/envio` returns 200
- [x] No remaining Envio-family invites in the tree (only 3rd-party: Fuel, Monad, ETHGlobal, LUKSO)
- [ ] Verify preview deploy renders with working Discord links

🤖 Generated with [Claude Code](https://claude.com/claude-code)