### PR TITLE
chore: clean up author bio copy

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -3,7 +3,7 @@ nikbhintade:
   title: Growth Engineer at Envio
   url: /blog/author/nikbhintade
   image_url: /blog-assets/authors/nikbhintade.jpg
-  description: "Growth Engineer at Envio working on developer experience, ecosystem growth, and technical content around blockchain indexing and Web3 infrastructure."
+  description: "Working on developer experience, ecosystem growth, and technical content around blockchain indexing and Web3 infrastructure."
   socials:
     twitter: https://x.com/nikbhintade
     linkedin: https://linkedin.com/in/nikbhintade
@@ -12,7 +12,7 @@ j_o_r_d_y_s:
   title: Head of Marketing & Ops at Envio
   url: /blog/author/j_o_r_d_y_s
   image_url: /blog-assets/authors/j_o_r_d_y_s.jpg
-  description: "Head of Marketing & Ops at Envio, passionate about building communities and sharing knowledge around blockchain indexing and Web3 infrastructure."
+  description: "Passionate about building communities and sharing knowledge around blockchain indexing and Web3 infrastructure."
   socials:
     twitter: https://x.com/j_o_r_d_y_s
     linkedin: https://linkedin.com/in/jordynlaurier
@@ -21,7 +21,7 @@ KenauVith32:
   title: Growth Engineer at Envio
   url: /blog/author/KenauVith32
   image_url: /blog-assets/authors/KenauVith32.jpg
-  description: "Growth Engineer at Envio working on developer experience, ecosystem growth, and technical content around blockchain indexing and Web3 infrastructure."
+  description: "Working on developer experience, ecosystem growth, and technical content around blockchain indexing and Web3 infrastructure."
   socials:
     twitter: https://x.com/KenauVith32
     linkedin: https://www.linkedin.com/in/kenau-vith-0b93b726b/


### PR DESCRIPTION
## Summary
- Tightens author bios so titles aren't repeated under the name and again at the start of each description.

## Test plan
- [x] `yarn start` — author pages render title once, description distinct

cc @nikbhintade

🤖 Generated with [Claude Code](https://claude.com/claude-code)