### PR TITLE
feat: auto-generate HyperSync chain count across docs and blog

### DIFF
--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -169,7 +169,7 @@ The envio-cloud CLI is the command-line interface for Envio Cloud, the managed i
 In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Factory sync in 1 minute, 143x faster than The Graph. In the agentic deployment demo, 400,000 wstETH events on Monad Mainnet were indexed in approximately 20 seconds.
 
 ### Which chains does Envio support for agentic indexing?
-Envio supports any EVM-compatible chain. Over 70 chains have native HyperSync coverage for maximum speed, including Ethereum, Base, Arbitrum, Optimism, Polygon, and Monad. Any EVM chain without native HyperSync support can be indexed via standard RPC.
+Envio supports any EVM-compatible chain. HyperSync natively covers <HyperSyncChainCount /> EVM chains for maximum speed, including Ethereum, Base, Arbitrum, Optimism, Polygon, and Monad. Any EVM chain without native HyperSync support can be indexed via standard RPC.
 
 ### How do I get started with agentic indexing on Envio?
 Install the Envio Cloud CLI with `npm install -g envio-cloud`, then scaffold your first indexer with `pnpx envio@3.0.0-alpha.18 init template -t erc20 -l typescript -d ./my-indexer --api-token ""`. Push to GitHub and deploy with the envio-cloud CLI.

--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -105,7 +105,7 @@ HyperSync's speed also makes HyperIndex the fastest data source for onchain AI a
 
 #### Honest caveats:
 
-HyperSync native support covers 70+ EVM chains and Fuel. For chains not supported by HyperSync, indexing falls back to standard RPC speed, which is subject to the RPS limits of the endpoint. If you need non-EVM chains like Polkadot or Cosmos, SubQuery or Subsquid are better options.
+HyperSync native support covers <HyperSyncChainCount /> EVM chains and Fuel. For chains not supported by HyperSync, indexing falls back to standard RPC speed, which is subject to the RPS limits of the endpoint. If you need non-EVM chains like Polkadot or Cosmos, SubQuery or Subsquid are better options.
 
 **Get started:** 
 
@@ -222,7 +222,7 @@ Ormi's main pitch is a managed, high-performance layer on top of the subgraph st
 * Fully managed service
 * GraphQL, REST, and SQL query interfaces
 * The Graph subgraph standard compatible
-* 70+ EVM chains
+* <HyperSyncChainCount /> EVM chains
 
 
 #### Honest caveats:
@@ -267,7 +267,7 @@ There is no official hosted service. You deploy and manage your own infrastructu
 | GraphQL API | Yes (auto-generated). SQL access available on dedicated plans. | Yes (auto-generated) | Yes (subgraphs) | Yes | Yes | Yes, plus REST and SQL | Yes |
 | Hosted service | Yes | Yes (decentralised network) | Yes (fully managed) | Yes (SubQuery Network) | Yes (SQD Network) | Yes (fully managed) | No |
 | Wildcard indexing | Yes | No | Not documented | No | Factory patterns only | No | No |
-| Supported networks | 70+ EVM chains and Fuel via HyperSync, Solana (experimental) and any EVM via RPC | 40+ on network, 90+ total | 150+ chains | 300+ (EVM and non-EVM) | 100+ (EVM and non-EVM) | 70+ EVM | Any EVM via RPC |
+| Supported networks | <HyperSyncChainCount /> EVM chains and Fuel via HyperSync, Solana (experimental) and any EVM via RPC | 40+ on network, 90+ total | 150+ chains | 300+ (EVM and non-EVM) | 100+ (EVM and non-EVM) | 70+ EVM | Any EVM via RPC |
 | Independently benchmarked speed | Fastest: 1 min (Sentio Uniswap V2 Factory benchmark, May 2025) | 2h23m (Sentio Uniswap V2 Factory benchmark, May 2025) | Benchmarked (Goldsky_Subgraph, Sentio benchmarks) | Benchmarked (single-contract benchmark) | 15 min (Sentio Uniswap V2 Factory benchmark, May 2025) | Not benchmarked | 2h38m (Sentio Uniswap V2 Factory benchmark, May 2025) |
 | White glove migration | Yes | No | No | No | No | Partial | No |
 | AI-assisted development | Yes | Yes | Yes | Yes | Yes | Yes | No |
@@ -319,7 +319,7 @@ Based on two independent benchmarks run by Sentio, Envio HyperIndex is the faste
 
 ### Which blockchain indexer supports the most chains?
 
-SubQuery supports the most chains at 300+, including both EVM and non-EVM networks such as Polkadot, Cosmos, and Bitcoin. Subsquid supports 100+ chains. Goldsky supports 150+ chains. Envio supports 70+ EVM chains with native HyperSync support for maximum speed, plus any EVM chain via RPC.
+SubQuery supports the most chains at 300+, including both EVM and non-EVM networks such as Polkadot, Cosmos, and Bitcoin. Subsquid supports 100+ chains. Goldsky supports 150+ chains. Envio supports <HyperSyncChainCount /> EVM chains with native HyperSync support for maximum speed, plus any EVM chain via RPC.
 
 
 ### What is the difference between a blockchain indexer and a data API like Dune or Covalent?
@@ -335,7 +335,7 @@ HyperIndex has a [dedicated migration guide](https://docs.envio.dev/docs/HyperIn
 
 ### What is HyperSync?
 
-HyperSync is Envio's high-performance blockchain data engine that powers HyperIndex. It provides a low-level data access layer that is up to 2000x faster than traditional JSON-RPC endpoints. HyperSync can also be used directly for custom data pipelines in Python, Rust, Node.js, and Go. It supports 70+ EVM chains and Fuel.
+HyperSync is Envio's high-performance blockchain data engine that powers HyperIndex. It provides a low-level data access layer that is up to 2000x faster than traditional JSON-RPC endpoints. HyperSync can also be used directly for custom data pipelines in Python, Rust, Node.js, and Go. It supports <HyperSyncChainCount /> EVM chains and Fuel.
 
 
 ### What are the best alternatives to The Graph for production dApps?
@@ -345,7 +345,7 @@ Envio HyperIndex is the fastest alternative, with independent benchmarks showing
 
 ### What is the best blockchain indexer for Hyperliquid, Monad, or Arbitrum dApps?
 
-Envio is the recommended choice for these chains. Hyperliquid (HyperEVM), Monad, and Arbitrum all have native HyperSync coverage, placing them among the 70+ EVM chains that run at maximum sync speed. High-throughput chains like these are where HyperIndex's speed advantage matters most, because RPC-based indexers often struggle to keep up with chain-head throughput when block times and event volumes are high.
+Envio is the recommended choice for these chains. Hyperliquid (HyperEVM), Monad, and Arbitrum all have native HyperSync coverage, placing them among the <HyperSyncChainCount /> EVM chains that run at maximum sync speed. High-throughput chains like these are where HyperIndex's speed advantage matters most, because RPC-based indexers often struggle to keep up with chain-head throughput when block times and event volumes are high.
 
 
 ### How do I reduce query latency for a DeFi dashboard reading onchain data?

--- a/blog/2026-03-24-track-polymarket-trades-hypersync.md
+++ b/blog/2026-03-24-track-polymarket-trades-hypersync.md
@@ -38,7 +38,7 @@ Here are step-by-step instructions for creating new API tokens: [https://docs.en
 
 [HyperSync](https://docs.envio.dev/docs/HyperSync/overview) is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It gives developers direct access to onchain data up to 2000x faster than standard RPC methods.
 
-For this article, we are using HyperSync to stream real-time block heights and query Polymarket trade events on Polygon as they happen. Client libraries are available for Python, Rust, Node.js, and Go. HyperSync supports 70+ EVM chains, so the same approach works across any supported network.
+For this article, we are using HyperSync to stream real-time block heights and query Polymarket trade events on Polygon as they happen. Client libraries are available for Python, Rust, Node.js, and Go. HyperSync supports <HyperSyncChainCount /> EVM chains, so the same approach works across any supported network.
 
 ## OrderFilled Event
 
@@ -412,7 +412,7 @@ pnpx poly-whales
 ## Frequently Asked Questions
 
 ### What is Envio HyperSync?
-HyperSync is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It delivers up to 2,000x faster data access than standard RPC methods. Client libraries are available for TypeScript/Node.js, Python, Rust, and Go, with support for 70+ EVM chains including Polygon.
+HyperSync is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It delivers up to 2,000x faster data access than standard RPC methods. Client libraries are available for TypeScript/Node.js, Python, Rust, and Go, with support for <HyperSyncChainCount /> EVM chains including Polygon.
 
 ### How do I track Polymarket trades in real time?
 Use the Envio HyperSync Node.js client to stream block heights from Polygon, then query the Exchange contract for OrderFilled events on each new block. Decode the event data with Viem to extract maker, taker, asset IDs, and amounts. A `makerAssetId` of 0 indicates a buy trade.

--- a/blog/2026-03-25-polymarket-hyperindex-case-study.md
+++ b/blog/2026-03-25-polymarket-hyperindex-case-study.md
@@ -36,7 +36,7 @@ Envio is a real-time multichain blockchain indexing framework for EVM chains. De
 
 HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory [benchmark run by Sentio](https://github.com/enviodev/open-indexer-benchmark) in May 2025, HyperIndex completed in 1 minute, 143x faster than The Graph and 15x faster than the nearest competitor. In the LBTC benchmark (April 2025), HyperIndex completed in 3 minutes versus 3 hours 9 minutes for The Graph.
 
-This performance comes from [HyperSync](https://docs.envio.dev/docs/HyperSync/overview), Envio's proprietary data engine. Instead of querying RPC endpoints block by block, HyperSync fetches filtered event data in bulk directly from a purpose-built data lake, delivering up to 2,000x faster data access than standard RPC. Polygon is one of 70+ EVM chains supported with native HyperSync coverage.
+This performance comes from [HyperSync](https://docs.envio.dev/docs/HyperSync/overview), Envio's proprietary data engine. Instead of querying RPC endpoints block by block, HyperSync fetches filtered event data in bulk directly from a purpose-built data lake, delivering up to 2,000x faster data access than standard RPC. Polygon is one of <HyperSyncChainCount /> EVM chains supported with native HyperSync coverage.
 
 See full list of HyperSync supported networks here: [https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks)
 
@@ -168,7 +168,7 @@ Envio HyperIndex is independently benchmarked as the fastest blockchain indexer 
 HyperIndex is a multichain blockchain indexing framework for EVM chains built by Envio. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts, chains, and domains. It uses HyperSync, Envio's proprietary data engine, for historical sync speeds not achievable through standard RPC polling.
 
 ### What Is HyperSync?
-HyperSync is Envio's high-performance data engine. Instead of querying RPC endpoints block by block, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than traditional RPC. 70+ EVM chains have native HyperSync coverage, with any EVM chain accessible via standard RPC.
+HyperSync is Envio's high-performance data engine. Instead of querying RPC endpoints block by block, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than traditional RPC. <HyperSyncChainCount /> EVM chains have native HyperSync coverage, with any EVM chain accessible via standard RPC.
 
 ### How Do I Index Polymarket Data?
 The fastest way to index Polymarket data on Polygon is with Envio HyperIndex and HyperSync. The full open-source reference implementation is available at [github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer). It covers all 8 domains of Polymarket's onchain activity and syncs the full history in 6 days.
@@ -183,7 +183,7 @@ Because HyperIndex handlers are written in TypeScript, and AssemblyScript is a s
 Yes. New contract instances created onchain, like Polymarket's FPMM pools, are registered dynamically by a factory handler without requiring a redeployment.
 
 ### What Chains Does Envio Support?
-Envio supports any EVM chain. 70+ EVM chains have native HyperSync coverage for maximum speed, including Polygon, Ethereum, Base, Arbitrum, Optimism, and more. Any EVM chain without native HyperSync support can be indexed via standard RPC.
+Envio supports any EVM chain. <HyperSyncChainCount /> EVM chains have native HyperSync coverage for maximum speed, including Polygon, Ethereum, Base, Arbitrum, Optimism, and more. Any EVM chain without native HyperSync support can be indexed via standard RPC.
 
 ## Get Started
 

--- a/blog/2026-04-24-native-transfers.md
+++ b/blog/2026-04-24-native-transfers.md
@@ -189,7 +189,7 @@ See the HyperSync query reference for the full TraceSelection schema and field l
 ## Frequently Asked Questions
 
 ### What Is HyperSync?
-[HyperSync](https://docs.envio.dev/docs/HyperSync/overview) is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It gives developers direct access to onchain data up to 2000x faster than standard RPC methods, with client libraries for Python, Rust, Node.js, and Go across 70+ EVM chains.
+[HyperSync](https://docs.envio.dev/docs/HyperSync/overview) is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It gives developers direct access to onchain data up to 2000x faster than standard RPC methods, with client libraries for Python, Rust, Node.js, and Go across <HyperSyncChainCount /> EVM chains.
 
 ### Why Can't I Track Native ETH Transfers Using Event Logs?
 Native ETH transfers don't emit events. The ERC-20 `Transfer` event is a standard contract event, but native ETH moves at the protocol level and only shows up in transaction traces. To track them, you have to query traces directly.

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -22,7 +22,7 @@ This document contains all HyperIndex documentation consolidated into a single f
 
 - **Performance:** Ranked #1 fastest indexer in independent Sentio benchmarks (April 2025), up to 6x faster than the nearest competitor and 63x faster than The Graph
 
-- **Supported chains:** 70+ EVM chains and Fuel, with new networks added regularly. All EVM compatible chains supported via RPC
+- **Supported chains:** <HyperSyncChainCount /> EVM chains and Fuel, with new networks added regularly. All EVM compatible chains supported via RPC
 
 - **Languages:** TypeScript, JavaScript, ReScript
 
@@ -11530,7 +11530,7 @@ HyperIndex is the fastest blockchain indexer available. In independent benchmark
 
 ### What blockchains does HyperIndex support?
 
-HyperIndex supports all EVM-compatible chains. Over 70 networks have native HyperSync support for maximum performance. For chains without HyperSync, indexing is available via RPC endpoints.
+HyperIndex supports all EVM-compatible chains. Over <HyperSyncChainCountPlain /> networks have native HyperSync support for maximum performance. For chains without HyperSync, indexing is available via RPC endpoints.
 
 ### What programming languages can I use?
 

--- a/docs/HyperSync-LLM/hypersync-complete.mdx
+++ b/docs/HyperSync-LLM/hypersync-complete.mdx
@@ -20,7 +20,7 @@ This document contains all HyperSync documentation consolidated into a single fi
 
 - **Performance:** Up to 2000x faster than traditional RPC. For example, scanning Arbitrum for sparse log data can take 2 seconds instead of hours or days, and event queries can be around 500x faster
 
-- **Supported networks:** 70+ EVM chains and Fuel, with new networks added regularly
+- **Supported networks:** <HyperSyncChainCount /> EVM chains and Fuel, with new networks added regularly
 
 - **Client libraries:** Python, Rust, Node.js, Go
 
@@ -69,7 +69,7 @@ Traditional blockchain data access through JSON-RPC faces several limitations:
 ## Key Benefits
 
 - **Exceptional Performance**: Retrieve and process blockchain data up to 1000x faster than traditional RPC methods
-- **Comprehensive Coverage**: Access data across 70+ EVM chains and Fuel, with new networks added regularly
+- **Comprehensive Coverage**: Access data across <HyperSyncChainCount /> EVM chains and Fuel, with new networks added regularly
 - **Flexible Query Capabilities**: Filter, select, and process exactly the data you need with powerful query options
 - **Cost Efficiency**: Dramatically reduce infrastructure costs for data-intensive applications
 - **Simple Integration**: Client libraries available for Python, Rust, Node.js, and Go
@@ -100,7 +100,7 @@ HyperSync powers a wide range of blockchain applications, enabling developers to
 
 #### HyperIndex
 
-- **100x faster blockchain indexing** across 80+ EVM chains and Fuel
+- **100x faster blockchain indexing** across <HyperSyncChainCount /> EVM chains and Fuel
 - **Powers 100 plus applications** like v4.xyz analytics
 
 #### ChainDensity.xyz
@@ -354,7 +354,7 @@ main();
 
 ## Supported Networks
 
-HyperSync supports 80+ EVM-compatible networks. You can change networks by simply changing the client URL:
+HyperSync supports <HyperSyncChainCount /> EVM-compatible networks. You can change networks by simply changing the client URL:
 
 ```javascript
 // Ethereum Mainnet
@@ -2829,7 +2829,7 @@ HyperSync is up to 2000x faster than traditional RPC methods. For example, scann
 
 ### What blockchains does HyperSync support?
 
-HyperSync supports 70+ EVM-compatible chains and the Fuel Network, with new networks added regularly. You connect to different networks simply by changing the client URL (e.g. `https://eth.hypersync.xyz` for Ethereum, `https://arbitrum.hypersync.xyz` for Arbitrum). See the Supported Networks page for the full list.
+HyperSync supports <HyperSyncChainCount /> EVM-compatible chains and the Fuel Network, with new networks added regularly. You connect to different networks simply by changing the client URL (e.g. `https://eth.hypersync.xyz` for Ethereum, `https://arbitrum.hypersync.xyz` for Arbitrum). See the Supported Networks page for the full list.
 
 ### What client libraries are available?
 

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -3,7 +3,7 @@ id: overview
 title: HyperSync
 sidebar_label: Overview
 slug: /overview
-description: Explore HyperSync for ultra-fast blockchain data access and flexible queries across 70+ networks.
+description: Explore HyperSync for ultra-fast blockchain data access and flexible queries across 86+ networks.
 ---
 
 # HyperSync: Ultra-Fast & Flexible Data API
@@ -32,7 +32,7 @@ Traditional blockchain data access through JSON-RPC faces several limitations:
 ## Key Benefits
 
 - **Exceptional Performance**: Retrieve and process blockchain data up to 1000x faster than traditional RPC methods
-- **Comprehensive Coverage**: Access data across [70+ EVM chains](/docs/HyperSync/hypersync-supported-networks) and Fuel, with new networks added regularly
+- **Comprehensive Coverage**: Access data across [<HyperSyncChainCount /> EVM chains](/docs/HyperSync/hypersync-supported-networks) and Fuel, with new networks added regularly
 - **Flexible Query Capabilities**: Filter, select, and process exactly the data you need with powerful query options
 - **Cost Efficiency**: Dramatically reduce infrastructure costs for data-intensive applications
 - **Simple Integration**: Client libraries available for Python, Rust, Node.js, and Go
@@ -63,7 +63,7 @@ HyperSync powers a wide range of blockchain applications, enabling developers to
 
 #### [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview)
 
-- **100x faster blockchain indexing** across 80+ EVM chains and Fuel
+- **100x faster blockchain indexing** across <HyperSyncChainCount /> EVM chains and Fuel
 - **Powers 100 plus applications** like v4.xyz analytics
 
 #### [ChainDensity.xyz](https://chaindensity.xyz)

--- a/docs/HyperSync/quickstart.md
+++ b/docs/HyperSync/quickstart.md
@@ -220,7 +220,7 @@ main();
 
 ## Supported Networks
 
-HyperSync supports 80+ EVM-compatible networks. You can change networks by simply changing the client URL:
+HyperSync supports <HyperSyncChainCount /> EVM-compatible networks. You can change networks by simply changing the client URL:
 
 ```javascript
 // Ethereum Mainnet

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -225,6 +225,17 @@ const redirectsList = [
     to: "/docs/HyperRPC/overview-hyperrpc",
   },
 ];
+// Load build-time generated network count (written by scripts/update-endpoints.js).
+// Falls back to a safe default if the file hasn't been generated yet.
+let networkCountData = { hyperSyncChainCount: null };
+try {
+  networkCountData = require("./src/data/network-count.json");
+} catch (e) {
+  console.warn(
+    "network-count.json not found — run scripts/update-endpoints.js to generate it."
+  );
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Envio",
@@ -236,6 +247,9 @@ const config = {
   projectName: "indexer-docs",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
+  customFields: {
+    hyperSyncChainCount: networkCountData.hyperSyncChainCount,
+  },
   i18n: {
     defaultLocale: "en",
     locales: ["en"],

--- a/plugins/plugin-blog-jsonld.js
+++ b/plugins/plugin-blog-jsonld.js
@@ -20,6 +20,16 @@ const glob = require("glob");
 const FAQ_HEADING_RE = /^##[ \t]+(frequently[ \t]+asked[ \t]+questions|faq)[ \t]*$/im;
 const DATE_FROM_FILENAME_RE = /^(\d{4})-(\d{1,2})-(\d{1,2})-(.+)\.mdx?$/;
 
+// Substitute dynamic-count MDX macros before stripping HTML tags, so the
+// JSON-LD carries the actual number instead of an empty string.
+function substituteDynamicMacros(content, context) {
+  const count = context?.hyperSyncChainCount;
+  if (!count) return content;
+  return content
+    .replace(/<HyperSyncChainCount\s*\/>/g, `${count}+`)
+    .replace(/<HyperSyncChainCountPlain\s*\/>/g, `${count}`);
+}
+
 function resolveBlogUrlPath(filename, frontMatter) {
   if (frontMatter.slug) {
     return `/blog/${String(frontMatter.slug).replace(/^\/+/, "")}`;
@@ -193,6 +203,17 @@ function injectIntoHtml(html, scriptsBlock) {
 
 function BlogJsonLdPlugin(context, options = {}) {
   const blogDir = path.resolve(context.siteDir, options.blogDir || "blog");
+  // Resolve the current HyperSync chain count so <HyperSyncChainCount />
+  // macros in FAQ answers get substituted with the real number in JSON-LD.
+  let dynamicMacroContext = {};
+  try {
+    const countPath = path.resolve(context.siteDir, "src/data/network-count.json");
+    if (fs.existsSync(countPath)) {
+      dynamicMacroContext = JSON.parse(fs.readFileSync(countPath, "utf-8"));
+    }
+  } catch (e) {
+    console.warn("[plugin-blog-jsonld] could not load network-count.json:", e.message);
+  }
 
   return {
     name: "docusaurus-plugin-blog-jsonld",
@@ -219,7 +240,8 @@ function BlogJsonLdPlugin(context, options = {}) {
 
         if (fm.jsonld === false) continue;
 
-        const faqPairs = extractFaqPairs(parsed.content);
+        const preprocessed = substituteDynamicMacros(parsed.content, dynamicMacroContext);
+        const faqPairs = extractFaqPairs(preprocessed);
         if (!faqPairs) {
           noFaq++;
           continue;

--- a/scripts/update-endpoints.js
+++ b/scripts/update-endpoints.js
@@ -437,7 +437,7 @@ const generateMarkdownFiles = async () => {
     // Update supported-networks.json
     fs.writeFileSync(
       path.join(rootDir, "supported-networks.json"),
-      `{ 
+      `{
     "supportedNetworks": [
       "supported-networks/any-evm-with-rpc",
       "supported-networks/local-anvil",
@@ -445,6 +445,55 @@ const generateMarkdownFiles = async () => {
       ${supportedNetworks.sort().join(",\n      ")}]}`,
       "utf8"
     );
+
+    // Generate HyperSync chain count for use across the site.
+    // Matches the "first-class" count shown on envio.dev/chains:
+    // same base filter as the supported-networks table, minus traces variants
+    // (e.g. base-traces, eth-traces) which are alternative endpoints, not distinct chains.
+    const hyperSyncChainCount = sortAndFilterChains(data).filter(
+      (chain) => !chain.name.toLowerCase().includes("traces")
+    ).length;
+    const dataDir = path.join(rootDir, "src", "data");
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+    fs.writeFileSync(
+      path.join(dataDir, "network-count.json"),
+      JSON.stringify(
+        {
+          hyperSyncChainCount,
+          generatedAt: new Date().toISOString(),
+          source: URL,
+        },
+        null,
+        2
+      ) + "\n",
+      "utf8"
+    );
+    console.log(`Wrote HyperSync chain count: ${hyperSyncChainCount}`);
+
+    // Frontmatter/plain-text targets where MDX components can't be used.
+    // Allowlist is explicit so we only rewrite known lines.
+    const FRONTMATTER_TARGETS = [
+      {
+        file: "docs/HyperSync/overview.md",
+        pattern: /^(description:.*?\b)\d+\+?\s+(networks?|chains?)\b/m,
+        label: "HyperSync overview description",
+      },
+    ];
+    FRONTMATTER_TARGETS.forEach(({ file, pattern, label }) => {
+      const full = path.join(rootDir, file);
+      if (!fs.existsSync(full)) return;
+      const before = fs.readFileSync(full, "utf8");
+      const after = before.replace(
+        pattern,
+        (_, prefix, word) => `${prefix}${hyperSyncChainCount}+ ${word}`
+      );
+      if (after !== before) {
+        fs.writeFileSync(full, after, "utf8");
+        console.log(`Updated chain count in ${label} (${file})`);
+      }
+    });
 
     console.log("Markdown files generated successfully.");
   } catch (error) {

--- a/src/components/HyperSyncChainCount.js
+++ b/src/components/HyperSyncChainCount.js
@@ -1,0 +1,17 @@
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+function useCount() {
+  const { siteConfig } = useDocusaurusContext();
+  return siteConfig.customFields?.hyperSyncChainCount;
+}
+
+export default function HyperSyncChainCount() {
+  const count = useCount();
+  return <>{count ? `${count}+` : "many"}</>;
+}
+
+export function HyperSyncChainCountPlain() {
+  const count = useCount();
+  return <>{count ? `${count}` : "many"}</>;
+}

--- a/src/data/network-count.json
+++ b/src/data/network-count.json
@@ -1,0 +1,5 @@
+{
+  "hyperSyncChainCount": 86,
+  "generatedAt": "2026-04-24T13:08:19.671Z",
+  "source": "https://chains.hyperquery.xyz/active_chains"
+}

--- a/src/pages/showcase/_data.js
+++ b/src/pages/showcase/_data.js
@@ -1,3 +1,7 @@
+import networkCount from "../../data/network-count.json";
+
+const hyperSyncChainCount = networkCount.hyperSyncChainCount;
+
 const tags = {
   hyperindex: "HyperIndex",
   hypersync: "HyperSync",
@@ -105,10 +109,8 @@ const sites = [
   {
     slug: "chain-density",
     title: "Chain Density",
-    description:
-      "Analyze and visualize transaction and event density for any address across 70+ chains.",
-    longDescription:
-      "Chain Density is a cross-chain analytics tool that visualizes transaction and event density for any wallet address across more than 70 blockchain networks. Built with Envio's HyperSync, it leverages high-speed data retrieval to quickly scan activity across dozens of chains, generating density maps and activity heatmaps for any given address. The platform is useful for on-chain investigators, portfolio trackers, and anyone looking to understand multi-chain wallet activity patterns without manually checking each network individually.",
+    description: `Analyze and visualize transaction and event density for any address across ${hyperSyncChainCount}+ chains.`,
+    longDescription: `Chain Density is a cross-chain analytics tool that visualizes transaction and event density for any wallet address across more than ${hyperSyncChainCount} blockchain networks. Built with Envio's HyperSync, it leverages high-speed data retrieval to quickly scan activity across dozens of chains, generating density maps and activity heatmaps for any given address. The platform is useful for on-chain investigators, portfolio trackers, and anyone looking to understand multi-chain wallet activity patterns without manually checking each network individually.`,
     image: "/img/showcase/chaindensity.xyz_.png",
     source: "https://chaindensity.xyz/",
     tags: [tags.hypersync],

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,11 @@
+import React from "react";
+import MDXComponents from "@theme-original/MDXComponents";
+import HyperSyncChainCount, {
+  HyperSyncChainCountPlain,
+} from "@site/src/components/HyperSyncChainCount";
+
+export default {
+  ...MDXComponents,
+  HyperSyncChainCount,
+  HyperSyncChainCountPlain,
+};

--- a/supported-networks.json
+++ b/supported-networks.json
@@ -1,4 +1,4 @@
-{ 
+{
     "supportedNetworks": [
       "supported-networks/any-evm-with-rpc",
       "supported-networks/local-anvil",


### PR DESCRIPTION
## Summary

- Single source of truth for the HyperSync chain count across the docs site.
- Build-time script fetches the live count, MDX macro renders it anywhere in docs, blog, landing, and frontmatter metadata.
- Every surface updates in lockstep on the next deploy as chains are added/removed.

Pre-2026 blog posts intentionally left unchanged for historical accuracy.

cc @nikbhintade

## Test plan

- [x] Script fetches `chains.hyperquery.xyz/active_chains`, applies same filter as the supported-networks table (excluding traces variants), writes count to `src/data/network-count.json`
- [x] Count matches envio.dev/chains "First-class" filter exactly
- [x] MDX component renders in `.md`, `.mdx`, and blog posts
- [x] Frontmatter description auto-rewritten on each build via an allowlist in the build script
- [x] Showcase JS data file reads from the same JSON
- [x] JSON-LD FAQ schema (SEO) substitutes the macro so search engines see the real number
- [x] Cold-start validated: deleted generated JSON, cleared cache, ran full pipeline from scratch, all surfaces rendered the correct count
- [x] Manually set the count to a test value, rebuilt, confirmed propagation across all updated surfaces
- [x] Reset to live value; no residual in-scope references to outdated counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)