### PR TITLE
fix: resolve 4xx errors from Moz crawl

### DIFF
--- a/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
+++ b/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
@@ -139,7 +139,7 @@ Yes. HyperIndex supports multichain indexing from a single instance. You define 
 
 ### How do I debug a blockchain indexer that is returning incorrect data?
 
-Start by checking whether the indexer has processed all expected blocks using the terminal UI. If data looks stale, stop the indexer with `pnpm envio stop` and restart with `pnpm dev` to clear persisted state. If you are using an RPC endpoint, check for rate limiting errors in the logs and consider switching to HyperSync for your network. The [Envio docs](https://docs.envio.dev/docs/HyperIndex/Troubleshoot/common-issues) cover the most common issues in detail.
+Start by checking whether the indexer has processed all expected blocks using the terminal UI. If data looks stale, stop the indexer with `pnpm envio stop` and restart with `pnpm dev` to clear persisted state. If you are using an RPC endpoint, check for rate limiting errors in the logs and consider switching to HyperSync for your network. The [Envio docs](https://docs.envio.dev/docs/HyperIndex/common-issues) cover the most common issues in detail.
 
 ### Do I need to manage my own infrastructure to run Envio HyperIndex?
 

--- a/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
+++ b/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
@@ -139,7 +139,7 @@ Yes. HyperIndex supports multichain indexing from a single instance. You define 
 
 ### How do I debug a blockchain indexer that is returning incorrect data?
 
-Start by checking whether the indexer has processed all expected blocks using the terminal UI. If data looks stale, stop the indexer with `pnpm envio stop` and restart with `pnpm dev` to clear persisted state. If you are using an RPC endpoint, check for rate limiting errors in the logs and consider switching to HyperSync for your network. The [Envio docs](https://docs.envio.dev/docs/HyperIndex/common-issues) cover the most common issues in detail.
+Start by checking whether the indexer has processed all expected blocks using the terminal UI. If data looks stale, stop the indexer with `pnpm envio stop` and restart with `pnpm dev` to clear persisted state. If you are using an RPC endpoint, check for rate-limiting errors in the logs and consider switching to HyperSync for your network. The [Envio docs](https://docs.envio.dev/docs/HyperIndex/common-issues) cover the most common issues in detail.
 
 ### Do I need to manage my own infrastructure to run Envio HyperIndex?
 

--- a/blog/2023-10-04-how-to-become-a-blockchain-dapp-developer.md
+++ b/blog/2023-10-04-how-to-become-a-blockchain-dapp-developer.md
@@ -112,7 +112,7 @@ Get started in under 5 minutes:
 pnpx envio init
 ```
 
-For a deeper look at how blockchain indexers work, see [How Does a Blockchain Indexer Work?](https://docs.envio.dev/blog/what-is-a-blockchain-indexer-for-dapp-development).
+For a deeper look at how blockchain indexers work, see [What is a Blockchain Indexer?](https://docs.envio.dev/blog/what-is-a-blockchain-indexer).
 
 ## Frequently asked questions
 

--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,12 @@
       "source": "/mcp",
       "destination": "/api/mcp"
     }
+  ],
+  "redirects": [
+    {
+      "source": "/blog/tags/:tag*",
+      "destination": "/blog/tag/:tag*",
+      "permanent": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix two stale internal links in older blog posts and add a redirect for an inbound URL pattern that 404s.

## Test plan
- [x] Build passes (`yarn build`)
- [x] Confirmed `/blog/what-is-a-blockchain-indexer/index.html` exists in build output
- [x] Confirmed `/docs/HyperIndex/common-issues/index.html` exists in build output
- [x] Confirmed `/blog/tag/case-studies/index.html` exists in build output
- [x] Verified rendered HTML in built blog posts links to corrected URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hyperlinks in troubleshooting and developer guides to align with new documentation URL structure
  * Refreshed resource references and titles to point to accurately named content

* **Chores**
  * Implemented automatic redirects for blog tag URLs to support the new path structure while maintaining backward compatibility for existing links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->