### PR TITLE
docs: tighten rollback guard sections (review of #802)

### DIFF
--- a/docs/HyperIndex/Advanced/reorgs-support.md
+++ b/docs/HyperIndex/Advanced/reorgs-support.md
@@ -123,14 +123,14 @@ By properly configuring reorg support, you ensure that your indexed data remains
 
 ## Using HyperSync Directly? Handle Reorgs with the Rollback Guard
 
-If you're using [HyperSync](/docs/HyperSync/hypersync-query#rollback-guard) directly (without HyperIndex), you'll need to handle reorg detection and rollback yourself using the **rollback guard** that is returned with every HyperSync query response.
+If you use [HyperSync](/docs/HyperSync/hypersync-query#rollback-guard) directly, without HyperIndex, you have to handle reorg detection and rollback yourself using the **rollback guard** returned on each query response.
 
-HyperSync validates block parent hashes internally and re-syncs when it detects a fork, so it always serves canonical chain data. However, data you've already fetched may become stale after a reorg. The rollback guard provides the block hashes you need to detect this: compare the `first_parent_hash` of your current query response against the `hash` from your previous query response. If they don't match, a reorg has occurred and you should re-fetch the affected data.
+HyperSync validates block parent hashes internally and re-syncs when it detects a fork, so it always serves canonical chain data. Data you have already fetched can still go stale after a reorg, though. To detect that, compare the `first_parent_hash` of the current response against the `hash` you stored from the previous response. If they differ, a reorg has occurred and you need to re-fetch the affected range.
 
-For full details on reorg detection with the rollback guard, including a pseudocode example, see the [HyperSync Rollback Guard documentation](/docs/HyperSync/hypersync-query#rollback-guard).
+For full details, including a pseudocode example, see the [HyperSync Rollback Guard documentation](/docs/HyperSync/hypersync-query#rollback-guard).
 
 :::tip
-HyperIndex automates all of this — it fetches recent block hashes to pinpoint exactly where a reorg occurred and automatically rolls back database state. If you don't need the full flexibility of raw HyperSync, HyperIndex can save you significant implementation effort.
+HyperIndex automates all of this: it fetches recent block hashes to pinpoint exactly where a reorg occurred and automatically rolls back database state. Unless you need the full flexibility of raw HyperSync, HyperIndex saves significant implementation effort.
 :::
 
 ---

--- a/docs/HyperSync-LLM/hypersync-complete.mdx
+++ b/docs/HyperSync-LLM/hypersync-complete.mdx
@@ -1373,7 +1373,7 @@ struct QueryResponse {
 
 ### Rollback Guard
 
-The `rollback_guard` is returned with every query response and is used to detect chain reorganizations (reorgs). When the blockchain forks, previously returned data may become invalid — the rollback guard gives you the information needed to detect this and re-fetch affected data.
+The optional `rollback_guard` lets you detect chain reorganizations (reorgs) between successive queries.
 
 ```rust
 struct RollbackGuard {
@@ -1386,39 +1386,20 @@ struct RollbackGuard {
 
     /// First block scanned in this query
     first_block_number: u64,
-    /// Parent hash of the first block scanned in this query
+    /// Parent hash of the first block scanned
     first_parent_hash: Hash,
 }
 ```
 
-#### How HyperSync Handles Reorgs Internally
+The field is `Option<RollbackGuard>`: present when the response covers blocks near the chain tip, absent when there is no data to guard.
 
-HyperSync continuously ingests the latest block data. As new blocks arrive, HyperSync validates that each block's `parent_hash` matches the hash of the previous block. If a mismatch is detected — indicating a chain fork — HyperSync re-syncs the affected blocks to stay on the canonical chain.
+**How HyperSync handles reorgs internally.** As HyperSync ingests new blocks it checks each block's `parent_hash` against the previous block's `hash`. On a mismatch it re-syncs the affected blocks and continues serving the canonical chain. A single query response is always internally consistent; the rollback guard is for detecting reorgs _between_ successive queries.
 
-This means HyperSync always serves the latest canonical data. However, if you previously queried data that was later affected by a reorg, that data is now stale. The rollback guard lets you detect this situation.
+**Detecting a reorg.** After each query, store the guard's `block_number` and `hash`. On the next query, compare your stored `hash` against the new response's `first_parent_hash`. A match means the chain is intact; a mismatch means a reorg occurred between the two queries.
 
-#### Data Consistency Within a Query
+**Recovering from a reorg.** The guard tells you _that_ a reorg happened but not how deep. Keep enough history to cover your chain's reorg threshold (for example, 200 blocks for Polygon), then walk backwards: re-fetch each stored block's hash and compare. The first block whose hash still matches is the last canonical block. Rewind downstream state to that point and resume querying.
 
-An important guarantee: **within a single query response, the data is always consistent**. You will never receive data where half comes from one fork and half from another. The rollback guard is relevant for detecting reorgs *between* successive queries.
-
-#### Detecting Reorgs with the Rollback Guard
-
-To detect reorgs, store the rollback guard from each query response and compare it against the next:
-
-1. **Store the `hash`** (last block hash) from each query's `rollback_guard`.
-2. **On each subsequent query**, check if the `first_parent_hash` of the new response equals the `hash` from your previous response.
-3. **If they don't match**, a reorg has occurred and some previously received data may be invalid.
-
-#### Handling a Detected Reorg
-
-When a reorg is detected, the rollback guard tells you *that* a reorg happened, but not *which specific block* was reorganized. To handle this:
-
-1. **Store the rollback guard from every recent query** — keep enough history to cover the reorg threshold for your chain (e.g., up to 200 blocks for Polygon).
-2. **Walk backwards through stored rollback guards** to find the first query whose block hash no longer matches the chain.
-3. **Re-query from that point** to get the updated canonical data.
-4. **Roll back any downstream state** derived from the now-invalid data and reprocess.
-
-Consider using HyperIndex instead of building reorg handling yourself — it automatically detects reorg depth and rolls back database state.
+For automatic reorg handling, use [HyperIndex](/docs/HyperIndex/overview) instead: it tracks recent block hashes, locates the reorg point, and rolls back database state for you.
 
 ## Stream and Collect Functions
 

--- a/docs/HyperSync/hypersync-query.md
+++ b/docs/HyperSync/hypersync-query.md
@@ -470,7 +470,7 @@ struct QueryResponse {
 
 ### Rollback Guard
 
-The `rollback_guard` is returned with every query response and is used to detect chain reorganizations (reorgs). When the blockchain forks, previously returned data may become invalid — the rollback guard gives you the information needed to detect this and re-fetch affected data.
+The optional `rollback_guard` lets you detect chain reorganizations (reorgs) between successive queries, so you can re-fetch any data that has become stale.
 
 ```rust
 struct RollbackGuard {
@@ -483,104 +483,74 @@ struct RollbackGuard {
 
     /// First block scanned in this query
     first_block_number: u64,
-    /// Parent hash of the first block scanned in this query
+    /// Parent hash of the first block scanned
     first_parent_hash: Hash,
 }
 ```
 
-#### How HyperSync Handles Reorgs Internally
+The guard is `Option<RollbackGuard>`: it is present whenever the response covers blocks near the chain tip (where reorgs can still happen) and absent for queries that return no data.
 
-HyperSync continuously ingests the latest block data. As new blocks arrive, HyperSync validates that each block's `parent_hash` matches the hash of the previous block. If a mismatch is detected — indicating a chain fork — HyperSync re-syncs the affected blocks to stay on the canonical chain.
+#### How HyperSync handles reorgs internally
 
-This means HyperSync always serves the latest canonical data. However, if you previously queried data that was later affected by a reorg, that data is now stale. The rollback guard lets you detect this situation.
+As HyperSync ingests new blocks it checks each block's `parent_hash` against the previous block's `hash`. When a mismatch is detected, HyperSync re-syncs the affected blocks and continues serving the canonical chain.
 
-#### Data Consistency Within a Query
+A single query response is always internally consistent: you will never receive a mix of blocks from different forks. The rollback guard exists to detect reorgs that happen _between_ successive queries, where data you fetched earlier may now be stale.
 
-An important guarantee: **within a single query response, the data is always consistent**. You will never receive data where half comes from one fork and half from another. The rollback guard is relevant for detecting reorgs *between* successive queries.
+#### Detecting a reorg
 
-#### Detecting Reorgs with the Rollback Guard
+After each query, store the guard's `block_number` and `hash`. On the next query, compare:
 
-To detect reorgs, you need to store the rollback guard from each query response and compare it against the next query's rollback guard. Here's how it works:
+- `previous response.hash` (last block you saw)
+- `next response.first_parent_hash` (parent of the first block in the new batch)
 
-1. **Store the `hash`** (last block hash) from each query's `rollback_guard`.
-2. **On each subsequent query**, check if the `first_parent_hash` of the new response equals the `hash` from your previous response.
-3. **If they don't match**, a reorg has occurred — the chain has reorganized since your last query, and some of the data you previously received may now be invalid.
+If they match, the chain is intact. If they differ, a reorg occurred somewhere between the two queries.
 
 ```
-Query N response:
-  rollback_guard.hash = 0xABC...     ← store this
+Query N:    rollback_guard.hash              = 0xABC...   (stored)
 
-Query N+1 response:
-  rollback_guard.first_parent_hash = 0xABC...  ← matches! No reorg.
-
-                    — OR —
-
-Query N+1 response:
-  rollback_guard.first_parent_hash = 0xDEF...  ← mismatch! Reorg detected.
+Query N+1:  rollback_guard.first_parent_hash = 0xABC...   match    -> no reorg
+                                             = 0xDEF...   mismatch -> reorg
 ```
 
-#### Handling a Detected Reorg
+#### Recovering from a reorg
 
-When a reorg is detected, the rollback guard tells you *that* a reorg happened, but not *which specific block* was reorganized (because the hashes of all subsequent blocks change after a reorg). To handle this:
-
-1. **Store the rollback guard from every recent query** — keep at least enough history to cover the reorg threshold for your chain (e.g., up to 200 blocks for Polygon).
-2. **Walk backwards through your stored rollback guards** to find the first query whose block hash no longer matches the chain. This tells you how far back the reorg goes.
-3. **Re-query from that point** to get the updated canonical data.
-4. **Roll back any downstream state** (database writes, computed state, etc.) that was derived from the now-invalid data, and reprocess with the fresh data.
-
-Here's a simplified example in pseudocode:
+The guard tells you _that_ a reorg happened but not how deep. To find the depth, keep enough history to cover your chain's reorg threshold (for example, 200 blocks for Polygon) and walk backwards: re-fetch each stored block's hash and compare. The first block whose hash still matches is the last canonical block; rewind your downstream state to there and resume querying.
 
 ```python
-# Store rollback guards from recent queries
-rollback_history = []  # list of (block_number, hash) tuples
+history = []  # list of (block_number, hash)
 
 while True:
-    response = hypersync_client.get(query)
+    res = client.get(query)
+    guard = res.rollback_guard
+    if guard is None:
+        process(res.data)
+        query.from_block = res.next_block
+        continue
 
-    if rollback_history:
-        last_hash = rollback_history[-1][1]
-        if response.rollback_guard.first_parent_hash != last_hash:
-            # Reorg detected! Find how far back it goes.
-            reorg_start = None
-            for i in range(len(rollback_history) - 1, -1, -1):
-                stored_block, stored_hash = rollback_history[i]
-                # Re-fetch this block's hash from the chain to verify
-                chain_hash = get_block_hash_from_hypersync(stored_block)
-                if chain_hash == stored_hash:
-                    # This block is still valid, reorg starts after this
-                    reorg_start = stored_block + 1
-                    break
+    if history and guard.first_parent_hash != history[-1][1]:
+        # Walk back to find the last block still on chain.
+        while history:
+            block_num, stored_hash = history[-1]
+            if client.get_block_hash(block_num) == stored_hash:
+                break
+            history.pop()
 
-            if reorg_start:
-                # Roll back your state to reorg_start
-                rollback_state_to(reorg_start)
-                # Trim history and re-query from reorg_start
-                rollback_history = [
-                    (bn, h) for bn, h in rollback_history if bn < reorg_start
-                ]
-                query.from_block = reorg_start
-                continue
+        rewind_to = history[-1][0] + 1 if history else query.from_block
+        rollback_state_to(rewind_to)
+        query.from_block = rewind_to
+        continue
 
-    # No reorg — process data normally
-    process_data(response.data)
+    process(res.data)
+    history.append((guard.block_number, guard.hash))
 
-    # Store this query's rollback guard
-    rollback_history.append((
-        response.rollback_guard.block_number,
-        response.rollback_guard.hash
-    ))
+    cutoff = guard.block_number - REORG_THRESHOLD
+    history = [(b, h) for b, h in history if b >= cutoff]
 
-    # Trim old history beyond reorg threshold
-    min_block = response.rollback_guard.block_number - REORG_THRESHOLD
-    rollback_history = [
-        (bn, h) for bn, h in rollback_history if bn >= min_block
-    ]
-
-    query.from_block = response.next_block
+    query.from_block = res.next_block
 ```
 
 :::tip Consider HyperIndex
-If you need automatic reorg handling, consider using [HyperIndex](/docs/HyperIndex/overview) instead of building this yourself. HyperIndex fetches an array of recent block hashes and numbers to pinpoint exactly where a reorg occurred, then automatically rolls back database state to the correct point. This saves significant implementation effort. HyperSync gives you full flexibility to handle reorgs however you want, but HyperIndex handles this complexity for you out of the box.
+[HyperIndex](/docs/HyperIndex/overview) handles all of this for you: it tracks recent block hashes, locates the reorg point, and rolls back database state automatically. See [Reorgs Support](/docs/HyperIndex/Advanced/reorgs-support) for details.
 :::
 
 ## Stream and Collect Functions


### PR DESCRIPTION
Cleanup pass on top of #802. Targets the same draft branch so the suggestions can be merged in (or cherry-picked) before opening for review.

## Summary

- Restores `optional` on `rollback_guard` and clarifies when the field is `None`. The underlying type is `Option<RollbackGuard>` (verified in `hypersync-net-types-0.12.3/src/response.rs:16` and the producer in `skar/src/state/in_memory.rs:132`, which returns `None` when the in-memory state is empty). The previous wording (\"returned with every query response\") was technically incorrect.
- Collapses the four `####` subsections in `hypersync-complete.mdx` into bold inline headers so the LLM doc reads as a quick reference rather than a tutorial.
- Trims the Python pseudocode in `hypersync-query.md`: removes the duplicate trim/append paths, factors out the unwrap of `rollback_guard`, and adds a `guard is None` branch so the example matches the type.
- Drops em dashes throughout the new content (per repo style); replaces with colons, parentheses, or split sentences.
- Tightens the HyperIndex reorgs-support addition (same conceptual content, fewer words).

## Why a separate PR

#802 is a draft, but it already has the substantive content and a session link in the description. Stacking the cleanup as its own PR keeps the diff reviewable line-by-line without forcing a force-push on the draft branch. Once the cleanup looks right, merge this into `claude/add-rollback-guard-9KGmu` and re-open #802 for review.

## Test plan

- [ ] Visual check of the rendered Rollback Guard section in `docs/HyperSync/hypersync-query.md`
- [ ] Visual check of the Rollback Guard section in `docs/HyperSync-LLM/hypersync-complete.mdx`
- [ ] Confirm cross-links from `docs/HyperIndex/Advanced/reorgs-support.md` still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)