### PR TITLE
docs: fix broken /docs/reorgs-support link

### DIFF
--- a/docs/HyperSync/hypersync-query.md
+++ b/docs/HyperSync/hypersync-query.md
@@ -550,7 +550,7 @@ while True:
 ```
 
 :::tip Consider HyperIndex
-[HyperIndex](/docs/HyperIndex/overview) handles all of this for you: it tracks recent block hashes, locates the reorg point, and rolls back database state automatically. See [Reorgs Support](/docs/HyperIndex/Advanced/reorgs-support) for details.
+[HyperIndex](/docs/HyperIndex/overview) handles all of this for you: it tracks recent block hashes, locates the reorg point, and rolls back database state automatically. See [Reorgs Support](/docs/reorgs-support) for details.
 :::
 
 ## Stream and Collect Functions

--- a/docs/HyperSync/hypersync-query.md
+++ b/docs/HyperSync/hypersync-query.md
@@ -550,7 +550,7 @@ while True:
 ```
 
 :::tip Consider HyperIndex
-[HyperIndex](/docs/HyperIndex/overview) handles all of this for you: it tracks recent block hashes, locates the reorg point, and rolls back database state automatically. See [Reorgs Support](/docs/reorgs-support) for details.
+[HyperIndex](/docs/HyperIndex/overview) handles all of this for you: it tracks recent block hashes, locates the reorg point, and rolls back database state automatically. See [Reorgs Support](/docs/HyperIndex/reorgs-support) for details.
 :::
 
 ## Stream and Collect Functions


### PR DESCRIPTION
Fixes the Vercel build failure on #802 after #891 merged.

## What broke

The Docusaurus broken-link check failed:

\`\`\`
- Broken link on source page path = /docs/HyperSync/hypersync-query:
   -> linking to /docs/HyperIndex/Advanced/reorgs-support
\`\`\`

## Why

In #891 I added a link from the HyperSync rollback guard \`:::tip\` block to the HyperIndex reorgs-support page using its filesystem path. But \`docs/HyperIndex/Advanced/reorgs-support.md\` declares \`slug: /reorgs-support\` in its frontmatter, so the canonical URL is \`/docs/reorgs-support\`. Path-based routing does not apply when a slug is set.

## Fix

One-line change: \`/docs/HyperIndex/Advanced/reorgs-support\` -> \`/docs/reorgs-support\`.

## Test plan

- [ ] Vercel preview build for #802 turns green
- [ ] Click the \"Reorgs Support\" link in the rollback guard tip on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)