### PR TITLE
showcase: harden renderWithCode against missing description

### DIFF
--- a/src/pages/showcase/_detail.js
+++ b/src/pages/showcase/_detail.js
@@ -2,8 +2,8 @@ import Link from "@docusaurus/Link";
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
 
-function renderWithCode(text) {
-  const parts = text.split(/(`[^`]+`)/g);
+function renderWithCode(text = "") {
+  const parts = String(text).split(/(`[^`]+`)/g);
   return parts.map((part, i) => {
     if (part.startsWith("`") && part.endsWith("`")) {
       return <code key={i}>{part.slice(1, -1)}</code>;
@@ -117,7 +117,7 @@ export default function ShowcaseDetail({ site }) {
 
         <div style={{ lineHeight: 1.8, color: "var(--ifm-color-emphasis-700)" }}>
           <p style={{ fontSize: "1rem" }}>
-            {renderWithCode(site.longDescription || site.description)}
+            {renderWithCode(site.longDescription || site.description || "")}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Coerce `renderWithCode` input to a string with a default of `""`
- Default the call site so showcase entries with neither `longDescription` nor `description` don't throw

Follow-up to [#893](https://github.com/enviodev/docs/pull/893), addressing the CodeRabbit comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of showcase item rendering to gracefully handle cases where description data may be missing or undefined, preventing potential rendering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->