### PR TITLE
Remove alpha warning from HyperIndex V3 migration docs

### DIFF
--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -66,15 +66,15 @@ HyperSync (the data engine powering HyperIndex) implements rate limits for reque
 - **Local Development**: An API token will be required. An automatic login feature from the CLI will be available to make this smoother.
 - **Self-Hosted Deployments**: API tokens are required for HyperSync access in self-hosted deployments. The token can be set via the `ENVIO_API_TOKEN` environment variable in your indexer configuration. This can be read from the `.env` file in the root of your HyperIndex project.
 - **Envio Cloud**: Indexers deployed to Envio Cloud will have special access that doesn't require a custom API token.
-- **Future Pricing**: From mid-November 2025 onwards, we will introduce tiered packages for those self-hosting HyperIndex and wishing to use HyperSync. For preferred introductory pricing based on your specific use case, reach out to us on Discord.
+- **Future Pricing**: From mid-November 2025 onwards, we will introduce tiered packages for those self-hosting HyperIndex and wishing to use HyperSync. For preferred introductory pricing based on your specific use case, reach out to us on [Discord](https://discord.gg/envio).
 
 For more details about API tokens, including how to generate and implement them, see our API Tokens documentation.
 
 
 ## 🔗 Quick Links
 
-- GitHub Repository ⭐
-- Join our Discord Community
+- [GitHub Repository](https://github.com/enviodev/hyperindex) ⭐
+- [Join our Discord Community](https://discord.gg/envio)
 
 ---
 
@@ -88,15 +88,15 @@ Learn how to create and run a blockchain indexer with Envio’s HyperIndex, from
 
 ### Prerequisites
 
-- **Node.js** _(v22 or newer recommended)_
-- **pnpm** _(v8 or newer)_
-- **Docker Desktop** _(required to run the Envio indexer locally)_
+- **[Node.js](https://nodejs.org/en/download/current)** _(v22 or newer recommended)_
+- **[pnpm](https://pnpm.io/installation)** _(v8 or newer)_
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** _(required to run the Envio indexer locally)_
 
 > **Note:** Docker is required only if you plan to run your indexer locally. You can skip installing Docker if you'll only be using Envio Cloud.
 
 #### Additionally for Windows Users:
 
-- **WSL** _Windows Subsystem for Linux_
+- **[WSL](https://learn.microsoft.com/en-us/windows/wsl/install)** _Windows Subsystem for Linux_
 
 
 ## Essential Files
@@ -122,7 +122,7 @@ For a complete walkthrough of the process, refer to the Quickstart guide.
 
 Build an Envio HyperIndex indexer end-to-end with an AI coding assistant.
 
-Most developers now reach for an AI coding assistant before they open a file. This guide walks through an AI-centric flow for creating, developing, and deploying a HyperIndex indexer. It is semi-generic, so any capable AI coding assistant (Cursor, Windsurf, Copilot Agent, Continue, etc.) will work. That said, **we've seen the best results with Claude Code** and recommend starting there.
+Most developers now reach for an AI coding assistant before they open a file. This guide walks through an AI-centric flow for creating, developing, and deploying a HyperIndex indexer. It is semi-generic, so any capable AI coding assistant (Cursor, Windsurf, Copilot Agent, Continue, etc.) will work. That said, **we've seen the best results with [Claude Code](https://claude.com/claude-code)** and recommend starting there.
 
 :::tip Prefer the interactive flow?
 If you'd rather drive the CLI yourself, see Getting Started and the Quickstart.
@@ -195,7 +195,7 @@ Every command supports `-o json`, which makes it easy for assistants and scripts
 
 The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex.
 
-**Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio init` and providing the contract address from Etherscan.
+**Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
 
 
 ### Video Tutorials
@@ -313,7 +313,7 @@ HyperIndex delivers industry-leading performance for blockchain data indexing. I
 
 ## Recent Independent Benchmarks
 
-The most comprehensive and up-to-date benchmarks were conducted by Sentio in April 2025 and are available in the sentio-benchmark repository. These benchmarks compare Envio's HyperIndex against other popular blockchain indexers across multiple real-world scenarios:
+The most comprehensive and up-to-date benchmarks were conducted by Sentio in April 2025 and are available in the [sentio-benchmark repository](https://github.com/enviodev/sentio-benchmark). These benchmarks compare Envio's HyperIndex against other popular blockchain indexers across multiple real-world scenarios:
 
 ### Key Performance Highlights
 
@@ -339,7 +339,7 @@ You can read the full details in our Indexer Benchmarking Results blog post.
 
 ## Verify For Yourself
 
-We encourage developers to run their own benchmarks. You can also use the templates provided in the Open Indexer Benchmark repository.
+We encourage developers to run their own benchmarks. You can also use the templates provided in the [Open Indexer Benchmark repository](https://github.com/enviodev/open-indexer-benchmark).
 
 ---
 
@@ -372,7 +372,7 @@ The Claude skills are only available in HyperIndex v3. If the latest stable vers
 pnpx envio@3.0.0-alpha.21 init
 ```
 
-Replace `3.0.0-alpha.21` with the latest available v3 version. You can find the latest releases here.
+Replace `3.0.0-alpha.21` with the latest available v3 version. You can find the latest releases [here](https://github.com/enviodev/hyperindex/releases).
 :::
 
 ## Step 2: Set Up a Monorepo Structure
@@ -432,7 +432,7 @@ Phase 3 — Verify
 
 :::tip
 - After migration, run `pnpm dev` to verify the indexer runs correctly
-- Use the Indexer Migration Validator to compare outputs between your subgraph and the new HyperIndex indexer
+- Use the [Indexer Migration Validator](https://github.com/enviodev/indexer-migration-validator) to compare outputs between your subgraph and the new HyperIndex indexer
 :::
 
 ## Manual Migration
@@ -446,7 +446,7 @@ For a detailed manual migration guide covering the step by step conversion of su
 **File:** `migration-guide.md`
 
 :::info
-Please reach out to our team on Discord for personalized migration assistance.
+Please reach out to our team on [Discord](https://discord.gg/envio) for personalized migration assistance.
 :::
 
 ## Introduction
@@ -633,7 +633,7 @@ context.Subscription.set(entity);
 
 HyperIndex is a powerful tool that can be used to index any contract. There are some features that are especially powerful that go above subgraph implementations and so in some cases you may want to optimise your migration to HyperIndex further to take advantage of these features. Here are some useful tips:
 
-- Use `field_selection` to opt into optional transaction and block fields (e.g. `hash`, `status`, `gasUsed`) that are not included by default, see Transaction receipts for a migration-focused example and the field selection docs for the full list.
+- Use `field_selection` to opt into optional transaction and block fields (e.g. `hash`, `status`, `gasUsed`) that are not included by default, see [Transaction receipts](#transaction-receipts) for a migration-focused example and the field selection docs for the full list.
 - Use the `unordered_multichain_mode` option to enable unordered multichain mode, this is the most common need for multichain indexing. However comes with tradeoffs worth understanding. Doc here: unordered multichain mode
 - Use wildcard indexing to index by event signatures rather than by contract address.
 - HyperIndex uses the standard GraphQL query language, whereas TheGraph uses a custom GraphQL syntax. You can read about the differences and how to convert queries in our Query Conversion Guide. We also provide a query converter tool for backwards compatibility with existing TheGraph queries.
@@ -677,15 +677,15 @@ See the full list of available `transaction_fields` in the Configuration File do
 
 ## Validating Your Migration
 
-After completing your migration, it's important to verify that your HyperIndex indexer produces the same data as your original subgraph. Use the Indexer Migration Validator CLI tool to compare results between both endpoints and identify any discrepancies. The tool automatically generates entity configs from your GraphQL schema and provides detailed field-level analysis of differences.
+After completing your migration, it's important to verify that your HyperIndex indexer produces the same data as your original subgraph. Use the [Indexer Migration Validator](https://github.com/enviodev/indexer-migration-validator) CLI tool to compare results between both endpoints and identify any discrepancies. The tool automatically generates entity configs from your GraphQL schema and provides detailed field-level analysis of differences.
 
 ## Share Your Learnings
 
-If you discover helpful tips during your migration, we'd love contributions! Open a PR to this guide and help future developers.
+If you discover helpful tips during your migration, we'd love contributions! Open a [PR](https://github.com/enviodev/docs) to this guide and help future developers.
 
 ## Getting Help
 
-**Join Our Discord**: The fastest way to get personalized help is through our Discord community.
+**Join Our Discord**: The fastest way to get personalized help is through our [Discord community](https://discord.gg/envio).
 
 ---
 
@@ -693,7 +693,7 @@ If you discover helpful tips during your migration, we'd love contributions! Ope
 
 **File:** `migrate-from-ponder.md`
 
-> **Need help?** Reach out on Discord for personalized migration assistance.
+> **Need help?** Reach out on [Discord](https://discord.gg/envio) for personalized migration assistance.
 
 Migrating from Ponder to HyperIndex is straightforward — both frameworks use TypeScript, index EVM events, and expose a GraphQL API. The key differences are the config format, schema syntax, and entity operation API.
 
@@ -821,12 +821,12 @@ See the full list of available fields in the Configuration File docs.
 :::note
 Note: Alchemy subgraphs sunset on Dec 8th, 2025. Envio is offering affected Alchemy users 2 months of free hosting on Envio, along with full white-glove migration support to help projects move over smoothly.
 
-For more info on how you can start your free trial or book migration support, visit this page to learn more.
+For more info on how you can start your free trial or book migration support, visit this [page](https://envio.dev/alchemy-migration) to learn more.
 :::
 
 Migrating Alchemy subgraphs to Envio’s HyperIndex is a simple and developer-friendly process. Alchemy subgraphs follow The Graph’s model and HyperIndex uses a very similar structure, so most of your existing setup can carry over cleanly.
 
-If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our Getting Started guide before you begin your migration from Alchemy.
+If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our [Getting Started](https://docs.envio.dev/docs/HyperIndex/getting-started) guide before you begin your migration from Alchemy.
 
 ## Why Migrate to Envio’s HyperIndex?
 - **High Speed Performance**: 143x faster than subgraphs
@@ -923,7 +923,7 @@ networks:
 
 
 
-If you hit any issues, check the Configuration File docs or reach out to our team in Discord.
+If you hit any issues, check the [Configuration File](https://docs.envio.dev/docs/HyperIndex/configuration-file) docs or reach out to our team in [Discord](https://discord.gg/envio).
 
 ### schema.graphql Migration
 
@@ -990,15 +990,15 @@ Here is a code snippet to give you a sense of what these changes look like in pr
     
 
 
-For a few extra tips on migrating from Alchemy to Envio, check out our other migration guide in our docs.
+For a few extra tips on migrating from Alchemy to Envio, check out our other [migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide#extra-tips) in our docs.
 
 ## Share Your Learnings
 
-If you come across anything useful during your migration, please feel free to contribute. Simply open a PR to this guide and help future developers.
+If you come across anything useful during your migration, please feel free to contribute. Simply open a [PR](https://github.com/enviodev/docs/pulls) to this guide and help future developers.
 
 ## Getting Help
 
-Join our Discord if you need support. It is the fastest way to get direct help from the team and the community.
+Join our [Discord](https://discord.gg/envio) if you need support. It is the fastest way to get direct help from the team and the community.
 
 ---
 
@@ -1006,7 +1006,7 @@ Join our Discord if you need support. It is the fastest way to get direct help f
 
 **File:** `migrate-to-v3.md`
 
-15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped 32 minor releases and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.
+15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped [32 minor releases](https://github.com/enviodev/hyperindex/releases) and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.
 
 HyperIndex V3 focuses on modernizing the codebase and laying the foundation for many more months of development. This guide walks you through upgrading from V2 to V3.
 
@@ -1178,7 +1178,7 @@ The explicit `handler` field in `config.yaml` still works, so you don't need to 
 
 ### RPC for Realtime Indexing
 
-Built by an external contributor @cairoeth to allow specifying `realtime` mode for an RPC data source to embrace low-latency head tracking:
+Built by an external contributor [@cairoeth](https://github.com/cairoeth) to allow specifying `realtime` mode for an RPC data source to embrace low-latency head tracking:
 
 ```yaml
 rpc:
@@ -1375,7 +1375,7 @@ The TUI is now auto-disabled in CI environments and when running under AI agents
 
 HyperIndex ships a purpose-built testing framework powered by `createTestIndexer()`. Write tests against the same indexer that runs in production — no database, no Docker, no manual mock wiring.
 
-The framework integrates with Vitest, replacing the previous mocha/chai setup with a single package that doesn't require configuration by default and includes snapshot testing out-of-the-box. It also provides typed test assertions and utilities to read/write entities in-between processing runs.
+The framework integrates with [Vitest](https://vitest.dev/), replacing the previous mocha/chai setup with a single package that doesn't require configuration by default and includes snapshot testing out-of-the-box. It also provides typed test assertions and utilities to read/write entities in-between processing runs.
 
 #### Three ways to feed events
 
@@ -1474,7 +1474,7 @@ See the Testing documentation for more details.
 
 ### Podman Support
 
-Beyond Docker, HyperIndex now supports Podman for local development environments. This provides an alternative container runtime for developers who prefer Podman or have it available in their environment.
+Beyond Docker, HyperIndex now supports [Podman](https://podman.io/) for local development environments. This provides an alternative container runtime for developers who prefer Podman or have it available in their environment.
 
 ### Nested Tuples for Contract Import
 
@@ -1734,12 +1734,12 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 - Removed `preload_handlers` option (now always enabled)
 - Removed `preRegisterDynamicContracts` option
 - Removed `event_decoder` option (the Rust-based decoder is now the only implementation)
-- Removed `rpc_config` in favor of `rpc`, which now supports multiple URLs, `for` mode (`sync`, `realtime`, `fallback`), and WebSocket configuration (see RPC for Realtime Indexing)
+- Removed `rpc_config` in favor of `rpc`, which now supports multiple URLs, `for` mode (`sync`, `realtime`, `fallback`), and WebSocket configuration (see [RPC for Realtime Indexing](#rpc-for-realtime-indexing))
 - Removed the `output` flag — generated types are always emitted to `.envio/` at the project root
 
 ### HyperSync API Token Required
 
-Indexers using HyperSync as a data source now require an `ENVIO_API_TOKEN` environment variable. You can obtain a free API token at envio.dev/app/api-tokens.
+Indexers using HyperSync as a data source now require an `ENVIO_API_TOKEN` environment variable. You can obtain a free API token at [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens).
 
 ```bash
 export ENVIO_API_TOKEN=your_token_here
@@ -1921,7 +1921,7 @@ Re-run `envio codegen` after upgrading; everything you previously imported from 
 
 **If you use testing with Mocha (recommended: migrate to Vitest):**
 
-We recommend migrating from mocha/chai to Vitest, which offers a better testing experience with the new HyperIndex testing framework:
+We recommend migrating from mocha/chai to [Vitest](https://vitest.dev/), which offers a better testing experience with the new HyperIndex testing framework:
 
 ```bash
 pnpm remove ts-mocha ts-node mocha chai @types/mocha @types/chai
@@ -2067,7 +2067,7 @@ Remove the following options from your config if present:
 - `preRegisterDynamicContracts` — no longer needed
 - `unordered_multichain_mode` — replaced with `multichain` option
 - `event_decoder` — the Rust-based decoder is now the only implementation
-- `rpc_config` — replaced with `rpc` (see Breaking Changes)
+- `rpc_config` — replaced with `rpc` (see [Breaking Changes](#configyaml-changes))
 
 **New option for batch size:**
 
@@ -2087,7 +2087,7 @@ Optionally move your handler files to `src/handlers/` and remove the explicit `h
 
 If your indexer uses HyperSync (the default data source), you need to set up an API token:
 
-1. Get a free API token at envio.dev/app/api-tokens
+1. Get a free API token at [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens)
 2. Set the environment variable:
 
 ```bash
@@ -2185,7 +2185,7 @@ indexer.onBlock(
 );
 ```
 
-For chain-specific handlers or interval/range filters, use the `where` callback (see Unified Handlers API).
+For chain-specific handlers or interval/range filters, use the `where` callback (see [Unified Handlers API](#unified-handlers-api)).
 
 **Rename deprecated APIs:**
 
@@ -2207,7 +2207,7 @@ For chain-specific handlers or interval/range filters, use the `where` callback 
 
 **Removed APIs:**
 
-- `getGeneratedByChainId` — use the `indexer.chains[chainId]` instead (see Indexer State & Config)
+- `getGeneratedByChainId` — use the `indexer.chains[chainId]` instead (see [Indexer State & Config](#indexer-state--config))
 - **`getWhere` API** — update to the new GraphQL-style filter syntax:
 
 ```typescript
@@ -2276,7 +2276,7 @@ pnpm dev
 
 **Environment Variables:**
 
-- [ ] **Set `ENVIO_API_TOKEN`** if using HyperSync (get token)
+- [ ] **Set `ENVIO_API_TOKEN`** if using HyperSync ([get token](https://envio.dev/app/api-tokens))
 - [ ] Remove `UNSTABLE__TEMP_UNORDERED_HEAD_MODE`
 - [ ] Remove `UNORDERED_MULTICHAIN_MODE`
 - [ ] Remove `MAX_BATCH_SIZE` (use `full_batch_size` in config.yaml)
@@ -2300,7 +2300,7 @@ pnpm dev
 - [ ] Replace lowercased entity type imports with capitalized versions (e.g., `transfer` → `Transfer`)
 - [ ] Update `getWhere` calls to new GraphQL-style filter syntax (e.g., `getWhere({ field: { _eq: value } })`)
 - [ ] Update any `S.nullable` schema usage — now returns `null` instead of `undefined`
-- [ ] Migrate from `MockDb` to `createTestIndexer()` (see MockDb Migration Cheat Sheet)
+- [ ] Migrate from `MockDb` to `createTestIndexer()` (see [MockDb Migration Cheat Sheet](#mockdb-migration-cheat-sheet))
 - [ ] Replace contract-specific type exports (`ERC20_Transfer_eventLog`) with generic types (`EvmEvent`)
 
 **CLI:**
@@ -2314,38 +2314,38 @@ pnpm dev
 
 ## Getting Help
 
-If you encounter any issues during migration, join our Discord community for support.
+If you encounter any issues during migration, join our [Discord community](https://discord.gg/envio) for support.
 
 ## Release Notes
 
 For detailed release notes, see:
 
-- v3.0.0-rc.0
-- v3.0.0-alpha.24
-- v3.0.0-alpha.23
-- v3.0.0-alpha.22
-- v3.0.0-alpha.21
-- v3.0.0-alpha.20
-- v3.0.0-alpha.19
-- v3.0.0-alpha.18
-- v3.0.0-alpha.17
-- v3.0.0-alpha.16
-- v3.0.0-alpha.15
-- v3.0.0-alpha.14
-- v3.0.0-alpha.13
-- v3.0.0-alpha.12
-- v3.0.0-alpha.11
-- v3.0.0-alpha.10
-- v3.0.0-alpha.9
-- v3.0.0-alpha.8
-- v3.0.0-alpha.7
-- v3.0.0-alpha.6
-- v3.0.0-alpha.5
-- v3.0.0-alpha.4
-- v3.0.0-alpha.3
-- v3.0.0-alpha.2
-- v3.0.0-alpha.1
-- v3.0.0-alpha.0
+- [v3.0.0-rc.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.0)
+- [v3.0.0-alpha.24](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.24)
+- [v3.0.0-alpha.23](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.23)
+- [v3.0.0-alpha.22](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.22)
+- [v3.0.0-alpha.21](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.21)
+- [v3.0.0-alpha.20](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.20)
+- [v3.0.0-alpha.19](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.19)
+- [v3.0.0-alpha.18](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.18)
+- [v3.0.0-alpha.17](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.17)
+- [v3.0.0-alpha.16](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.16)
+- [v3.0.0-alpha.15](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.15)
+- [v3.0.0-alpha.14](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.14)
+- [v3.0.0-alpha.13](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.13)
+- [v3.0.0-alpha.12](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.12)
+- [v3.0.0-alpha.11](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.11)
+- [v3.0.0-alpha.10](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.10)
+- [v3.0.0-alpha.9](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.9)
+- [v3.0.0-alpha.8](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.8)
+- [v3.0.0-alpha.7](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.7)
+- [v3.0.0-alpha.6](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.6)
+- [v3.0.0-alpha.5](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.5)
+- [v3.0.0-alpha.4](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.4)
+- [v3.0.0-alpha.3](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.3)
+- [v3.0.0-alpha.2](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.2)
+- [v3.0.0-alpha.1](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.1)
+- [v3.0.0-alpha.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.0)
 
 ---
 
@@ -2605,7 +2605,7 @@ Scalar types represent basic data types and map directly to JavaScript, TypeScri
 | `Timestamp`        | Timestamp with timezone                      | `Date`                    | `Js.Date.t`    |
 | `Json`             | JSON object (from envio@2.20)                | `Json`                    | `Js.Json.t`    |
 
-Learn more about GraphQL scalars here.
+Learn more about GraphQL scalars [here](https://graphql.org/learn/).
 
 
 ## Enum Types
@@ -3174,7 +3174,7 @@ To implement multichain indexing, you need to:
 For a comprehensive, production-ready example of multichain indexing, we recommend exploring our Uniswap V4 Multichain Indexer. This official reference implementation:
 
 - Indexes Uniswap V4 deployments across 10 different blockchain networks
-- Powers the official v4.xyz interface with real-time data
+- Powers the official [v4.xyz](https://v4.xyz) interface with real-time data
 - Demonstrates best practices for high-performance multichain indexing
 - Provides a complete, production-grade implementation you can study and adapt
 
@@ -3405,7 +3405,7 @@ This flow allows you to verify that your event handlers correctly create, update
 
 ## Assertions
 
-The testing library works with any JavaScript assertion library. In the examples, we use Node.js's built-in assert module, but you can also use popular alternatives like chai or expect.
+The testing library works with any JavaScript assertion library. In the examples, we use Node.js's built-in assert module, but you can also use popular alternatives like [chai](https://www.chaijs.com/) or [expect](https://github.com/Automattic/expect.js).
 
 Common assertion patterns include:
 
@@ -3489,7 +3489,7 @@ open Belt
   );
   ```
 
-If you encounter any issues or have questions, please reach out to us on Discord
+If you encounter any issues or have questions, please reach out to us on [Discord](https://discord.gg/envio)
 
 ---
 
@@ -3501,7 +3501,7 @@ If you encounter any issues or have questions, please reach out to us on Discord
 
 ## Introduction
 
-Hasura is a GraphQL engine that provides a web interface for interacting with your indexed blockchain data. When running HyperIndex locally, Hasura serves as your primary tool for:
+[Hasura](https://hasura.io/) is a GraphQL engine that provides a web interface for interacting with your indexed blockchain data. When running HyperIndex locally, Hasura serves as your primary tool for:
 
 - Querying indexed data via GraphQL
 - Visualizing database tables and relationships
@@ -3564,7 +3564,7 @@ query MyQuery {
 
 Click the "Play" button to execute the query and see the results.
 
-For more advanced GraphQL query options, see Hasura's quickstart guide.
+For more advanced GraphQL query options, see Hasura's [quickstart guide](https://hasura.io/docs/latest/queries/quickstart/).
 
 ### Data Tab
 
@@ -3684,7 +3684,7 @@ This pattern scales: you can keep per-entity counters, rolling windows (daily/ho
 
 #### Exceptional cases
 
-If runtime aggregate queries are a hard requirement for your use case, please reach out and we can evaluate options for your project on Envio Cloud. Contact us on Discord.
+If runtime aggregate queries are a hard requirement for your use case, please reach out and we can evaluate options for your project on Envio Cloud. Contact us on [Discord](https://discord.gg/envio).
 
 ## Disable Hasura for Self-Hosted Blockchain Indexers
 
@@ -3858,7 +3858,7 @@ Point any MCP-compatible client to the endpoint URL above using the **Streamable
 
 The following blockchain indexer example is a reference implementation and can serve as a starting point for applications with similar logic.
 
-This official Uniswap V4 indexer is a comprehensive implementation for the Uniswap V4 protocol using Envio HyperIndex. This is the same indexer that powers the v4.xyz website, providing real-time data for the Uniswap V4 interface.
+This [official Uniswap V4 indexer](https://github.com/enviodev/uniswap-v4-indexer) is a comprehensive implementation for the Uniswap V4 protocol using Envio HyperIndex. This is the same indexer that powers the [v4.xyz](https://v4.xyz) website, providing real-time data for the Uniswap V4 interface.
 
 ## Key Features
 
@@ -3894,14 +3894,14 @@ The Envio-powered Uniswap V4 indexer offers extraordinary performance benefits:
 
 To use this indexer, you can:
 
-1. Clone the repository
+1. Clone the [repository](https://github.com/enviodev/uniswap-v4-indexer)
 2. Follow the installation instructions in the README
 3. Run the indexer locally or deploy it to a production environment
 4. Access indexed data through the GraphQL API
 
 ## Contribution
 
-The Uniswap V4 indexer is actively maintained and welcomes contributions from the community. If you'd like to contribute or report issues, please visit the GitHub repository.
+The Uniswap V4 indexer is actively maintained and welcomes contributions from the community. If you'd like to contribute or report issues, please visit the [GitHub repository](https://github.com/enviodev/uniswap-v4-indexer).
 
 :::note
 This is an official reference implementation that powers the v4.xyz website. While extensively tested in production, remember to validate the data for your specific use case. The indexer is continuously updated to support the latest Uniswap V4 features and optimizations.
@@ -3917,21 +3917,21 @@ The following blockchain indexers serve as exceptional reference implementations
 
 ## Overview
 
-Sablier is a token streaming protocol that enables real-time finance on the blockchain, allowing tokens to be streamed continuously over time. These official Sablier indexers track streaming activity across 18 different EVM-compatible chains, providing comprehensive data through a unified GraphQL API.
+[Sablier](https://sablier.com/) is a token streaming protocol that enables real-time finance on the blockchain, allowing tokens to be streamed continuously over time. These official Sablier indexers track streaming activity across 18 different EVM-compatible chains, providing comprehensive data through a unified GraphQL API.
 
 ## Professional Indexer Suite
 
 Sablier maintains three specialized indexers, each targeting a specific part of their protocol:
 
-### 1. Lockup Indexer
+### 1. [Lockup Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/lockup)
 
 Tracks the core Sablier lockup contracts, which handle the streaming of tokens with fixed durations and amounts. This indexer provides data about stream creation, cancellation, and withdrawal events. Used primarily for the vesting functionality of Sablier.
 
-### 2. Flow Indexer
+### 2. [Flow Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/flow)
 
 Monitors Sablier's advanced streaming functionality, allowing for dynamic flow rates and more complex streaming scenarios. This indexer captures stream modifications, batch operations, and other flow-specific events. Powers the payments side of the Sablier application.
 
-### 3. Airdrops Indexer
+### 3. [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
 
 Tracks Sablier's Merkle Airdrops, which enables efficient batch stream creation using cryptographic proofs. This indexer captures data about batch creations, claims, and related activities. Used for both Airstreams and Instant Airdrops functionality.
 
@@ -3962,17 +3962,17 @@ These blockchain indexers demonstrate several development best practices:
 To use these indexers as a reference for your own development:
 
 1. Clone the specific repository based on your needs:
-   - Lockup Indexer
-   - Flow Indexer
-   - Merkle Indexer
+   - [Lockup Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/lockup-envio)
+   - [Flow Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/flow-envio)
+   - [Merkle Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/merkle-envio)
 2. Review the file structure and implementation patterns
 3. Examine the event handlers for efficient data processing techniques
 4. Study the schema design for effective entity modeling
 
 For complete API documentation and usage examples, see:
 
-- Sablier API Overview
-- Implementation Caveats
+- [Sablier API Overview](https://docs.sablier.com/api/overview#envio)
+- [Implementation Caveats](https://docs.sablier.com/api/caveats)
 
 :::note
 These are official indexers maintained by the Sablier team and represent production-quality implementations. They serve as an excellent example of professional blockchain indexer development and are regularly updated to support the latest protocol features.
@@ -3995,7 +3995,7 @@ Envio provides flexibility in how you deploy and host your indexers:
 
 - **Envio Cloud (Fully Managed)**: Let Envio handle everything. The following sections of this page outline Envio Cloud in more detail. This is the recommended deployment method for most users and removes the hosting overhead for your team. See below for the all the awesome features we provide and see the Pricing & Billing page for more information on which plan suits your indexing needs.
 
-- **Self-Hosting**: Run your indexer on your own infrastructure. This requires advanced setup and infrastructure knowledge not unique to Envio. See the following repository for a simple docker example to get you started. Please note this example does not cover all infrastructure related needs. It is recommended that at least a separate Postgres management tool is used for self-hosting in production. For further instructions see the Self Hosting Guide
+- **Self-Hosting**: Run your indexer on your own infrastructure. This requires advanced setup and infrastructure knowledge not unique to Envio. See the following [repository](https://github.com/enviodev/local-docker-example) for a simple docker example to get you started. Please note this example does not cover all infrastructure related needs. It is recommended that at least a separate Postgres management tool is used for self-hosting in production. For further instructions see the Self Hosting Guide
 
 ## Key Features
 
@@ -4021,7 +4021,7 @@ Envio Cloud provides a seamless GitHub-integrated deployment workflow:
 
 **Multiple Indexers**: Deploy several indexers from a single repository using different configurations, branches, or directories.
 
-You can view and manage your hosted indexers in the Envio Explorer.
+You can view and manage your hosted indexers in the [Envio Explorer](https://envio.dev/explorer).
 
 
 
@@ -4228,7 +4228,7 @@ Envio Cloud provides a seamless git-based deployment workflow, similar to modern
 
 ### Requirements
 
-- **Version Support**: We strongly advise using the latest release version for improved deployment performance. Envio Cloud requires a minimum version of at least `2.21.5`.
+- **Version Support**: We strongly advise using the latest [release version](https://github.com/enviodev/hyperindex/releases) for improved deployment performance. Envio Cloud requires a minimum version of at least `2.21.5`.
 Additionally, the following versions are not supported on Envio Cloud: 
   - `2.29.x`
 - **PNPM Support**: the deployment must be compatible with pnpm version `10.32.0`
@@ -4236,9 +4236,9 @@ Additionally, the following versions are not supported on Envio Cloud:
   - **Package.json**: a `package.json` file must be present in the root folder and support the above two requirements, with the envio version explicitly configured in the dependencies.
   - **Configuration file**: a HyperIndex configuration file must be present.
 
-  The root folder and configuration file name can be set in the indexer settings.
+  The root folder and configuration file name can be set in the [indexer settings](#configure-your-indexer).
 - **GitHub Repository**: The repository must be no larger than `100MB`. Caching between deployments is supported for paid plans using the Effects Api.
-- **Node Version**: It is strongly recommended that the indexer is compatible with node version 24 or higher.
+- **Node Version**: It is strongly recommended that the indexer is compatible with node version [24 or higher](https://github.com/nodejs/node/tags).
 
 
 
@@ -4288,7 +4288,7 @@ For complete pricing details and feature comparison, see our Pricing & Billing p
 
 ### Initial Setup
 
-1. **Log in with GitHub**: Visit the Envio App and authenticate with your GitHub account
+1. **Log in with GitHub**: Visit the [Envio App](https://envio.dev/app/login) and authenticate with your GitHub account
 2. **Select an Organization**: Choose your personal account or any organization you have access to
 3. **Install the Envio Deployments GitHub App**: Grant access to the repositories you want to deploy
 
@@ -4567,7 +4567,7 @@ When indexing stops, the dashboard clearly surfaces the issue so you can investi
 :::warning Alpha Release
 The `envio-cloud` CLI is currently in **alpha**. The tool is under active development and will be iterated on before a stable version 1 release once the final form of the tool's interaction is finalized.
 
-For feature requests, please reach out to us on Telegram or Discord.
+For feature requests, please reach out to us on [Telegram](https://t.me/envaborations) or [Discord](https://discord.gg/envio).
 :::
 
 The `envio-cloud` CLI is a command-line tool for interacting with Envio Cloud. It enables you to deploy, manage, and monitor your blockchain indexers directly from the terminal — making it particularly useful for CI/CD pipelines, scripting, and agentic workflows.
@@ -4998,7 +4998,7 @@ envio-cloud indexer list --org enviodev -o json | jq -r '.data[].indexer_id'
 - **Production Features** - Tags, IP whitelisting, caching, and alerts
 - **Monitoring** - Dashboard monitoring and alerts
 - **Envio CLI** - Local development CLI reference
-- **npm package** - Latest version and changelog
+- **[npm package](https://www.npmjs.com/package/envio-cloud)** - Latest version and changelog
 
 ---
 
@@ -5016,7 +5016,7 @@ Envio offers flexible pricing options to meet the needs of projects at different
 Envio Cloud offers flexible pricing plans to match your project's needs, from free development environments to enterprise-grade dedicated hosting.
 
 :::info Current Pricing
-For the most up-to-date pricing information, detailed plan comparisons, and feature breakdowns, please visit our official Envio Pricing Page.
+For the most up-to-date pricing information, detailed plan comparisons, and feature breakdowns, please visit our official [Envio Pricing Page](https://envio.dev/pricing).
 :::
 
 **Available Plans:**
@@ -5042,7 +5042,7 @@ The free development plan is intended for testing and development purposes only 
 :::
 
 :::tip
-For detailed feature explanations, see our Features page. For deployment instructions, see our Deployment Guide. Not sure which option is right for your project? Book a call with our team to discuss your specific needs.
+For detailed feature explanations, see our Features page. For deployment instructions, see our Deployment Guide. Not sure which option is right for your project? [Book a call with our team](https://cal.com/jonjon-clark/15min) to discuss your specific needs.
 :::
 
 ---
@@ -5084,7 +5084,7 @@ Before self-hosting, ensure you have:
 ## Getting Started
 
 In general, if you want to self-host, you will likely use a Docker setup.
-For a working example, check out the local-docker-example repository.
+For a working example, check out the [local-docker-example repository](https://github.com/enviodev/local-docker-example).
 It contains a minimal `Dockerfile` and `docker-compose.yaml` that configure the Envio indexer together with PostgreSQL and Hasura.
 
 ## Configuration Explained
@@ -5108,8 +5108,8 @@ The configuration uses environment variables with sensible defaults. For product
 
 If you encounter issues with self-hosting:
 
-- Check the Envio GitHub repository for known issues
-- Join the Envio Discord community for community support
+- Check the [Envio GitHub repository](https://github.com/enviodev/hyperindex) for known issues
+- Join the [Envio Discord community](https://discord.gg/envio) for community support
 
 :::tip
 For most production use cases, we recommend using Envio Cloud to benefit from automatic scaling, monitoring, and maintenance.
@@ -5142,7 +5142,7 @@ Being a member of the GitHub organisation **does not** automatically grant acces
 
 ## Introduction
 
-This tutorial will guide you through indexing Optimism Standard Bridge deposits in under 5 minutes using Envio HyperIndex's no-code contract import feature.
+This tutorial will guide you through indexing Optimism Standard Bridge deposits in under 5 minutes using Envio HyperIndex's no-code [contract import](https://docs.envio.dev/docs/HyperIndex/contract-import) feature.
 
 The Optimism Standard Bridge enables the movement of ETH and ERC-20 tokens between Ethereum and Optimism. We'll index bridge deposit events by extracting the `DepositFinalized` logs emitted by the bridge contracts on both networks.
 
@@ -5152,9 +5152,9 @@ The Optimism Standard Bridge enables the movement of ETH and ERC-20 tokens betwe
 
 Before starting, ensure you have the following installed:
 
-- **Node.js** _(v22 or newer recommended)_
-- **pnpm** _(v8 or newer)_
-- **Docker Desktop** _(required to run the Envio indexer locally)_
+- **[Node.js](https://nodejs.org/en/download/current)** _(v22 or newer recommended)_
+- **[pnpm](https://pnpm.io/installation)** _(v8 or newer)_
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** _(required to run the Envio indexer locally)_
 
 > **Note:** Docker is specifically required to run your blockchain indexer locally. You can skip Docker installation if you plan only to use Envio Cloud.
 
@@ -5184,7 +5184,7 @@ pnpx envio init
    0x4200000000000000000000000000000000000010
    ```
 
-   View on Optimistic Etherscan
+   [View on Optimistic Etherscan](https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000010)
 
 3. Select the `DepositFinalized` event:
    - Navigate using arrow keys (↑↓)
@@ -5206,7 +5206,7 @@ pnpx envio init
    0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1
    ```
 
-   View on Etherscan
+   [View on Etherscan](https://etherscan.io/address/0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1)
 
 4. Select the `ETHDepositInitiated` event
 
@@ -5276,7 +5276,7 @@ Now you can interact with your indexed data:
 
 ### Accessing Hasura
 
-1. Open Hasura at http://localhost:8080
+1. Open Hasura at [http://localhost:8080](http://localhost:8080)
 2. When prompted, enter the admin password: `testing`
 
 ### Monitoring Indexing Progress
@@ -5287,7 +5287,7 @@ Now you can interact with your indexed data:
 
 
 
-> **Note:** Thanks to Envio's HyperSync, indexing happens significantly faster than with standard RPC methods.
+> **Note:** Thanks to Envio's [HyperSync](https://docs.envio.dev/docs/hypersync), indexing happens significantly faster than with standard RPC methods.
 
 ### Querying Indexed Events
 
@@ -5329,7 +5329,7 @@ Congratulations! You've successfully created an indexer for Optimism Bridge depo
 - Create relationships between events on different networks
 - Deploy your indexer to Envio Cloud
 
-For more tutorials and advanced features, check out our documentation or watch our video walkthroughs on YouTube.
+For more tutorials and advanced features, check out our [documentation](https://docs.envio.dev) or watch our [video walkthroughs](https://www.youtube.com/watch?v=9U2MTFU9or0) on YouTube.
 
 ---
 
@@ -5339,7 +5339,7 @@ For more tutorials and advanced features, check out our documentation or watch o
 
 ## Introduction
 
-In this tutorial, you'll learn how to index ERC20 token transfers on the Base network using Envio HyperIndex. By leveraging the no-code contract import feature, you'll be able to quickly analyze USDC transfer activity, including identifying the largest transfers.
+In this tutorial, you'll learn how to index ERC20 token transfers on the Base network using Envio HyperIndex. By leveraging the no-code [contract import](https://docs.envio.dev/docs/HyperIndex/contract-import) feature, you'll be able to quickly analyze USDC transfer activity, including identifying the largest transfers.
 
 We'll create an indexer that tracks all USDC token transfers on Base by extracting the `Transfer` events emitted by the USDC contract. The entire process takes less than 5 minutes to set up and start querying data.
 
@@ -5349,9 +5349,9 @@ We'll create an indexer that tracks all USDC token transfers on Base by extracti
 
 Before starting, ensure you have the following installed:
 
-- **Node.js** _(v22 or newer recommended)_
-- **pnpm** _(v8 or newer)_
-- **Docker Desktop** _(required to run the Envio indexer locally)_
+- **[Node.js](https://nodejs.org/en/download/current)** _(v22 or newer recommended)_
+- **[pnpm](https://pnpm.io/installation)** _(v8 or newer)_
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** _(required to run the Envio indexer locally)_
 
 > **Note:** Docker is specifically required to run your blockchain indexer locally. You can skip Docker installation if you plan only to use Envio Cloud.
 
@@ -5381,7 +5381,7 @@ pnpx envio init
    0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
    ```
 
-   View on BaseScan
+   [View on BaseScan](https://basescan.org/address/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913)
 
 3. Select the `Transfer` event:
    - Navigate using arrow keys (↑↓)
@@ -5459,7 +5459,7 @@ Now you can interact with your indexed USDC transfer data:
 
 ### Accessing Hasura
 
-1. Open Hasura at http://localhost:8080
+1. Open Hasura at [http://localhost:8080](http://localhost:8080)
 2. When prompted, enter the admin password: `testing`
 
 
@@ -5472,7 +5472,7 @@ Now you can interact with your indexed USDC transfer data:
 
 
 
-> **Note:** Thanks to Envio's HyperSync, you can index millions of USDC transfers in just minutes rather than hours or days with traditional methods.
+> **Note:** Thanks to Envio's [HyperSync](https://docs.envio.dev/docs/hypersync), you can index millions of USDC transfers in just minutes rather than hours or days with traditional methods.
 
 ### Querying Indexed Events
 
@@ -5513,7 +5513,7 @@ Congratulations! You've successfully created an indexer for USDC token transfers
 - Add more tokens or events to your indexer
 - Deploy your indexer to Envio Cloud
 
-For more tutorials and advanced features, check out our documentation or watch our video walkthrough on YouTube.
+For more tutorials and advanced features, check out our [documentation](https://docs.envio.dev) or watch our [video walkthrough](https://www.youtube.com/watch?v=e1xznmKBLa8) on YouTube.
 
 ---
 
@@ -5521,9 +5521,9 @@ For more tutorials and advanced features, check out our documentation or watch o
 
 **File:** `Tutorials/tutorial-indexing-fuel.md`
 
-HyperIndex supports any EVM-compatible blockchain and the Fuel Network.
+HyperIndex supports any EVM-compatible blockchain and the [Fuel](https://fuel.network/) Network.
 
-Blockchain indexers are vital to the success of any dApp. In this tutorial, we will create an Envio indexer for the Fuel dApp Sway Farm step by step.
+Blockchain indexers are vital to the success of any dApp. In this tutorial, we will create an Envio indexer for the Fuel dApp [Sway Farm](https://swayfarm.xyz/) step by step.
 
 Sway Farm is a simple farming game and for the sake of a real-world example, let's create the indexer for a leaderboard of all farmers 🧑‍🌾
 
@@ -5531,17 +5531,17 @@ Sway Farm is a simple farming game and for the sake of a real-world example, let
 
 ## About Fuel
 
-Fuel is an operating system purpose-built for Ethereum rollups. Fuel's unique architecture allows rollups to solve for PSI (parallelization, state minimized execution, interoperability). Powered by the FuelVM, Fuel aims to expand Ethereum's capability set without compromising security or decentralization.
+[Fuel](https://fuel.network/) is an operating system purpose-built for Ethereum rollups. Fuel's unique architecture allows rollups to solve for PSI (parallelization, state minimized execution, interoperability). Powered by the FuelVM, Fuel aims to expand Ethereum's capability set without compromising security or decentralization.
 
-Website | X | Discord
+[Website](https://fuel.network/) | [X](https://twitter.com/fuel_network?lang=en) | [Discord](https://discord.com/invite/xfpK4Pe)
 
 ## Prerequisites
 
 ### Environment tooling
 
-- **Node.js** _(v22 or newer recommended)_
-- **pnpm** _(v8 or newer)_
-- **Docker Desktop** _(required to run the Envio indexer locally)_
+- **[Node.js](https://nodejs.org/en/download/current)** _(v22 or newer recommended)_
+- **[pnpm](https://pnpm.io/installation)** _(v8 or newer)_
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** _(required to run the Envio indexer locally)_
 
 > **Note:** Docker is specifically required to run your blockchain indexer locally. You can skip Docker installation if you plan only to use Envio Cloud.
 
@@ -5591,7 +5591,7 @@ In the following prompt, you can choose an initialization option. There's a Gree
 
 > A separate Tutorial page provides more details about the `Greeter` template.
 
-Next it'll ask us for an ABI file. You can find it in the `./out/debug` directory after building your Sway contract with `forc build`:
+Next it'll ask us for an ABI file. You can find it in the `./out/debug` directory after building your [Sway](https://docs.fuel.network/docs/sway/) contract with `forc build`:
 
 ```bash
 ? What is the path to your json abi file? ./sway-farm/contract/out/debug/contract-abi.json
@@ -5611,7 +5611,7 @@ After the ABI file is provided, Envio parses all possible events you can use for
 [↑↓ to move, space to select one, → to all, ← to none, type to filter]
 ```
 
-Let's select the events we want to index. I opened the code of the contract file and realized that for a leaderboard we need only events which update player information. Hence, I left only `NewPlayer`, `LevelUp`, and `SellItem` selected in the list. We'd want to index more events in real life, but this is enough for the tutorial.
+Let's select the events we want to index. I opened the code of the [contract file](https://github.com/FuelLabs/sway-farm/blob/47e3ed5a91593ebcf8d2c67ae6fad41d9954c8a8/contract/src/abi_structs.sw#L365-L406) and realized that for a leaderboard we need only events which update player information. Hence, I left only `NewPlayer`, `LevelUp`, and `SellItem` selected in the list. We'd want to index more events in real life, but this is enough for the tutorial.
 
 ```bash
 ? Which events would you like to index?
@@ -5697,7 +5697,7 @@ networks:
 
 In the tutorial, we don't need to adjust it in any way. But later you can modify the file and add more events for indexing.
 
-As a nice to have, you can use a Sway struct name without specifying a `logId`, like this:
+As a nice to have, you can use a [Sway](https://docs.fuel.network/docs/sway/) struct name without specifying a `logId`, like this:
 
 ```
 - name: SellItem
@@ -5787,7 +5787,7 @@ SwayFarmContract.SellItem.handler(async ({ event, context }) => {
 
 Without overengineering, simply set the player data into the database. What's nice is that whenever your ABI or entities in `graphql.schema` change, Envio regenerates types and shows the compilation error.
 
-> 🧠 You can find the indexer repo created during the tutorial on GitHub.
+> 🧠 You can find the indexer repo created during the tutorial on [GitHub](https://github.com/enviodev/sway-farm-indexer).
 
 ## Starting the Indexer
 
@@ -5825,13 +5825,13 @@ Once you have verified that the indexer is working for your contracts, then you 
 
 Deploying an indexer to Envio Cloud allows you to extract information via graphQL queries into your front-end or some back-end application.
 
-Navigate to the Envio Cloud to start deploying your indexer and refer to this documentation for more information on deploying your indexer.
+Navigate to the [Envio Cloud](https://envio.dev/app/login) to start deploying your indexer and refer to this documentation for more information on deploying your indexer.
 
 ## What next?
 
 Once you have successfully finished the tutorial, you are ready to become a blockchain indexing wizard!
 
-Join our Discord channel to make sure you catch all new releases.
+Join our [Discord](https://discord.gg/envio) channel to make sure you catch all new releases.
 
 ---
 
@@ -5845,7 +5845,7 @@ This tutorial provides a step-by-step guide to indexing a simple Greeter smart c
 
 ### What is the Greeter Contract?
 
-The Greeter contract is a straightforward smart contract that allows users to store greeting messages on the blockchain. For this tutorial, we'll be indexing instances of this contract deployed on both **Polygon** and **Linea** networks.
+The [Greeter contract](https://github.com/Float-Capital/hardhat-template) is a straightforward smart contract that allows users to store greeting messages on the blockchain. For this tutorial, we'll be indexing instances of this contract deployed on both **Polygon** and **Linea** networks.
 
 ### What You'll Build
 
@@ -5859,9 +5859,9 @@ By the end of this tutorial, you'll have:
 
 Before starting, ensure you have the following installed:
 
-- **Node.js** _(v22 or newer recommended)_
-- **pnpm** _(v8 or newer)_
-- **Docker Desktop** _(required to run the Envio indexer locally)_
+- **[Node.js](https://nodejs.org/en/download/current)** _(v22 or newer recommended)_
+- **[pnpm](https://pnpm.io/installation)** _(v8 or newer)_
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** _(required to run the Envio indexer locally)_
 
 > **Note:** Docker is specifically required to run your blockchain indexer locally. You can skip Docker installation if you plan only to use Envio Cloud.
 
@@ -5985,14 +5985,14 @@ To see your indexer in action, you can write new greetings to the blockchain:
 
 ### For Polygon:
 
-1. Visit the contract on Polygonscan
+1. Visit the contract on [Polygonscan](https://polygonscan.com/address/0x9D02A17dE4E68545d3a58D3a20BbBE0399E05c9c#writeContract)
 2. Connect your wallet
 3. Use the `setGreeting` function to write a new greeting
 4. Submit the transaction
 
 ### For Linea:
 
-1. Visit the contract on Lineascan
+1. Visit the contract on [Lineascan](https://lineascan.build/address/0xdEe21B97AB77a16B4b236F952e586cf8408CF32A#writeContract)
 2. Connect your wallet
 3. Use the `setGreeting` function to write a new greeting
 4. Submit the transaction
@@ -6003,7 +6003,7 @@ Since this is a multichain example, you can interact with both contracts to see 
 
 Now you can explore the data your indexer has captured:
 
-1. Open Hasura at http://localhost:8080
+1. Open Hasura at [http://localhost:8080](http://localhost:8080)
 2. When prompted for authentication, use the password: `testing`
 3. Navigate to the **Data** tab to browse the database tables
 4. Or use the **API** tab to write GraphQL queries
@@ -6029,7 +6029,7 @@ query GetGreetings {
 
 When you're ready to move from local development to production:
 
-1. Visit Envio Cloud
+1. Visit [Envio Cloud](https://envio.dev/app/login)
 2. Follow the steps to deploy your indexer
 3. Get a production GraphQL endpoint for your application
 
@@ -6054,7 +6054,7 @@ Now that you've mastered the basics, you can:
 - Explore the Advanced Querying features
 - Create aggregated statistics from your indexed data
 
-For more tutorials and examples, visit the Envio Documentation or join our Discord community for support.
+For more tutorials and examples, visit the [Envio Documentation](https://docs.envio.dev/) or join our [Discord community](https://discord.gg/envio) for support.
 
 ---
 
@@ -6072,7 +6072,7 @@ Many blockchain applications require price data to calculate values such as:
 
 This tutorial explores three different approaches to incorporating price data into your Envio indexer, using a real-world example of tracking ETH deposits into a Uniswap V3 liquidity pool on the Blast blockchain.
 
-> **TL;DR:** The complete code for this tutorial is available in this GitHub repository.
+> **TL;DR:** The complete code for this tutorial is available in [this GitHub repository](https://github.com/enviodev/price-data).
 
 ## What You'll Learn
 
@@ -6097,7 +6097,7 @@ Let's explore each method in detail.
 
 ## Method 1: Using Oracle Price Feeds
 
-Oracle networks provide on-chain price data through specialized smart contracts. For this tutorial, we'll use API3 price feeds on Blast.
+Oracle networks provide on-chain price data through specialized smart contracts. For this tutorial, we'll use [API3](https://api3.org/) price feeds on Blast.
 
 ### How Oracles Work
 
@@ -6111,12 +6111,12 @@ Oracle services like API3 maintain a network of data providers that push price u
 
 To locate the ETH/USD price feed using API3 on Blast:
 
-1. Identify the API3 contract address: `0x709944a48cAf83535e43471680fDA4905FB3920a`
+1. Identify the API3 contract address: [`0x709944a48cAf83535e43471680fDA4905FB3920a`](https://blastscan.io/address/0x709944a48cAf83535e43471680fDA4905FB3920a)
 
 2. Find the data feed ID for ETH/USD:
 
    - The dAPI name "ETH/USD" as bytes32: `0x4554482f55534400000000000000000000000000000000000000000000000000`
-   - Using the `dapiNameToDataFeedId` function, this maps to `0x3efb3990846102448c3ee2e47d22f1e5433cd45fa56901abe7ab3ffa054f70b5`
+   - Using the [`dapiNameToDataFeedId`](https://blastscan.io/address/0x709944a48cAf83535e43471680fDA4905FB3920a#readContract#F8) function, this maps to `0x3efb3990846102448c3ee2e47d22f1e5433cd45fa56901abe7ab3ffa054f70b5`
 
 3. Monitor the `UpdatedBeaconSetWithBeacons` events with this data feed ID to get price updates
 
@@ -6176,9 +6176,9 @@ const factoryContract = getContract({
 })();
 ```
 
-> **Tip:** You can also manually find the pool address using the `getPool` function on a block explorer.
+> **Tip:** You can also manually find the pool address using the [`getPool`](https://blastscan.io/address/0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd#readContract#F2) function on a block explorer.
 
-Running this code reveals the USDB/WETH pool is at `0xf52B4b69123CbcF07798AE8265642793b2E8990C`.
+Running this code reveals the USDB/WETH pool is at [`0xf52B4b69123CbcF07798AE8265642793b2E8990C`](https://blastscan.io/address/0xf52B4b69123CbcF07798AE8265642793b2E8990C).
 
 ### Getting Price Data From Swap Events
 
@@ -6200,7 +6200,7 @@ Uniswap V3 emits `Swap` events containing price information in the `sqrtPriceX96
 
 ## Method 3: Using Off-chain APIs
 
-External price APIs like CoinGecko provide comprehensive token price data but require HTTP calls from your indexer.
+External price APIs like [CoinGecko](https://www.coingecko.com/en/api) provide comprehensive token price data but require HTTP calls from your indexer.
 
 ### Making API Requests
 
@@ -6469,7 +6469,7 @@ When comparing our three price data sources, we found:
 
 Looking at the `offchainOracleDiff` column, we can see that oracle and off-chain prices typically align closely but can deviate by as much as 17.98% in some cases.
 
-For the highlighted transaction (0xe7e79ddf29ed2f0ea8cb5bb4ffdab1ea23d0a3a0a57cacfa875f0d15768ba37d), we can compare our calculated values:
+For the highlighted transaction ([0xe7e79ddf29ed2f0ea8cb5bb4ffdab1ea23d0a3a0a57cacfa875f0d15768ba37d](https://blastscan.io/tx/0xe7e79ddf29ed2f0ea8cb5bb4ffdab1ea23d0a3a0a57cacfa875f0d15768ba37d)), we can compare our calculated values:
 
 - **Actual value** (from block explorer): $2,358.27
 - **DEX pool value** (`depositedPool`): $2,117.07
@@ -6518,7 +6518,7 @@ By carefully choosing and implementing the right price data strategy, you can bu
 
 ## Introduction
 
-The Scaffold-ETH 2 Envio extension makes indexing your deployed smart contracts as simple as possible. Generate a boilerplate indexer for your deployed contracts with a single click and start indexing their events immediately.
+The [Scaffold-ETH 2](https://scaffoldeth.io/extensions) Envio extension makes indexing your deployed smart contracts as simple as possible. Generate a boilerplate indexer for your deployed contracts with a single click and start indexing their events immediately.
 
 With this extension, you get:
 - 🔍 **Automatic indexer generation** from your deployed contracts
@@ -6530,10 +6530,10 @@ With this extension, you get:
 
 Before starting, ensure you have the following installed:
 
-- **Node.js v20** _(v20 or newer required)_
-- **pnpm** _(for Envio indexer)_
-- **Docker Desktop** _(required to run the Envio indexer locally)_
-- **Yarn** _(for Scaffold-ETH)_
+- **[Node.js v20](https://nodejs.org/en/download/current)** _(v20 or newer required)_
+- **[pnpm](https://pnpm.io/installation)** _(for Envio indexer)_
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** _(required to run the Envio indexer locally)_
+- **[Yarn](https://yarnpkg.com/getting-started/install)** _(for Scaffold-ETH)_
 
 ## Step 1: Create a New Scaffold-ETH 2 Project with Envio Extension
 
@@ -7617,7 +7617,7 @@ The first argument is an options object that describes the effect:
 
 The second argument is a function that will be called with the effect's input.
 
-> **Note:** For type definitions, you should use `S` from the `envio` package, which uses Sury library under the hood.
+> **Note:** For type definitions, you should use `S` from the `envio` package, which uses [Sury](https://github.com/DZakh/sury) library under the hood.
 
 After defining an effect, you can use `context.effect` to call it from your handler, loader, or another effect.
 
@@ -7717,13 +7717,13 @@ export const getBalance = createEffect(
 
 Every effect cache creates a new table in the database `envio_effect_${effectName}`. You can see it and query in Hasura console with admin secret.
 
-Also, use our Development Console to track the cache size and see number of calls which didn't hit the cache.
+Also, use our [Development Console](https://envio.dev/console) to track the cache size and see number of calls which didn't hit the cache.
 
 ### Reuse Effect Cache on Indexer Reruns
 
 To prevent invalid data we don't keep the effect cache on indexer reruns. But you can explicitly configure cache, which should be preloaded when the indexer is rerun.
 
-Open Development Console of the running indexer which accumulated the cache. You'll be able to see the `Sync Cache` button right at the `Effects` section. Clicking the button will load the cache from the indexer database to the `.envio/cache` directory in your indexer project.
+Open [Development Console](https://envio.dev/console) of the running indexer which accumulated the cache. You'll be able to see the `Sync Cache` button right at the `Effects` section. Clicking the button will load the cache from the indexer database to the `.envio/cache` directory in your indexer project.
 
 When the indexer is rerun by using `envio dev` or `envio start -r` call, the initial cache will be loaded from the `.envio/cache` directory and used for the indexer run.
 
@@ -7745,7 +7745,7 @@ For detailed instructions, see the Effect API Cache documentation.
 
 ### Rate Limit
 
-Starting from `v2.32.0`, the `rateLimit` option was added. It controls how frequently an effect can run within a given timeframe. You can set it to `false` to disable rate limiting or define a custom limit such as calls per second, minute, or a duration in milliseconds.
+Starting from [`v2.32.0`](https://github.com/enviodev/hyperindex/releases/tag/v2.32.0), the `rateLimit` option was added. It controls how frequently an effect can run within a given timeframe. You can set it to `false` to disable rate limiting or define a custom limit such as calls per second, minute, or a duration in milliseconds.
 
 ```typescript
 // Effect to get the balance of a specific address at a specific block
@@ -7770,7 +7770,7 @@ export const getBalance = createEffect(
 );
 ```
 
-Watch the following video to learn more about createEffect and other updates introduced in v2.32.0.
+Watch the following video to learn more about createEffect and other updates introduced in [v2.32.0](https://github.com/enviodev/hyperindex/releases/tag/v2.32.0).
 
 
 ### Sending Notifications (Webhooks)
@@ -7861,7 +7861,7 @@ If you're migrating from `experimental_createEffect` to `createEffect`, remove t
 
 **File:** `Guides/contract-state.md`
 
-> **Example Repository:** The complete code for this guide can be found here
+> **Example Repository:** The complete code for this guide can be found [here](https://github.com/enviodev/rpc-token-data-example)
 
 ## Introduction
 
@@ -7877,7 +7877,7 @@ This guide demonstrates how to access on-chain contract state from your event ha
 
 ### Scenario
 
-We want to track token information (name, symbol, decimals) for every token involved in a Uniswap V3 pool creation event.
+We want to track token information (name, symbol, decimals) for every token involved in a [Uniswap V3 pool creation event](https://docs.uniswap.org/contracts/v3/reference/core/interfaces/IUniswapV3Factory#poolcreated).
 
 ### Problem
 
@@ -7898,10 +7898,10 @@ To get the token name, symbol, and decimals, we need to:
 This guide assumes:
 
 - Basic familiarity with Envio indexing
-- Understanding of the viem library for making contract calls
-- Access to an Ethereum RPC endpoint (dRPC recommended)
+- Understanding of the [viem library](https://viem.sh/) for making contract calls
+- Access to an Ethereum RPC endpoint ([dRPC](https://drpc.org/) recommended)
 
-For a gentle introduction to viem with a similar example, check out this medium article.
+For a gentle introduction to viem with a similar example, check out this [medium article](https://medium.com/@0xape/typescript-and-viem-quickstart-for-blockchain-scripting-3f1846970b6f).
 
 ## Implementation Steps
 
@@ -8154,7 +8154,7 @@ export const getTokenMetadata = createEffect(
 
 Standard RPC requests return the **current state** of a contract, not the state at a specific historical block. For token metadata (name, symbol, decimals), this isn't typically an issue since these values rarely change.
 
-However, if you need historical state (like an account balance at a specific block), you would need a specialized RPC method like eth_getBalanceAt.
+However, if you need historical state (like an account balance at a specific block), you would need a specialized RPC method like [eth_getBalanceAt](https://docs.etherscan.io/api-pro/api-pro#get-historical-ether-balance-for-a-single-address-by-blockno).
 
 ### Handling Rate Limiting
 
@@ -8182,11 +8182,11 @@ For more advanced techniques, explore:
 
 **File:** `Guides/ipfs.md`
 
-> **Example Repository:** The complete code for this guide can be found here
+> **Example Repository:** The complete code for this guide can be found [here](https://github.com/enviodev/bored-ape-yacht-club-indexer)
 
 ## Introduction
 
-This guide demonstrates how to fetch and index data stored on IPFS within your Envio indexer. We'll use the Bored Ape Yacht Club NFT collection as a practical example, showing you how to retrieve and store token metadata from IPFS.
+This guide demonstrates how to fetch and index data stored on IPFS within your Envio indexer. We'll use the [Bored Ape Yacht Club](https://www.boredapeyachtclub.com/) NFT collection as a practical example, showing you how to retrieve and store token metadata from IPFS.
 
 IPFS (InterPlanetary File System) is commonly used in blockchain applications to store larger data like images and metadata that would be prohibitively expensive to store on-chain. By integrating IPFS fetching capabilities into your indexers, you can provide a more complete data model that combines on-chain events with off-chain metadata.
 
@@ -8749,7 +8749,7 @@ This feature is available starting from version `2.14.0`. The fallback RPC is ac
 
 ## Enhanced RPC with eRPC
 
-For more robust RPC usage, you can implement eRPC - a fault-tolerant EVM RPC proxy with advanced features like caching and failover.
+For more robust RPC usage, you can implement [eRPC](https://github.com/erpc/erpc) - a fault-tolerant EVM RPC proxy with advanced features like caching and failover.
 
 ### What eRPC Provides
 
@@ -8810,7 +8810,7 @@ networks:
     # Additional network configuration...
 ```
 
-For more detailed configuration options, refer to the eRPC documentation.
+For more detailed configuration options, refer to the [eRPC documentation](https://docs.erpc.cloud/config/example).
 
 ## Comparing HyperSync and RPC
 
@@ -8849,21 +8849,21 @@ Static, deep-linkable reference for the `config.yaml` Schema.
 
 ## Top-level Properties
 
-- description
-- name (required)
-- ecosystem
-- schema
-- output
-- contracts
-- networks (required)
-- unordered_multichain_mode
-- event_decoder
-- rollback_on_reorg
-- save_full_history
-- field_selection
-- raw_events
-- preload_handlers
-- address_format
+- [description](#description)
+- [name](#name) (required)
+- [ecosystem](#ecosystem)
+- [schema](#schema)
+- [output](#output)
+- [contracts](#contracts)
+- [networks](#networks) (required)
+- [unordered_multichain_mode](#unorderedmultichainmode)
+- [event_decoder](#eventdecoder)
+- [rollback_on_reorg](#rollbackonreorg)
+- [save_full_history](#savefullhistory)
+- [field_selection](#fieldselection)
+- [raw_events](#rawevents)
+- [preload_handlers](#preloadhandlers)
+- [address_format](#addressformat)
 
 ### description {#description}
 
@@ -8898,7 +8898,7 @@ Ecosystem of the project.
 - **type**: `anyOf(object | null)`
 
 Variants:
-- `1`: EcosystemTag
+- `1`: [EcosystemTag](#def-ecosystemtag)
 - `2`: `null`
 
 
@@ -8957,7 +8957,7 @@ Configuration of the blockchain networks that the project is deployed on.
 
 - **type**: `array>`
 - **items**: `object`
-- **items ref**: Network
+- **items ref**: [Network](#def-network)
 
 
 Example (config.yaml):
@@ -8991,7 +8991,7 @@ The event decoder to use for the indexer (default: hypersync-client)
 - **type**: `anyOf(object | null)`
 
 Variants:
-- `1`: EventDecoder
+- `1`: [EventDecoder](#def-eventdecoder)
 - `2`: `null`
 
 
@@ -9034,7 +9034,7 @@ Select the block and transaction fields to include in all events globally
 - **type**: `anyOf(object | null)`
 
 Variants:
-- `1`: FieldSelection
+- `1`: [FieldSelection](#def-fieldselection)
 - `2`: `null`
 
 
@@ -9075,7 +9075,7 @@ Address format for Ethereum addresses: 'checksum' or 'lowercase' (default: check
 - **type**: `anyOf(object | null)`
 
 Variants:
-- `1`: AddressFormat
+- `1`: [AddressFormat](#def-addressformat)
 - `2`: `null`
 
 
@@ -9220,7 +9220,7 @@ networks:
 
 Variants:
 - `1`: `string`
-- `2`: Rpc
+- `2`: [Rpc](#def-rpc)
 - `3`: `array>`
 
 Example (config.yaml):
@@ -9368,26 +9368,26 @@ The commands are organized into the following categories:
 
 ### Initialization Commands
 
-- `envio init` - Create new indexer projects
-- `envio init contract-import` - Import from existing contracts
-- `envio init template` - Use pre-built templates
+- [`envio init`](#envio-init) - Create new indexer projects
+- [`envio init contract-import`](#envio-init-contract-import) - Import from existing contracts
+- [`envio init template`](#envio-init-template) - Use pre-built templates
 
 ### Development Commands
 
-- `envio dev` - Run in development mode with hot reloading
-- `envio codegen` - Generate code from configuration files
-- `envio start` - Start the indexer without code generation
+- [`envio dev`](#envio-dev) - Run in development mode with hot reloading
+- [`envio codegen`](#envio-codegen) - Generate code from configuration files
+- [`envio start`](#envio-start) - Start the indexer without code generation
 
 ### Environment Management
 
-- `envio stop` - Stop running processes
-- `envio local` - Manage local environment
-- `envio local docker` - Control Docker containers
-- `envio local db-migrate` - Manage database schema
+- [`envio stop`](#envio-stop) - Stop running processes
+- [`envio local`](#envio-local) - Manage local environment
+- [`envio local docker`](#envio-local-docker) - Control Docker containers
+- [`envio local db-migrate`](#envio-local-db-migrate) - Manage database schema
 
 ### Analysis Tools
 
-- `envio benchmark-summary` - View performance data
+- [`envio benchmark-summary`](#envio-benchmark-summary) - View performance data
 
 ## Global Command
 
@@ -10231,13 +10231,13 @@ This comprehensive glossary explains the key terms and concepts used throughout 
 
 ## Table of Contents
 
-- Blockchain Fundamentals
-- Smart Contract Concepts
-- Indexing & Data
-- Development Tools
-- Programming Languages
-- Envio Platform
-- Mathematical Concepts
+- [Blockchain Fundamentals](#blockchain-fundamentals)
+- [Smart Contract Concepts](#smart-contract-concepts)
+- [Indexing & Data](#indexing--data)
+- [Development Tools](#development-tools)
+- [Programming Languages](#programming-languages)
+- [Envio Platform](#envio-platform)
+- [Mathematical Concepts](#mathematical-concepts)
 
 ## Blockchain Fundamentals
 
@@ -11176,7 +11176,7 @@ yarn add graphql-ws ws
 
 ## Getting Support
 
-For any questions about WebSocket usage, contact the Envio team via Telegram or Discord.
+For any questions about WebSocket usage, contact the Envio team via [Telegram](https://t.me/envio) or [Discord](https://discord.gg/envio).
 
 ---
 
@@ -11190,12 +11190,12 @@ This guide covers all the differences between TheGraph's query syntax and Envio'
 
 ## Converter Tool
 
-We've built a query converter tool that automatically converts TheGraph queries to Envio's GraphQL syntax. You can:
+We've built a [query converter tool](https://github.com/enviodev/subgraph-to-hyperindex-query-converter) that automatically converts TheGraph queries to Envio's GraphQL syntax. You can:
 
 - **Convert and execute**: Provide your Envio GraphQL endpoint and a query written in TheGraph syntax. The tool will convert it, execute it against your endpoint, and return the results
 - **Convert only**: Use the tool to convert queries and view the converted output without executing them. To convert queries without executing them, add `/debug` to the converter endpoint and send your query. The response will contain only the converted query without actually running it.
 
-**Repository**: subgraph-to-hyperindex-query-converter
+**Repository**: [subgraph-to-hyperindex-query-converter](https://github.com/enviodev/subgraph-to-hyperindex-query-converter)
 
 :::info Availability
 The query converter tool is only available to users on paid tiers.
@@ -11211,7 +11211,7 @@ If you'd like to use the query converter tool for your indexer, please reach out
 
 :::warning Beta Status
 This converter tool is still very much in beta. We're actively working on it and discovering new query conversions that need to be handled.  
-**If you encounter any conversion failures or incorrect conversions, please file a GitHub issue in the repository so we can address it.**
+**If you encounter any conversion failures or incorrect conversions, please [file a GitHub issue](https://github.com/enviodev/subgraph-to-hyperindex-query-converter/issues) in the repository so we can address it.**
 :::
 
 ### Converter Tool Limitations
@@ -11219,7 +11219,7 @@ This converter tool is still very much in beta. We're actively working on it and
 The query converter tool has several limitations to be aware of:
 
 - **Rate limits**: The rate limits of your associated tier will still apply when using the converter tool.
-- **Beta status and incomplete coverage**: Since the tool is in beta there is a possibility we have missed some conversion patterns. Some queries may still fail to convert correctly or may not be handled at all. If you encounter any conversion failures or incorrect conversions, please file a GitHub issue in the repository so we can address it.
+- **Beta status and incomplete coverage**: Since the tool is in beta there is a possibility we have missed some conversion patterns. Some queries may still fail to convert correctly or may not be handled at all. If you encounter any conversion failures or incorrect conversions, please [file a GitHub issue](https://github.com/enviodev/subgraph-to-hyperindex-query-converter/issues) in the repository so we can address it.
 - **WebSocket subscriptions**: WebSocket subscriptions are not supported. The converter only works with standard HTTP GraphQL queries.
 - **Directives not supported**: GraphQL directives (such as `@skip`, `@include`, etc.) are not supported because the converter uses simple string parsing rather than a full GraphQL parser. Directives are ignored or may break parsing.
 - **Variables in orderBy/orderDirection**: Variables used in `orderBy` and `orderDirection` parameters are ignored because HyperIndex requires literal field names in `order_by` clauses, and variable values are unknown at conversion time. Queries using variables for ordering will return unordered results.
@@ -11252,14 +11252,14 @@ For production applications, we recommend migrating your queries to Envio's stan
 
 # Logging in Envio HyperIndex
 
-Effective logging is essential for monitoring your blockchain indexer's performance, diagnosing issues, and gathering insights. The Envio indexer uses pino, a high-performance logging library for JavaScript. These logs can be integrated with analytics tools such as Kibana to generate metrics and visualizations.
+Effective logging is essential for monitoring your blockchain indexer's performance, diagnosing issues, and gathering insights. The Envio indexer uses [pino](https://github.com/pinojs/pino/), a high-performance logging library for JavaScript. These logs can be integrated with analytics tools such as [Kibana](https://www.elastic.co/what-is/kibana) to generate metrics and visualizations.
 
 ## Table of Contents
 
-- User Logging - How to implement logging in your event handlers
-- Configuration & Output Formats - Configuring log output and formats
-- Log Levels - Understanding available log levels
-- Troubleshooting - Common issues and solutions
+- [User Logging](#users) - How to implement logging in your event handlers
+- [Configuration & Output Formats](#metrics-debugging-and-troubleshooting) - Configuring log output and formats
+- [Log Levels](#developer-logging) - Understanding available log levels
+- [Troubleshooting](#troubleshooting) - Common issues and solutions
 
 ## Users
 
@@ -11377,7 +11377,7 @@ LOG_STRATEGY="both-prettyconsole"  # Pretty logs to console, Pino format to file
 LOG_FILE=""
 ```
 
-For production environments or detailed analytics, consider integrating logs with Kibana or similar tools. We're developing Kibana dashboards for self-hosting and UI dashboards for our hosting solution. If you have specific dashboard requirements, please contact us on Discord.
+For production environments or detailed analytics, consider integrating logs with Kibana or similar tools. We're developing Kibana dashboards for self-hosting and UI dashboards for our hosting solution. If you have specific dashboard requirements, please [contact us on Discord](https://discord.gg/envio).
 
 ## Developer Logging
 
@@ -11439,29 +11439,29 @@ This approach allows you to view essential information in the UI while capturing
 
 **File:** `Troubleshoot/common-issues.md`
 
-This guide helps you identify and resolve common issues you might encounter when working with Envio HyperIndex. If you don't find a solution to your problem here, please join our Discord community for additional support.
+This guide helps you identify and resolve common issues you might encounter when working with Envio HyperIndex. If you don't find a solution to your problem here, please join our [Discord community](https://discord.gg/envio) for additional support.
 
 ## Table of Contents
 
-- Setup and Configuration Issues
-  - Module Not Found Errors
-  - Smart Contract Updates
-  - Node.js Version Compatibility
-  - PNPM Version Compatibility
-- Runtime Issues
-  - Indexer Start Block Issues
-  - Tables Not Registered in Hasura
-  - RPC-Related Issues
-- Debugging a Stuck Indexer
-  - Indexer Not Making Progress
-- Rate Limiting on Hosted Service
-  - HTTP 429 Errors
-- Hasura Authentication
-  - Cannot Log In to the Hasura Console
-- Infrastructure Conflicts
-  - Local Postgres Conflicts
-- Missing Events
-  - Events Not Appearing in Indexed Data
+- [Setup and Configuration Issues](#setup-and-configuration-issues)
+  - [Module Not Found Errors](#cannot-find-module-errors-on-pnpm-start)
+  - [Smart Contract Updates](#smart-contract-updated-after-the-initial-codegen)
+  - [Node.js Version Compatibility](#using-the-correct-version-of-nodejs)
+  - [PNPM Version Compatibility](#using-the-correct-version-of-pnpm)
+- [Runtime Issues](#runtime-issues)
+  - [Indexer Start Block Issues](#indexer-not-starting-at-the-specified-start-block)
+  - [Tables Not Registered in Hasura](#tables-for-entities-are-not-registered-on-hasura)
+  - [RPC-Related Issues](#rpc-related-issues)
+- [Debugging a Stuck Indexer](#debugging-a-stuck-indexer)
+  - [Indexer Not Making Progress](#indexer-not-making-progress)
+- [Rate Limiting on Hosted Service](#rate-limiting-on-hosted-service)
+  - [HTTP 429 Errors](#http-429-errors-when-querying-your-endpoint)
+- [Hasura Authentication](#hasura-authentication)
+  - [Cannot Log In to the Hasura Console](#cannot-log-in-to-the-hasura-console)
+- [Infrastructure Conflicts](#infrastructure-conflicts)
+  - [Local Postgres Conflicts](#postgres-running-locally)
+- [Missing Events](#missing-events)
+  - [Events Not Appearing in Indexed Data](#events-not-appearing-in-indexed-data)
 
 ## Setup and Configuration Issues
 
@@ -11619,7 +11619,7 @@ network:
 The most important thing to do is check your indexer logs for errors or warnings. Logs will almost always point you to the root cause.
 
 - **Locally:** Check the terminal output from `pnpm dev` for error messages or stack traces.
-- **Envio Cloud:** Go to your deployment in the Envio Cloud dashboard and open the **Logs** tab.
+- **Envio Cloud:** Go to your deployment in the [Envio Cloud dashboard](https://envio.dev/app) and open the **Logs** tab.
 
 If the logs don't reveal an obvious error, work through the common causes below:
 
@@ -11639,7 +11639,7 @@ If the logs don't reveal an obvious error, work through the common causes below:
 
 **If running on Envio Cloud:**
 
-- Check the deployment logs in the Envio Cloud dashboard for error details.
+- Check the deployment logs in the [Envio Cloud dashboard](https://envio.dev/app) for error details.
 - If the deployment is unrecoverable, you can delete it and redeploy from the dashboard.
 - Consider running the same configuration locally first to reproduce and debug the issue before redeploying.
 
@@ -11654,10 +11654,10 @@ If the logs don't reveal an obvious error, work through the common causes below:
 **What to check:**
 
 1. **Confirm it's a query rate limit (not an RPC issue)**
-   - Rate limiting applies to your _GraphQL query endpoint_, not to the indexer's data ingestion. If your indexer is slow to sync, that's a different issue — see Debugging a Stuck Indexer.
+   - Rate limiting applies to your _GraphQL query endpoint_, not to the indexer's data ingestion. If your indexer is slow to sync, that's a different issue — see [Debugging a Stuck Indexer](#debugging-a-stuck-indexer).
 
 2. **Check your plan's limits**
-   - Review your current plan in the Envio Cloud dashboard under your deployment settings. Higher-tier plans include higher query rate limits. See Billing & Plans for details.
+   - Review your current plan in the [Envio Cloud dashboard](https://envio.dev/app) under your deployment settings. Higher-tier plans include higher query rate limits. See Billing & Plans for details.
 
 3. **Reduce query frequency from your application**
    - If your frontend or backend polls the endpoint frequently, consider adding caching, reducing poll intervals, or using WebSocket subscriptions for real-time updates instead of polling.
@@ -11688,7 +11688,7 @@ On Envio Cloud, you **do not need the Hasura admin secret** to query your data. 
 https://indexer.dev.hyperindex.xyz//v1/graphql
 ```
 
-The Hasura console UI is not exposed on hosted deployments. To explore your data, use the GraphQL playground available in the Envio Cloud dashboard, or query the endpoint directly from your application or tools like Postman.
+The Hasura console UI is not exposed on hosted deployments. To explore your data, use the GraphQL playground available in the [Envio Cloud dashboard](https://envio.dev/app), or query the endpoint directly from your application or tools like Postman.
 
 If you need to restrict access to your endpoint, see the Hosted Service features for security options.
 
@@ -11763,7 +11763,7 @@ When encountering an error in Envio, you'll receive an error code (like `EE101`)
 2. Read the explanation to understand what caused the error
 3. Follow the recommended steps to resolve the issue
 
-If you can't resolve an error after following the suggestions, please reach out for support on our Discord community.
+If you can't resolve an error after following the suggestions, please reach out for support on our [Discord community](https://discord.gg/envio).
 
 ## Error Categories
 
@@ -12138,7 +12138,7 @@ contracts:
 
 - Check your event handler logic for errors
 - Review recent changes to your blockchain indexer
-- If unable to resolve, contact support through Discord with error details
+- If unable to resolve, contact support through [Discord](https://discord.gg/envio) with error details
 
 ## Database-Related Errors
 
@@ -12246,7 +12246,7 @@ pnpm envio local db-migrate setup
 
 **Issue**: Contract name not found in interface mapping (unexpected internal error).
 
-**Solution**: Contact support through Discord for assistance.
+**Solution**: Contact support through [Discord](https://discord.gg/envio) for assistance.
 
 ## Network-Related Errors
 
@@ -12271,7 +12271,7 @@ pnpm envio local db-migrate setup
 - Check network connectivity
 - Verify RPC endpoint performance
 - Consider increasing timeouts if possible
-- If persists, contact support through Discord
+- If persists, contact support through [Discord](https://discord.gg/envio)
 
 ---
 
@@ -12407,7 +12407,7 @@ CONTRACT_TYPE
 3. **Run validation early** with `pnpm codegen` to catch issues before spending time on implementation
 4. **Use prefixes for domain entities** (e.g., `TokenTransfer` instead of `Transfer`)
 
-If you encounter persistent issues with reserved words or need help refactoring your schema to avoid them, please reach out for support on our Discord community.
+If you encounter persistent issues with reserved words or need help refactoring your schema to avoid them, please reach out for support on our [Discord community](https://discord.gg/envio).
 
 ---
 
@@ -12444,8 +12444,8 @@ If you encounter persistent issues with reserved words or need help refactoring 
 | **Field**                     | **Value**                                                                                          |
 |-------------------------------|----------------------------------------------------------------------------------------------------|
 | **Arbitrum Chain ID**     | 42161                                                                                            |
-| **HyperSync URL Endpoint**    | https://arbitrum.hypersync.xyz or https://42161.hypersync.xyz |
-| **HyperRPC URL Endpoint**     | https://arbitrum.rpc.hypersync.xyz or https://42161.rpc.hypersync.xyz |
+| **HyperSync URL Endpoint**    | [https://arbitrum.hypersync.xyz](https://arbitrum.hypersync.xyz) or [https://42161.hypersync.xyz](https://42161.hypersync.xyz) |
+| **HyperRPC URL Endpoint**     | [https://arbitrum.rpc.hypersync.xyz](https://arbitrum.rpc.hypersync.xyz) or [https://42161.rpc.hypersync.xyz](https://42161.rpc.hypersync.xyz) |
 
 
 ### Defining Network Configurations
@@ -12473,7 +12473,7 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on Discord; we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---
 
@@ -12486,8 +12486,8 @@ Can’t find what you’re looking for or need support? Reach out to us on Disco
 | **Field**                     | **Value**                                                                                          |
 |-------------------------------|----------------------------------------------------------------------------------------------------|
 | **Eth Chain ID**     | 1                                                                                            |
-| **HyperSync URL Endpoint**    | https://eth.hypersync.xyz or https://1.hypersync.xyz |
-| **HyperRPC URL Endpoint**     | https://eth.rpc.hypersync.xyz or https://1.rpc.hypersync.xyz |
+| **HyperSync URL Endpoint**    | [https://eth.hypersync.xyz](https://eth.hypersync.xyz) or [https://1.hypersync.xyz](https://1.hypersync.xyz) |
+| **HyperRPC URL Endpoint**     | [https://eth.rpc.hypersync.xyz](https://eth.rpc.hypersync.xyz) or [https://1.rpc.hypersync.xyz](https://1.rpc.hypersync.xyz) |
 
 
 ### Defining Network Configurations
@@ -12515,7 +12515,7 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on Discord; we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---
 
@@ -12528,8 +12528,8 @@ Can’t find what you’re looking for or need support? Reach out to us on Disco
 | **Field**                     | **Value**                                                                                          |
 |-------------------------------|----------------------------------------------------------------------------------------------------|
 | **Optimism Chain ID**     | 10                                                                                            |
-| **HyperSync URL Endpoint**    | https://optimism.hypersync.xyz or https://10.hypersync.xyz |
-| **HyperRPC URL Endpoint**     | https://optimism.rpc.hypersync.xyz or https://10.rpc.hypersync.xyz |
+| **HyperSync URL Endpoint**    | [https://optimism.hypersync.xyz](https://optimism.hypersync.xyz) or [https://10.hypersync.xyz](https://10.hypersync.xyz) |
+| **HyperRPC URL Endpoint**     | [https://optimism.rpc.hypersync.xyz](https://optimism.rpc.hypersync.xyz) or [https://10.rpc.hypersync.xyz](https://10.rpc.hypersync.xyz) |
 
 
 ### Defining Network Configurations
@@ -12557,7 +12557,7 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on Discord; we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---
 
@@ -12570,8 +12570,8 @@ Can’t find what you’re looking for or need support? Reach out to us on Disco
 | **Field**                     | **Value**                                                                                          |
 |-------------------------------|----------------------------------------------------------------------------------------------------|
 | **Polygon Chain ID**     | 137                                                                                            |
-| **HyperSync URL Endpoint**    | https://polygon.hypersync.xyz or https://137.hypersync.xyz |
-| **HyperRPC URL Endpoint**     | https://polygon.rpc.hypersync.xyz or https://137.rpc.hypersync.xyz |
+| **HyperSync URL Endpoint**    | [https://polygon.hypersync.xyz](https://polygon.hypersync.xyz) or [https://137.hypersync.xyz](https://137.hypersync.xyz) |
+| **HyperRPC URL Endpoint**     | [https://polygon.rpc.hypersync.xyz](https://polygon.rpc.hypersync.xyz) or [https://137.rpc.hypersync.xyz](https://137.rpc.hypersync.xyz) |
 
 
 ### Defining Network Configurations
@@ -12599,7 +12599,7 @@ For more information on how to set up your config, define a schema, and write ev
 
 ### Support
 
-Can’t find what you’re looking for or need support? Reach out to us on Discord; we’re always happy to help!
+Can’t find what you’re looking for or need support? Reach out to us on [Discord](https://discord.gg/envio); we’re always happy to help!
 
 ---
 
@@ -12637,7 +12637,7 @@ pnpx envio@3.0.0-alpha.14 init svm
 
 ## Introduction
 
-Envio supports the Fuel Network on mainnet and testnet. This page shows how to use HyperIndex with Fuel’s architecture and features.
+Envio supports the [Fuel Network](https://fuel.network/) on mainnet and testnet. This page shows how to use HyperIndex with Fuel’s architecture and features.
 
 Fuel offers several advantages as a modular execution layer including:
 
@@ -12664,11 +12664,11 @@ Looking for inspiration? Check out these indexers built by projects in the Fuel 
 
 | Project                               | Type             | GitHub Repository                                                                 |
 | ------------------------------------- | ---------------- | --------------------------------------------------------------------------------- |
-| Spark             | Orderbook DEX    | github                        |
-| Mira              | AMM DEX          | github                                |
-| Thunder | NFT Marketplace  | github                          |
-| Swaylend     | Lending Protocol | github |
-| Greeter                               | Tutorial         | github                                |
+| [Spark](https://sprk.fi/)             | Orderbook DEX    | [github](https://github.com/compolabs/spark-envio-indexer)                        |
+| [Mira](https://mira.ly/)              | AMM DEX          | [github](https://github.com/mira-amm/mira-indexer)                                |
+| [Thunder](https://thundernft.market/) | NFT Marketplace  | [github](https://github.com/ThunderFuel/thunder-indexer)                          |
+| [Swaylend](https://swaylend.com/)     | Lending Protocol | [github](https://github.com/Swaylend/swaylend-monorepo/tree/develop/apps/indexer) |
+| Greeter                               | Tutorial         | [github](https://github.com/enviodev/fuel-greeter)                                |
 
 ### Features Supported on Fuel
 
@@ -12688,7 +12688,7 @@ Fuel's event model differs significantly from EVM. Instead of predefined events,
 
 ### LOG_DATA Receipts (Primary Event Type)
 
-The most common event type in Fuel is the `LOG_DATA` receipt, created by the `log` instruction in Sway contracts.
+The most common event type in Fuel is the `LOG_DATA` receipt, created by the `log` instruction in [Sway](https://docs.fuel.network/docs/sway/) contracts.
 
 Unlike Solidity's `emit` which requires predefined event structures, Sway's `log` function allows passing any data, providing greater flexibility.
 
@@ -12802,10 +12802,10 @@ HyperFuel provides:
 
 Access HyperFuel data using any of these clients:
 
-- **Rust**: hyperfuel-client-rust
-- **Python**: hyperfuel-client-python
-- **Node.js**: hyperfuel-client-node
-- **JSON API**: hyperfuel-json-api
+- **Rust**: [hyperfuel-client-rust](https://github.com/enviodev/hyperfuel-client-rust)
+- **Python**: [hyperfuel-client-python](https://github.com/enviodev/hyperfuel-client-python)
+- **Node.js**: [hyperfuel-client-node](https://github.com/enviodev/hyperfuel-client-node)
+- **JSON API**: [hyperfuel-json-api](https://github.com/enviodev/hyperfuel-json-api)
 
 ### HyperFuel Endpoints
 
@@ -12816,7 +12816,7 @@ For detailed information, see the HyperFuel documentation.
 
 ## About Fuel Network
 
-Fuel is an operating system purpose-built for Ethereum rollups with unique architecture focused on:
+[Fuel](https://fuel.network/) is an operating system purpose-built for Ethereum rollups with unique architecture focused on:
 
 - **P**arallelization: Execute transactions concurrently for higher throughput
 - **S**tate-minimized execution: Efficient storage and computation model
@@ -12826,18 +12826,18 @@ Powered by the FuelVM, Fuel expands Ethereum's capabilities without compromising
 
 ### Resources
 
-- Website
-- Twitter
-- Discord
-- Documentation
+- [Website](https://fuel.network/)
+- [Twitter](https://twitter.com/fuel_network)
+- [Discord](https://discord.com/invite/xfpK4Pe)
+- [Documentation](https://docs.fuel.network/)
 
 ## Need Help?
 
 If you encounter any issues with Fuel indexing, please:
 
 1. Check our Troubleshooting guides
-2. Join our Discord for community support
-3. Create an issue in our GitHub repository
+2. Join our [Discord](https://discord.gg/envio) for community support
+3. Create an issue in our [GitHub repository](https://github.com/enviodev/hyperindex)
 
 ---
 
@@ -12855,7 +12855,7 @@ If you encounter any issues with Fuel indexing, please:
 
 ## Our position
 
-We're devs and we value OS ethos too, that's why our licensing mirrors a lot of the benefits from open source licensing however Envio and its products do not use a recognized open source license by the OSI, we are however public and open and our licensing reflects this.
+We're devs and we value OS ethos too, that's why our licensing mirrors a lot of the benefits from open source licensing however Envio and its products do not use a recognized open source license by the [OSI](https://opensource.org/), we are however public and open and our licensing reflects this.
 
 Our future business model lies in Envio Cloud and HyperSync requests and so we are protecting this, but to ensure continuity and no vendor lock-in, developers are able to run and develop on their indexer without either. Either by self-hosting, which our license permits, or by specifying an RPC URL in their indexer configuration and thus bypassing HyperSync.
 

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -3,7 +3,7 @@ id: hyperindex-complete
 title: HyperIndex Complete Documentation
 sidebar_label: HyperIndex Complete Documentation
 slug: /hyperindex-complete
-description: Complete reference documentation for HyperIndex — Envio's blazing-fast multichain blockchain indexer. Covers setup, configuration, event handlers, multichain indexing, GraphQL APIs, and migration from TheGraph, Ponder, SQD, SubQuery, and more.
+description: Complete reference documentation for HyperIndex - Envio's blazing-fast multichain blockchain indexer. Covers setup, configuration, event handlers, multichain indexing, GraphQL APIs, and migration from TheGraph, Ponder, SQD, SubQuery, and more.
 keywords: [HyperIndex, blockchain indexer, multichain indexing, HyperSync, Envio, GraphQL, TheGraph alternative, EVM indexer, smart contract events, Ponder alternative, SQD alternative, SubQuery alternative]
 robots: noindex, nofollow
 ---
@@ -14,44 +14,35 @@ This document contains all HyperIndex documentation consolidated into a single f
 
 ---
 
-:::info Key Facts
+::::info Key Facts - HyperIndex
 
-- **What it is:** A blazing fast, developer friendly multichain blockchain indexer that transforms onchain events into structured, queryable data via GraphQL
+| | |
+|---|---|
+| **What it is** | A blazing-fast, developer-friendly multichain blockchain indexer that transforms on-chain events into structured, queryable databases with GraphQL APIs |
+| **Data engine** | Powered by HyperSync - up to 2000x faster than traditional RPC endpoints |
+| **Performance** | Ranked #1 fastest indexer in independent Sentio benchmarks (April 2025) - up to 6x faster than the nearest competitor, 63x faster than TheGraph |
+| **Supported chains** | 70+ EVM chains and Fuel, with new networks added regularly; all EVM-compatible chains supported via RPC |
+| **Languages** | TypeScript, JavaScript, ReScript |
+| **Key files** | `config.yaml` (indexer settings), `schema.graphql` (data schema), `src/EventHandlers.*` (event logic) |
+| **Prerequisites** | Node.js v22+, pnpm v8+, Docker Desktop (local dev only) |
+| **Deployment** | Hosted service (managed, no API token needed) or self-hosted |
+| **API token** | Required for local dev and self-hosted deployments from 3 November 2025 via `ENVIO_API_TOKEN` env variable |
+| **Query interface** | GraphQL API auto-generated from your schema |
+| **Multichain** | Native multichain indexing with `unordered_multichain_mode` support |
+| **Wildcard indexing** | Index by event signature rather than contract address |
+| **Migration** | Straightforward migration path from TheGraph subgraphs |
+| **Get started** | `pnpx envio init` |
+| **Support** | [Discord](https://discord.gg/envio) · [GitHub](https://github.com/enviodev) |
 
-- **Data engine:** Powered by HyperSync with up to 2000x faster performance than traditional RPC endpoints
-
-- **Performance:** Ranked #1 fastest indexer in independent Sentio benchmarks (April 2025), up to 6x faster than the nearest competitor and 63x faster than The Graph
-
-- **Supported chains:** <HyperSyncChainCount /> EVM chains and Fuel, with new networks added regularly. All EVM compatible chains supported via RPC
-
-- **Languages:** TypeScript, JavaScript, ReScript
-
-- **Key files:** config.yaml (indexer config), schema.graphql (data schema), src/EventHandlers.* (event logic)
-
-- **Prerequisites:** Node.js v22+, pnpm v8+, Docker Desktop (local dev only)
-
-- **Deployment:** Envio Cloud (managed, no API token needed) or self hosted
-
-- **API token:** Required for local dev and self hosted deployments via ENVIO_API_TOKEN env variable (from 3 November 2025)
-
-- **Query interface:** Auto generated GraphQL API from your schema
-
-- **Multichain:** Native multichain indexing with unordered_multichain_mode support
-
-- **Wildcard indexing:** Index by event signature instead of contract address
-
-- **Migration:** Straightforward migration path from The Graph subgraphs
-
-- **Get started:** npx envio init
-
-- **Support:** [Discord](https://discord.gg/envio) and [GitHub](https://github.com/enviodev)
-
-:::
-
+::::
 
 ## Overview
 
 **File:** `overview.md`
+
+
+  
+  
 
 
 **HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications.
@@ -82,8 +73,8 @@ For more details about API tokens, including how to generate and implement them,
 
 ## 🔗 Quick Links
 
-- [GitHub Repository](https://github.com/enviodev/hyperindex) ⭐
-- Join our [Discord Community](https://discord.gg/envio)
+- GitHub Repository ⭐
+- Join our Discord Community
 
 ---
 
@@ -122,6 +113,79 @@ You can customize your indexer by modifying these files to meet your specific re
 
 
 For a complete walkthrough of the process, refer to the Quickstart guide.
+
+---
+
+## Quickstart With Ai
+
+**File:** `quickstart-with-ai.md`
+
+Build an Envio HyperIndex indexer end-to-end with an AI coding assistant.
+
+Most developers now reach for an AI coding assistant before they open a file. This guide walks through an AI-centric flow for creating, developing, and deploying a HyperIndex indexer. It is semi-generic, so any capable AI coding assistant (Cursor, Windsurf, Copilot Agent, Continue, etc.) will work. That said, **we've seen the best results with Claude Code** and recommend starting there.
+
+:::tip Prefer the interactive flow?
+If you'd rather drive the CLI yourself, see Getting Started and the Quickstart.
+:::
+
+
+## Step 1. Give the Assistant Access to the Envio Docs (MCP)
+
+Envio ships a Model Context Protocol server so your AI assistant can search and read Envio documentation directly instead of guessing from stale training data.
+
+**Claude Code:**
+
+```bash
+claude mcp add --transport http envio-docs https://docs.envio.dev/mcp
+```
+
+**Cursor / VS Code / other MCP clients**, add the endpoint to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "envio-docs": {
+      "url": "https://docs.envio.dev/mcp"
+    }
+  }
+}
+```
+
+Full setup details in the MCP Server guide. If your assistant doesn't support MCP, you can still point it at the LLM-friendly docs bundle.
+
+
+## Step 3. Develop with the Built-in Claude Skills
+
+HyperIndex v3 ships with **Claude skills** that teach AI assistants how HyperIndex works: config, schema, handlers, loaders, dynamic contracts, testing, and migration checklists. When an assistant is attached to a v3 project, it can read these skills directly instead of inventing patterns.
+
+A productive loop with skills + the docs MCP looks like:
+
+1. Describe the behavior you want in plain English.
+2. Let the assistant edit `config.yaml`, `schema.graphql`, and `src/EventHandlers.*`.
+3. Ask it to run `pnpm envio codegen` and `pnpm dev` to validate.
+4. Iterate on failures together.
+
+The three files you'll spend most of your time in:
+
+- **`config.yaml`**: networks, contracts, events
+- **`schema.graphql`**: entities and relationships
+- **`src/EventHandlers.*`**: per-event logic
+
+
+## Step 5. Deploy Programmatically with `envio-cloud`
+
+Once your indexer runs locally, the `envio-cloud` CLI lets an assistant (or a CI job) deploy and manage the hosted indexer without opening the dashboard.
+
+```bash
+npm install -g envio-cloud
+
+envio-cloud login --token $ENVIO_GITHUB_TOKEN
+envio-cloud indexer add --name my-indexer --repo my-repo
+envio-cloud deployment status my-indexer  --watch-till-synced
+envio-cloud deployment logs my-indexer  --follow
+```
+
+Every command supports `-o json`, which makes it easy for assistants and scripts to parse results. Full reference: Envio Cloud CLI.
 
 ---
 
@@ -279,6 +343,104 @@ We encourage developers to run their own benchmarks. You can also use the templa
 
 ---
 
+## How to Migrate Using AI
+
+**File:** `migrate-with-ai.md`
+
+HyperIndex v3 includes built-in Claude skills that guide AI programming assistants through the full subgraph migration process, from understanding your existing logic to converting handlers and running quality checks. This is the recommended way to migrate complex subgraphs.
+
+## Prerequisites
+
+- An AI programming assistant (Cursor or Claude Code)
+- pnpm installed
+- HyperIndex v3 (Claude skills are available in v3)
+
+## Step 1: Initialize a Boilerplate HyperIndex Indexer
+
+Create a new HyperIndex indexer that indexes the same contracts and events as the subgraph you are migrating. Run the following in a new directory:
+
+```bash
+pnpx envio init
+```
+
+Follow the CLI prompts to set up the boilerplate indexer with the same contracts and events as your existing subgraph.
+
+:::caution
+The Claude skills are only available in HyperIndex v3. If the latest stable version is not v3, you need to specify a v3 version explicitly:
+
+```bash
+pnpx envio@3.0.0-alpha.21 init
+```
+
+Replace `3.0.0-alpha.21` with the latest available v3 version. You can find the latest releases here.
+:::
+
+## Step 2: Set Up a Monorepo Structure
+
+Create a parent directory that contains both your new HyperIndex boilerplate indexer and the existing subgraph repo you want to migrate:
+
+```
+my-migration/
+├── my-subgraph/          # Your existing subgraph repo
+└── my-hyperindex-indexer/ # The boilerplate HyperIndex indexer from Step 1
+```
+
+This structure gives your assistant visibility into both projects so it can read and understand your subgraph logic while writing the HyperIndex implementation.
+
+## Step 3: Run Your AI Programming Assistant
+
+Open the monorepo root with your AI programming assistant running there (for example, run Claude Code in the monorepo root or open the monorepo in Cursor). **Put your assistant in plan mode first**, then provide a prompt like the following (replace the repo names with your own):
+
+```xml
+
+This monorepo contains two indexers:
+- `my-subgraph/` — an existing Graph Protocol subgraph indexer (source of truth)
+- `my-hyperindex-indexer/` — a HyperIndex boilerplate scaffolded from the same
+  contracts (migration target)
+
+
+
+Migrate the subgraph indexer to a fully working HyperIndex indexer.
+Follow these phases in order:
+
+Phase 1 — Plan
+- Produce a migration plan mapping each subgraph component to its HyperIndex
+  equivalent.
+- Flag anything that has no direct equivalent and propose a workaround.
+- Do NOT write code yet.
+
+Phase 2 — Implement
+- Migrate the entire subgraph following the plan and skill guides.
+- Process one handler file at a time.
+- After each file, run `pnpm envio codegen` to validate, and verify it against
+  the migration checklist before moving on.
+
+Phase 3 — Verify
+- Walk through every checklist item from the migration skill and confirm it
+  passes.
+- Run any available build or type check commands.
+- List any items you could not complete and why.
+
+
+
+- Only modify files in `my-hyperindex-indexer/`. Do not change the subgraph repo.
+- Preserve all entity fields and event mappings from the subgraph.
+- Do not skip or summarize checklist items — execute every one.
+- If you are uncertain about a migration decision, pause and ask me.
+
+```
+
+:::tip
+- After migration, run `pnpm dev` to verify the indexer runs correctly
+- Use the Indexer Migration Validator to compare outputs between your subgraph and the new HyperIndex indexer
+:::
+
+## Manual Migration
+
+For a detailed manual migration guide covering the step by step conversion of subgraph.yaml, schema, and event handlers, see Migrate from The Graph.
+
+---
+
 ## Migrate from The Graph to Envio
 
 **File:** `migration-guide.md`
@@ -292,6 +454,10 @@ Please reach out to our team on Discord for personalized migration assistance.
 Migrating your existing subgraph to Envio's HyperIndex is designed to be a developer-friendly process. HyperIndex draws strong inspiration from The Graph’s subgraph architecture, which makes the migration simple, especially with the help of coding assistants like Cursor and AI tools (don't forget to use our ai friendly docs).
 
 The process is simple but requires a good understanding of the underlying concepts. If you are new to HyperIndex, we recommend starting with the Getting Started guide.
+
+:::tip Prefer AI-assisted migration?
+If you want an assistant-led workflow, see How to Migrate Using AI for a guided process that works in both Cursor and Claude Code.
+:::
 
 ## Why Migrate to HyperIndex?
 
@@ -467,12 +633,47 @@ context.Subscription.set(entity);
 
 HyperIndex is a powerful tool that can be used to index any contract. There are some features that are especially powerful that go above subgraph implementations and so in some cases you may want to optimise your migration to HyperIndex further to take advantage of these features. Here are some useful tips:
 
-- Use the `field_selection` option to add additional fields to your index. Doc here: field selection
+- Use `field_selection` to opt into optional transaction and block fields (e.g. `hash`, `status`, `gasUsed`) that are not included by default, see Transaction receipts for a migration-focused example and the field selection docs for the full list.
 - Use the `unordered_multichain_mode` option to enable unordered multichain mode, this is the most common need for multichain indexing. However comes with tradeoffs worth understanding. Doc here: unordered multichain mode
 - Use wildcard indexing to index by event signatures rather than by contract address.
 - HyperIndex uses the standard GraphQL query language, whereas TheGraph uses a custom GraphQL syntax. You can read about the differences and how to convert queries in our Query Conversion Guide. We also provide a query converter tool for backwards compatibility with existing TheGraph queries.
 - Loaders are a powerful feature to optimize historical sync performance. You can read more about them here.
 - HyperIndex is very flexible and can be used to index offchain data too or send messages to a queue etc for fetching external data, you can further optimise the fetching by using the effects api
+
+### Transaction receipts
+
+In The Graph, you opt into receipt data per-handler with `receipt: true` in `subgraph.yaml`:
+
+```yaml
+eventHandlers:
+  - event: Transfer(indexed address,indexed address,indexed uint256)
+    handler: handleTransfer
+    receipt: true
+````
+
+This makes `event.receipt` available inside the handler with fields like `status`, `gasUsed`, and `logs`.
+
+In HyperIndex, receipt-level fields are part of `transaction_fields` and must be requested via `field_selection` in `config.yaml`. There is no separate receipt object — the fields are accessed directly on `event.transaction`:
+
+```yaml
+field_selection:
+  transaction_fields:
+    - hash
+    - status # 1 = success, 0 = reverted
+    - gasUsed
+    - cumulativeGasUsed
+    - contractAddress # non-null for contract-creation transactions
+    - logsBloom
+```
+
+```typescript
+MyContract.Transfer.handler(async ({ event, context }) => {
+  const { status, gasUsed } = event.transaction;
+  // ...
+});
+```
+
+See the full list of available `transaction_fields` in the Configuration File docs.
 
 ## Validating Your Migration
 
@@ -485,7 +686,131 @@ If you discover helpful tips during your migration, we'd love contributions! Ope
 ## Getting Help
 
 **Join Our Discord**: The fastest way to get personalized help is through our Discord community.
+
+---
+
+## Migrate from Ponder to HyperIndex
+
+**File:** `migrate-from-ponder.md`
+
+> **Need help?** Reach out on Discord for personalized migration assistance.
+
+Migrating from Ponder to HyperIndex is straightforward — both frameworks use TypeScript, index EVM events, and expose a GraphQL API. The key differences are the config format, schema syntax, and entity operation API.
+
+If you are new to HyperIndex, start with the Getting Started guide first.
+
+:::tip Prefer AI-assisted migration?
+For an assistant-led workflow, see How to Migrate Using AI, which includes a shared process for Cursor and Claude Code.
+:::
+
+## Why Migrate to HyperIndex?
+
+- **Up to 158x faster** historical sync via HyperSync
+- **Multichain by default** — index any number of chains in one config
+- **Same language** — your TypeScript logic transfers directly
+
+## Migration Overview
+
+Migration has three steps:
+
+1. `ponder.config.ts` → `config.yaml`
+2. `ponder.schema.ts` → `schema.graphql`
+3. Event handlers — adapt syntax and entity operations
+
+At any point, run:
+
+```bash
+pnpm envio codegen   # validate config + schema, regenerate types
+pnpm dev             # run the indexer locally
 ```
+
+
+## Step 1: `ponder.config.ts` → `config.yaml`
+
+**Ponder**
+
+```typescript
+
+export default createConfig({
+  chains: {
+    mainnet: { id: 1, rpc: process.env.PONDER_RPC_URL_1 },
+  },
+  contracts: {
+    MyToken: {
+      abi: myTokenAbi,
+      chain: "mainnet",
+      address: "0xabc...",
+      startBlock: 18000000,
+    },
+  },
+});
+```
+
+**HyperIndex (v3)**
+
+```yaml
+# yaml-language-server: $schema=./node_modules/envio/evm.schema.json
+name: my-indexer
+
+contracts:
+  - name: MyToken
+    abi_file_path: ./abis/MyToken.json
+    handler: ./src/EventHandlers.ts
+    events:
+      - event: Transfer
+      - event: Approval
+
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: MyToken
+        address:
+          - 0xabc...
+        start_block: 18000000
+```
+
+> **v2 note**: HyperIndex v2 uses `networks` instead of `chains`. See the v2→v3 migration guide.
+
+Key differences:
+
+| Concept         | Ponder                          | HyperIndex                       |
+| --------------- | ------------------------------- | -------------------------------- |
+| Config format   | `ponder.config.ts` (TypeScript) | `config.yaml` (YAML)             |
+| Chain reference | Named + viem object             | Numeric chain ID                 |
+| RPC URL         | In config                       | `RPC_URL_` env var      |
+| ABI source      | TypeScript import               | JSON file (`abi_file_path`)      |
+| Events to index | Inferred from handlers          | Explicit `events:` list          |
+| Handler file    | Inferred                        | Explicit `handler:` per contract |
+
+**Convert your ABI**: Ponder uses TypeScript ABI exports (`as const`). HyperIndex needs a plain JSON file in `abis/`. Strip the `export const ... =` wrapper and `as const` and save as `.json`.
+
+### Field selection — accessing transaction and block fields
+
+By default, only a minimal set of fields is available on `event.transaction` and `event.block`. Fields like `event.transaction.hash` are `undefined` unless explicitly requested.
+
+```yaml
+events:
+  - event: Transfer
+    field_selection:
+      transaction_fields:
+        - hash
+```
+
+Or declare once at the top level to apply to all events:
+
+```yaml
+name: my-indexer
+
+field_selection:
+  transaction_fields:
+    - hash
+
+contracts:
+  # ...
+```
+
+See the full list of available fields in the Configuration File docs.
 
 ---
 
@@ -677,17 +1002,127 @@ Join our Discord if you need support. It is the fastest way to get direct help f
 
 ---
 
-## Migrate To V3
+## Migrate to HyperIndex V3
 
 **File:** `migrate-to-v3.md`
-
-# Migrate to HyperIndex V3 Alpha
 
 15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped 32 minor releases and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.
 
 HyperIndex V3 Alpha focuses on modernizing the codebase and laying the foundation for many more months of development. This guide walks you through upgrading from V2 to V3.
 
 ## New Features
+
+### Unified Handlers API
+
+In V3 all handler registrations now happen through a single `indexer` value. Contract-specific exports (`ERC20.Transfer.handler`, `UniV3.PoolFactory.contractRegister`, etc.) have been removed in favor of `indexer.onEvent`, `indexer.contractRegister`, and `indexer.onBlock`.
+
+**Event handlers** with `indexer.onEvent`:
+
+```typescript
+
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: ({ chain }) => ({
+      params: [
+        { from: chain.Safe.addresses },
+        { to: chain.Safe.addresses },
+      ],
+    }),
+  },
+  async ({ event, context }) => {
+    // Handler logic
+  },
+);
+```
+
+**Dynamic contracts** with `indexer.contractRegister`:
+
+```typescript
+
+indexer.contractRegister(
+  {
+    contract: "UniV3",
+    event: "PoolFactory",
+  },
+  async ({ event, context }) => {
+    context.chain.Pool.add(event.params.poolAddress);
+  },
+);
+```
+
+**Block handlers** with `indexer.onBlock` consolidate across chains in a single call:
+
+```typescript
+
+indexer.onBlock(
+  { name: "EveryBlock" },
+  async ({ block, context }) => {
+    // Handler logic
+  },
+);
+```
+
+For chain-specific or interval-based block handlers, use the `where` callback:
+
+```typescript
+indexer.onBlock(
+  {
+    name: "Ranges",
+    where: ({ chain }) => {
+      if (chain.id !== 1) return false;
+      return {
+        block: {
+          number: {
+            _gte: 20_000_000,
+            _lte: 22_000_000,
+            _every: 100,
+          },
+        },
+      };
+    },
+  },
+  async ({ block, context }) => {
+    // Handler logic
+  },
+);
+```
+
+### Per-Event Start Block
+
+Handlers can specify custom start blocks per chain via `where.block.number._gte`, overriding contract and chain configuration:
+
+```typescript
+indexer.onEvent(
+  {
+    contract: "UniV4",
+    event: "Pool",
+    where: ({ chain }) => {
+      let startBlock: number;
+      switch (chain.id) {
+        case 1:
+          startBlock = 18_000_000;
+          break;
+        case 8453:
+          startBlock = 2_000_000;
+          break;
+        default: {
+          const _exhaustive: never = chain.id;
+          return false;
+        }
+      }
+      return {
+        block: { number: { _gte: startBlock } },
+      };
+    },
+  },
+  async ({ event, context }) => {
+    // Handler logic
+  },
+);
+```
 
 ### CommonJS → ESM
 
@@ -707,17 +1142,21 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 // Load data before registering handlers
 const addressesFromServer = await loadWhitelistedAddresses();
 
-ERC20.Transfer.handler(
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: {
+      params: [
+        { from: ZERO_ADDRESS, to: addressesFromServer },
+        { from: addressesFromServer, to: ZERO_ADDRESS },
+      ],
+    },
+  },
   async ({ event, context }) => {
     // ... your handler logic
   },
-  {
-    wildcard: true,
-    eventFilters: [
-      { from: ZERO_ADDRESS, to: addressesFromServer },
-      { from: addressesFromServer, to: ZERO_ADDRESS },
-    ],
-  }
 );
 ```
 
@@ -754,15 +1193,19 @@ In this case, the RPC won't be used for historical sync but will be used as the 
 The Handler Context object provides chain state via the `chain` property:
 
 ```typescript
-ERC20.Approval.handler(async ({ context }) => {
-  console.log(context.chain.id); // 1 - The chain id of the event
-  console.log(context.chain.isLive); // true - Whether the event chain is indexing at the head
-});
+
+indexer.onEvent(
+  { contract: "ERC20", event: "Approval" },
+  async ({ context }) => {
+    console.log(context.chain.id); // 1 - The chain id of the event
+    console.log(context.chain.isRealtime); // true - Whether the indexer entered realtime mode
+  },
+);
 ```
 
 ### Indexer State & Config
 
-As a replacement for the deprecated and removed `getGeneratedByChainId`, we introduce the `indexer` value. It provides nicely typed chains and contract data from your config, as well as the current indexing state, such as `isLive` and `addresses`. Use `indexer` either at the top level of the file or directly from handlers. It returns the latest indexer state.
+As a replacement for the deprecated and removed `getGeneratedByChainId`, we introduce the `indexer` value. It provides nicely typed chains and contract data from your config, as well as the current indexing state, such as `isRealtime` and `addresses`. Use `indexer` either at the top level of the file or directly from handlers. It returns the latest indexer state.
 
 With this change, we also introduce new official types: `Indexer`, `EvmChainId`, `FuelChainId`, and `SvmChainId`.
 
@@ -774,41 +1217,54 @@ indexer.chainIds; // [1, 42161, 10, 8453, 137, 56]
 indexer.chains[1].id; // 1
 indexer.chains[1].startBlock; // 0
 indexer.chains[1].endBlock; // undefined
-indexer.chains[1].isLive; // false
+indexer.chains[1].isRealtime; // false
 indexer.chains[1].PoolManager.name; // "PoolManager"
 indexer.chains[1].PoolManager.abi; // unknown[]
 indexer.chains[1].PoolManager.addresses; // ["0x000000000004444c5dc75cB358380D2e3dE08A90"]
 ```
 
-### Conditional Event Handlers
-
-Now it's possible to return a boolean value from the `eventFilters` function to disable or enable the handler conditionally.
+On indexer restart, reading `indexer` at the top level of a handler file returns values restored from the database — including dynamically registered contract addresses — rather than only what's declared in `config.yaml`:
 
 ```typescript
-ERC20.Transfer.handler(
-  async ({ event, context }) => {
-    // ... your handler logic
-  },
+
+// Includes initial + dynamically registered addresses persisted in the DB
+console.log(indexer.chains.eth.Pool.addresses);
+```
+
+### Conditional Event Handlers
+
+Now it's possible to return a boolean value from the `where` function to disable or enable the handler conditionally.
+
+```typescript
+
+indexer.onEvent(
   {
+    contract: "ERC20",
+    event: "Transfer",
     wildcard: true,
-    eventFilters: ({ chainId }) => {
+    where: ({ chain }) => {
       // Skip all ERC20 on Polygon
-      if (chainId === 137) {
+      if (chain.id === 137) {
         return false;
       }
 
       // Track all ERC20 on Ethereum Mainnet
-      if (chainId === 1) {
+      if (chain.id === 1) {
         return true;
       }
 
       // Track only whitelisted addresses on other chains
-      return [
-        { from: ZERO_ADDRESS, to: WHITELISTED_ADDRESSES[chainId] },
-        { from: WHITELISTED_ADDRESSES[chainId], to: ZERO_ADDRESS },
-      ];
+      return {
+        params: [
+          { from: ZERO_ADDRESS, to: WHITELISTED_ADDRESSES[chain.id] },
+          { from: WHITELISTED_ADDRESSES[chain.id], to: ZERO_ADDRESS },
+        ],
+      };
     },
-  }
+  },
+  async ({ event, context }) => {
+    // ... your handler logic
+  },
 );
 ```
 
@@ -839,7 +1295,7 @@ chains:
 
 ### ClickHouse Storage (Experimental)
 
-HyperIndex can run with multiple storage backends at the same time. Postgres remains the primary database, and entities can additionally be written to a ClickHouse database that is restart- and reorg-resistant. Prometheus metrics carry a storage-name label so you can distinguish backends.
+HyperIndex can now run with multiple storage backends at the same time. Postgres remains the primary database, and entities can additionally be written to a ClickHouse database that is restart- and reorg-resistant. Prometheus metrics carry a storage-name label so you can distinguish backends.
 
 Enable both backends in `config.yaml`:
 
@@ -862,6 +1318,10 @@ Multiple updates on the HyperSync side to achieve smaller latency and less traff
 - Server-Sent Events instead of polling to get updates about new blocks
 - CapnProto instead of JSON for query serialization
 - Cache for queries with repetitive filters - huge egress saving when indexing thousands of addresses
+- Improved connection establishment behind a proxy
+- Configurable log level support via `ENVIO_HYPERSYNC_LOG_LEVEL` environment variable
+- Automatic rate-limiting handling on the client side
+- Better reconnection logic, logging, and fallbacks for HyperSync SSE and RPC WebSocket height streaming for more stable indexing at the chain head
 
 ### Fuel Block Handler Support
 
@@ -869,12 +1329,12 @@ Block handlers are now supported for Fuel indexing.
 
 ### Solana Support (Experimental)
 
-HyperIndex now supports Solana with RPC as a source. This feature is experimental and may undergo minor breaking changes.
+HyperIndex now supports Solana with RPC as a source. This feature is experimental and may undergo minor breaking changes. Solana exposes its block-stream handler as `indexer.onSlot` (rather than `onBlock`) to match Solana's slot-based model.
 
 To initialize a Solana project:
 
 ```bash
-pnpx envio@3.0.0-alpha.14 init svm
+pnpx envio@3.0.0-rc.0 init svm
 ```
 
 See the Solana documentation for more details.
@@ -883,7 +1343,7 @@ See the Solana documentation for more details.
 
 - Removed language selection to prefer TypeScript by default
 - Cleaned up templates to follow the latest good practices
-- Added new templates to highlight HyperIndex features, starting with: `Feature: Factory Contract`
+- Added new templates to highlight HyperIndex features: `Feature: Factory Contract`, `Feature: External Calls`
 - Pre-configured GitHub Actions workflow for running tests and initialized git repository
 - Generated projects include Cursor/Claude skills to support agent-driven development
 
@@ -907,53 +1367,47 @@ Preload optimization is now enabled by default, replacing the previous `loaders`
 
 We gave our TUI some love, making it look more beautiful and compact. It also consumes fewer resources, shares a link to the Hasura playground, and dynamically adjusts to the terminal width.
 
+The TUI is now auto-disabled in CI environments and when running under AI agents, so logs stay clean without manual configuration. The legacy `TUI_OFF=true` environment variable was renamed to `ENVIO_TUI=false`.
+
 !TUI
 
-### New Testing Framework (Experimental)
+### New Testing Framework
 
-We introduced a new testing framework that allows you to test handlers' logic using real blockchain data and programmatically debug code without repetitive local runs. Key capabilities include:
-
-- Testing block and event handlers together
-- Snapshot testing support
-- Parallel test execution via worker thread isolation
+HyperIndex ships a purpose-built testing framework powered by `createTestIndexer()`. Write tests against the same indexer that runs in production — no database, no Docker, no manual mock wiring.
 
 The framework integrates with Vitest, replacing the previous mocha/chai setup with a single package that doesn't require configuration by default and includes snapshot testing out-of-the-box. It also provides typed test assertions and utilities to read/write entities in-between processing runs.
+
+#### Three ways to feed events
+
+**1. Auto-exit** — processes the first block with matching events, then exits. Each subsequent call continues where the last one stopped. Zero config needed.
 
 ```typescript
 
 
-describe("Indexer Testing", () => {
-  it("Should create accounts from ERC20 Transfer events", async () => {
+describe("ERC20 indexer", () => {
+  it("processes the first block with events", async (t) => {
     const indexer = createTestIndexer();
 
-    expect(
-      await indexer.process({
-        chains: {
-          1: {
-            startBlock: 10_861_674,
-            endBlock: 10_861_674,
-          },
-        },
-      }),
-      "Should find the first mint at block 10_861_674"
-    ).toMatchInlineSnapshot(`
+    const result = await indexer.process({ chains: { 1: {} } });
+
+    // Auto-filled by Vitest on first run — just review and commit
+    t.expect(result).toMatchInlineSnapshot(`
       {
         "changes": [
           {
-            "Account": {
+            "Transfer": {
               "sets": [
                 {
-                  "balance": -1000000000000000000000000000n,
-                  "id": "0x0000000000000000000000000000000000000000",
-                },
-                {
-                  "balance": 1000000000000000000000000000n,
-                  "id": "0x41653c7d61609d856f29355e404f310ec4142cfb",
+                  "blockNumber": 10861674,
+                  "from": "0x0000000000000000000000000000000000000000",
+                  "id": "1-10861674-23",
+                  "to": "0x41653c7d61609D856f29355E404F310Ec4142Cfb",
+                  "transactionHash": "0x4b37d2f343608457ca...",
+                  "value": 1000000000000000000000000000n,
                 },
               ],
             },
             "block": 10861674,
-            "blockHash": "0x32e4dd857b5b7e756551a00271e44b61dbda0a91db951cf79a3e58adb28f5c09",
             "chainId": 1,
             "eventsProcessed": 1,
           },
@@ -964,7 +1418,45 @@ describe("Indexer Testing", () => {
 });
 ```
 
-The test indexer also exposes chain information and provides `Entity.get`/`Entity.set` for reading and writing entities in-between processing runs:
+**2. Explicit block range** — pin to specific blocks for deterministic CI snapshots.
+
+```typescript
+const result = await indexer.process({
+  chains: {
+    1: {
+      startBlock: 10_861_674,
+      endBlock: 10_861_674,
+    },
+  },
+});
+```
+
+**3. Simulate** — feed typed synthetic events for pure unit tests. No network, no block ranges.
+
+```typescript
+await indexer.process({
+  chains: {
+    137: {
+      simulate: [
+        {
+          contract: "Greeter",
+          event: "NewGreeting",
+          params: { greeting: "Hello", user: "0x123..." },
+        },
+      ],
+    },
+  },
+});
+```
+
+#### Key capabilities
+
+- **Snapshot-driven assertions** — `result.changes` captures every entity set/delete per block. Pair with `toMatchInlineSnapshot` for auto-generated, reviewable snapshots.
+- **Direct entity access** — `indexer.Entity.get()`, `.getOrThrow()`, `.getAll()`, and `.set()` for reading and presetting state.
+- **Real pipeline, real confidence** — tests exercise the full indexer pipeline including dynamic contract registration, multi-chain support, and handler context.
+- **Parallel test execution** via worker thread isolation.
+
+The test indexer also exposes chain information:
 
 ```typescript
 const indexer = createTestIndexer();
@@ -991,6 +1483,35 @@ The `envio init` command now supports contracts with nested tuples in event sign
 ### PostgreSQL Update for Local Docker Compose
 
 The local development Docker Compose setup now uses PostgreSQL 18.1 (upgraded from 17.5).
+
+### `contractName` and `eventName` on Event
+
+Events now include `contractName` and `eventName` fields, making it easier to identify which contract and event you're working with in handlers:
+
+```typescript
+
+indexer.onEvent(
+  { contract: "ERC20", event: "Transfer" },
+  async ({ event }) => {
+    console.log(event.contractName); // "ERC20"
+    console.log(event.eventName);    // "Transfer"
+  },
+);
+```
+
+### New Official Exported Types
+
+Generated code now exports official generic types for entities, enums, and events. These replace the previous contract-specific type exports:
+
+```typescript
+import type {
+  MyEntity,        // Still exported but Entity is preferred
+  Entity,          // Generic entity type — use as Entity
+  Enum,            // Generic enum type — use as Enum (replaces direct MyEnum export)
+  EvmEvent,        // Generic event type — use as EvmEvent
+                   // Access specific fields: EvmEvent["block"]
+} from "envio";
+```
 
 ### Support for DESC Indices
 
@@ -1038,9 +1559,149 @@ const transfers = await context.Transfer.getWhere.from.eq("0x123...");
 const transfers = await context.Transfer.getWhere({ from: { _eq: "0x123..." } });
 ```
 
+Additionally, three new filter operators are available following Hasura-style conventions:
+
+```typescript
+context.Entity.getWhere({ amount: { _gte: 100n } })
+context.Entity.getWhere({ amount: { _lte: 500n } })
+context.Entity.getWhere({ status: { _in: ["active", "pending"] } })
+```
+
 ### Direct RPC Client
 
 Replaced Ethers.js with a direct RPC client implementation, reducing dependencies and improving performance.
+
+### Block Lag Configuration
+
+A per-chain `block_lag` option to index behind the chain head by a specified number of blocks. Replaces the global `ENVIO_INDEXING_BLOCK_LAG` environment variable. Defaults to 0. This is for advanced use cases — only use it if you know what you're doing.
+
+```yaml
+chains:
+  - id: 1
+    block_lag: 5
+```
+
+### Official `/metrics` Endpoint
+
+Prometheus metrics are now official. We cleaned up metric names, switched time units to seconds instead of milliseconds, and followed Prometheus naming conventions more closely. Metrics also cover data points previously available only via the `--bench` feature. A separate `/metrics/runtime` endpoint with a dedicated Prometheus registry is available for runtime metrics, isolated from the default `/metrics` endpoint.
+
+Starting from the v3.0.0 release, Prometheus metrics will follow semver and be documented.
+
+Breaking changes:
+
+- Cleaned up metric names and switched time units from milliseconds to seconds
+- Removed `--bench` support — use the `/metrics` endpoint instead
+
+Use the new `envio metrics` CLI command to fetch the Prometheus metrics of a locally running indexer without curling the endpoint manually.
+
+### Continue on Config Change
+
+HyperIndex can now keep indexing through some `config.yaml` changes — `rpc` configuration is the first to land — instead of erroring out on every restart. Where a change is incompatible, the CLI prints exactly which fields were touched and offers two clear options (revert, or `envio dev -r` to wipe and re-index). More flexibility will be unlocked over time; open a GitHub issue if you need a specific field supported.
+
+### Double Handler Registration
+
+It's now possible to register multiple handlers for the same event with similar filters:
+
+```typescript
+
+indexer.onEvent(
+  { contract: "ERC20", event: "Transfer" },
+  async ({ event, context }) => {
+    // Your logic here
+  },
+);
+
+indexer.onEvent(
+  { contract: "ERC20", event: "Transfer" },
+  async ({ event, context }) => {
+    // And here
+  },
+);
+```
+
+### Improved Multiple Data-Sources Support
+
+After switching to a fallback source, HyperIndex now attempts to recover to the primary source 60 seconds later. Previously, it would stay on the fallback until the fallback was down or the indexer was restarted. The source selection logic has also been improved for better indexing resilience and stricter enforcement of the `realtime` mode configuration.
+
+### Updated Dev Docker Flow
+
+`envio dev` no longer uses a generated Docker Compose file and manages containers, network, and volumes directly for greater flexibility. For example, disabling Hasura with `ENVIO_HASURA` now prevents `envio dev` from pulling the Hasura image. Use `envio dev --restart` (or `-r`) to forcefully clear the database even if there are no config changes detected.
+
+### Envio Dev Update
+
+`envio dev` no longer automatically resets the database on incompatible config or schema changes. Use `envio dev -r` to explicitly allow this.
+
+### Envio Start Update
+
+`envio start` now has a clear role: to run HyperIndex in the production environment. Use `envio dev` for local development to enable debugging with Dev Console.
+
+### Optimized `envio codegen`
+
+`envio codegen` is now near-instant. We no longer run `pnpm i` for the `generated` package, and we no longer recompile ReScript every time you change `config.yaml` or `schema.graphql`. The output is also a lot quieter.
+
+### Smaller `envio` Package (-88MB)
+
+By eliminating dynamically generated ReScript code, we no longer need to ship or run a ReScript compiler at runtime. The published npm package shrank from 141MB to 53MB.
+
+### No Hard pnpm Requirement
+
+Internal use of pnpm is gone. The `generated` package no longer has its own dependency tree, so HyperIndex works with whichever package manager you prefer.
+
+### Bun Support
+
+Run HyperIndex on Bun:
+
+```bash
+bun --bun envio dev
+```
+
+### Choose Your Package Manager on `envio init`
+
+`envio init` now accepts `--package-manager=pnpm|npm|bun|yarn` so you can scaffold projects without committing to pnpm.
+
+### Better Tuples Developer Experience
+
+Solidity struct components used to be generated as positional tuples in handler params, which made handler code awkward. They are now generated as objects with named fields:
+
+```solidity
+struct CreateEventCommon {
+  address funder;
+  address sender;
+  address recipient;
+  Lockup.CreateAmounts amounts;
+  IERC20 token;
+  bool cancelable;
+  bool transferable;
+  Lockup.Timestamps timestamps;
+  string shape;
+  address broker;
+}
+
+event CreateLockupTranchedStream(
+  uint256 indexed streamId,
+  Lockup.CreateEventCommon commonParams,
+  LockupTranched.Tranche[] tranches
+);
+```
+
+```ts
+// Before
+event.params.commonParams[5];
+event.params.commonParams[3][0];
+
+// After
+event.params.commonParams.cancelable;
+event.params.commonParams.amounts.deposit;
+```
+
+### Improved Multichain Backfill
+
+For large multichain indexers, HyperIndex now throttles chains that have already reached the head so they don't compete for resources while the rest finish backfilling. Once every chain has caught up, throttling is lifted and all chains continue indexing equally.
+
+### Toolchain Upgrades
+
+- ReScript upgraded from v11 to v12 (internally and in `envio init` templates)
+- TypeScript upgraded from v5 to v6 (internally and in `envio init` templates)
 
 ## Breaking Changes
 
@@ -1051,12 +1712,18 @@ Replaced Ethers.js with a direct RPC client implementation, reducing dependencie
 
 ### Handler API Changes
 
+- **Unified handler registration via `indexer`** — contract-specific exports were removed. Replace `Contract.Event.handler(handler, options)` with `indexer.onEvent({ contract, event, ...options }, handler)`. Replace `Contract.Event.contractRegister(...)` with `indexer.contractRegister({ contract, event }, ...)`. The old API has been hard removed and no longer works.
+- **Dynamic contract registration** — `context.add(address)` is replaced with `context.chain..add(address)`.
+- **`eventFilters` renamed to `where`** — the `where` callback receives `{ chain }` (not `{ chainId }`) and returns `false`, `true`, or `{ params: [...], block?: { number: { _gte, _lte, _every } } }`. The previous array shorthand is no longer accepted at the top level — wrap it in `{ params: [...] }`.
+- **Block handlers consolidated** — the standalone `onBlock` export and per-chain `forEach` registration are gone. Use a single `indexer.onBlock({ name, where? }, handler)` call. For chain-specific or interval-based handlers, return `{ block: { number: { _gte, _lte, _every } } }` from `where`, or `false` to skip a chain.
+- **Per-event start block** — handlers can now override the configured start block per chain via `where.block.number._gte`.
 - Removed `experimental_createEffect` in favor of `createEffect`
 - Renamed transaction field `kind` to `type`
 - For block handlers: `block.chainId` is removed in favor of `context.chain.id`
 - `Address` type changed from `string` to `` `0x${string}` ``
-- Removed `transaction.chainId` from field selection - use `context.chain.id` or `event.chainId` instead
-- **`getWhere` API redesigned** - changed from `context.Entity.getWhere.fieldName.eq(value)` to `context.Entity.getWhere({ fieldName: { _eq: value } })` using GraphQL-style filter syntax
+- Removed `transaction.chainId` from field selection — use `context.chain.id` or `event.chainId` instead
+- **`getWhere` API redesigned** — changed from `context.Entity.getWhere.fieldName.eq(value)` to `context.Entity.getWhere({ fieldName: { _eq: value } })` using GraphQL-style filter syntax
+- Events now include `contractName` and `eventName` fields
 
 ### config.yaml Changes
 
@@ -1068,6 +1735,7 @@ Replaced Ethers.js with a direct RPC client implementation, reducing dependencie
 - Removed `preRegisterDynamicContracts` option
 - Removed `event_decoder` option (the Rust-based decoder is now the only implementation)
 - Removed `rpc_config` in favor of `rpc`, which now supports multiple URLs, `for` mode (`sync`, `realtime`, `fallback`), and WebSocket configuration (see RPC for Realtime Indexing)
+- Removed the `output` flag — generated types are always emitted to `.envio/` at the project root
 
 ### HyperSync API Token Required
 
@@ -1082,6 +1750,8 @@ export ENVIO_API_TOKEN=your_token_here
 - Removed `UNSTABLE__TEMP_UNORDERED_HEAD_MODE` environment variable
 - Removed `UNORDERED_MULTICHAIN_MODE` environment variable
 - Removed `MAX_BATCH_SIZE` environment variable (use `full_batch_size` in config.yaml instead)
+- Renamed `ENVIO_PG_PUBLIC_SCHEMA` to `ENVIO_PG_SCHEMA` (the old name is still supported until v4)
+- Renamed `TUI_OFF=true` to `ENVIO_TUI=false` (TUI is also auto-disabled in CI environments and when running under AI agents)
 
 ### Generated Code Changes
 
@@ -1089,11 +1759,95 @@ export ENVIO_API_TOKEN=your_token_here
 - Removed internal `ContractType` enum (allows longer contract names)
 - Removed `getGeneratedByChainId` (use `indexer` value instead)
 - **Lowercased entity types removed**: Generated code no longer exports lowercased entity types (e.g., `transfer`). Use capitalized names instead (e.g., `Transfer`)
-- Entity array field values are now typed as `readonly` - update any code that directly mutates array fields
+- Entity array field values are now typed as `readonly` — update any code that directly mutates array fields
+- `S.nullable` schema type now returns `null` instead of `undefined`
 
-### Metrics Changes
+### CLI Behavior Changes
 
-- Renamed `chain_block_height` Prometheus metric to `envio_indexing_known_height`
+- `envio dev` no longer auto-resets the database. Use `envio dev --restart` (or `-r`) to clear it explicitly.
+- `envio start` is now production-only — use `envio dev` for local development.
+
+### Deprecated: `MockDb` Testing API
+
+The `MockDb` testing API has been removed. Migrate to `createTestIndexer()` with `simulate`:
+
+```diff
+-import { TestHelpers, type User } from "generated";
+-const { MockDb, Greeter, Addresses } = TestHelpers;
++import { createTestIndexer, type User, TestHelpers } from "envio";
++const { Addresses } = TestHelpers;
+
+ it("A NewGreeting event creates a User entity", async (t) => {
+-  const mockDbInitial = MockDb.createMockDb();
++  const indexer = createTestIndexer();
+   const userAddress = Addresses.defaultAddress;
+   const greeting = "Hi there";
+
+-  const mockNewGreetingEvent = Greeter.NewGreeting.createMockEvent({
+-    greeting: greeting,
+-    user: userAddress,
+-  });
+-
+-  const updatedMockDb = await Greeter.NewGreeting.processEvent({
+-    event: mockNewGreetingEvent,
+-    mockDb: mockDbInitial,
+-  });
++  await indexer.process({
++    chains: {
++      137: {
++        simulate: [
++          {
++            contract: "Greeter",
++            event: "NewGreeting",
++            params: { greeting, user: userAddress },
++          },
++        ],
++      },
++    },
++  });
+
+   const expectedUserEntity: User = {
+     id: userAddress,
+     latestGreeting: greeting,
+     numberOfGreetings: 1,
+     greetings: [greeting],
+   };
+
+-  const actualUserEntity = updatedMockDb.entities.User.get(userAddress);
++  const actualUserEntity = await indexer.User.getOrThrow(userAddress);
+   t.expect(actualUserEntity).toEqual(expectedUserEntity);
+ });
+```
+
+#### MockDb Migration Cheat Sheet
+
+| Old (`MockDb`) | New (`createTestIndexer`) |
+|---|---|
+| `MockDb.createMockDb()` | `createTestIndexer()` |
+| `Contract.Event.createMockEvent({...})` | Inline in `simulate: [{ contract, event, params }]` |
+| `Contract.Event.processEvent({event, mockDb})` | `indexer.process({ chains: { id: { simulate } } })` |
+| `mockDb.entities.Entity.get(id)` | `await indexer.Entity.getOrThrow(id)` |
+| `mockDb.entities.Entity.set({...})` | `indexer.Entity.set({...})` |
+| Manual handler threading & event chaining | Automatic — pass multiple events in the `simulate` array |
+
+### Deprecated: Contract-Specific Type Exports
+
+Generated code no longer exports contract-specific event log types (e.g., `ERC20_Transfer_eventLog`) or direct enum types (e.g., `MyEnum`). Use the new generic types instead:
+
+| Old | New |
+|---|---|
+| `ERC20_Transfer_eventLog` | `EvmEvent` |
+| `ERC20_Transfer_block` | `EvmEvent["block"]` |
+| `MyEnum` (direct export) | `Enum` |
+| `MyEntity` | `Entity` (preferred) |
+
+### Postgres Column Updates
+
+- `raw_events.event_id`: `NUMERIC` → `BIGINT`
+- `raw_events.serial`: `SERIAL` → `BIGSERIAL`
+- `envio_chains.events_processed`: `INTEGER` → `BIGINT`
+- `envio_checkpoints.id`: `INTEGER` → `BIGINT`
+- Deprecated `envio_chains._num_batches_fetched` — always returns 0 for backward compatibility
 
 ## Fixes
 
@@ -1101,6 +1855,9 @@ export ENVIO_API_TOKEN=your_token_here
 - Fixed checksum for addresses returned by RPC in lowercase
 - Fixed incorrect validation of transactions `to` field returned by RPC
 - Fixed OOM error on RPC request crashing loop
+- Fixed an edge case where a multichain indexer could freeze during a rollback on reorg (also backported to v2.32.10)
+- Fixed external Postgres database support via `ENVIO_PG_HOST`
+- Fixed `S.nullable` schema type to be `T | null` instead of `T | undefined`
 
 ## Migration Guide
 
@@ -1138,10 +1895,12 @@ Update your `package.json` with the following changes:
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "envio": "3.0.0-alpha.14"
+    "envio": "3.0.0-rc.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.3"
+    "@types/node": "24.12.2",
+    "typescript": "6.0.3",
+    "vitest": "4.1.0"
   }
 }
 ```
@@ -1149,6 +1908,16 @@ Update your `package.json` with the following changes:
 :::warning
 Adding `"type": "module"` is **required** for V3. Without it, your project will fail to start due to ESM import errors.
 :::
+
+**Remove the `generated` package.** As of `v3.0.0-alpha.24`, the local `generated` package no longer exists — types are emitted to `.envio/types.d.ts` (git-ignored) and wired up via a small `envio-env.d.ts` file at the project root. Drop the entry from `package.json` if you still have it:
+
+```diff
+-  "optionalDependencies": {
+-    "generated": "./generated"
+-  },
+```
+
+Re-run `envio codegen` after upgrading; everything you previously imported from `generated` is now exported from `envio`.
 
 **If you use testing with Mocha (recommended: migrate to Vitest):**
 
@@ -1245,7 +2014,8 @@ Update your `tsconfig.json` to support ESM:
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"]
+    "lib": ["es2022"],
+    "types": ["node"]
   }
 }
 ```
@@ -1278,7 +2048,7 @@ chains:
 
 **Update multichain mode (if applicable):**
 
-If you had `unordered_multichain_mode: true`, remove it - this is now the default. If you need ordered multichain behavior, explicitly set:
+If you had `unordered_multichain_mode: true`, remove it — this is now the default. If you need ordered multichain behavior, explicitly set:
 
 ```yaml
 multichain: ordered
@@ -1292,12 +2062,12 @@ multichain: ordered
 
 Remove the following options from your config if present:
 
-- `loaders` - now always enabled via Preload Optimization
-- `preload_handlers` - now always enabled
-- `preRegisterDynamicContracts` - no longer needed
-- `unordered_multichain_mode` - replaced with `multichain` option
-- `event_decoder` - the Rust-based decoder is now the only implementation
-- `rpc_config` - replaced with `rpc` (see Breaking Changes)
+- `loaders` — now always enabled via Preload Optimization
+- `preload_handlers` — now always enabled
+- `preRegisterDynamicContracts` — no longer needed
+- `unordered_multichain_mode` — replaced with `multichain` option
+- `event_decoder` — the Rust-based decoder is now the only implementation
+- `rpc_config` — replaced with `rpc` (see Breaking Changes)
 
 **New option for batch size:**
 
@@ -1334,14 +2104,98 @@ ENVIO_API_TOKEN=your_token_here
 
 - `UNSTABLE__TEMP_UNORDERED_HEAD_MODE`
 - `UNORDERED_MULTICHAIN_MODE`
-- `MAX_BATCH_SIZE` - use `full_batch_size` in config.yaml instead
+- `MAX_BATCH_SIZE` — use `full_batch_size` in config.yaml instead
 
 ### Step 5: Update Handler Code
+
+**Migrate to the unified `indexer` API:**
+
+All contract-specific handler exports (`ERC20.Transfer.handler`, `Greeter.NewGreeting.contractRegister`, etc.) have been removed. Register every handler through `indexer.onEvent`, `indexer.contractRegister`, or `indexer.onBlock`.
+
+```typescript
+// Before
+
+ERC20.Transfer.handler(
+  async ({ event, context }) => {
+    // ...
+  },
+  {
+    wildcard: true,
+    eventFilters: ({ chainId }) => [
+      { from: ZERO_ADDRESS, to: WHITELIST[chainId] },
+    ],
+  }
+);
+
+// After
+
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: ({ chain }) => ({
+      params: [{ from: ZERO_ADDRESS, to: WHITELIST[chain.id] }],
+    }),
+  },
+  async ({ event, context }) => {
+    // ...
+  },
+);
+```
+
+**Migrate dynamic contract registration:**
+
+```typescript
+// Before
+UniV3.PoolFactory.contractRegister(async ({ event, context }) => {
+  context.addPool(event.params.poolAddress);
+});
+
+// After
+indexer.contractRegister(
+  { contract: "UniV3", event: "PoolFactory" },
+  async ({ event, context }) => {
+    context.chain.Pool.add(event.params.poolAddress);
+  },
+);
+```
+
+**Migrate block handlers:**
+
+```typescript
+// Before
+
+indexer.chainIds.forEach((chainId) => {
+  onBlock(
+    { name: "EveryBlock", chain: chainId },
+    async ({ block, context }) => {
+      // ...
+    },
+  );
+});
+
+// After
+
+indexer.onBlock(
+  { name: "EveryBlock" },
+  async ({ block, context }) => {
+    // ...
+  },
+);
+```
+
+For chain-specific handlers or interval/range filters, use the `where` callback (see Unified Handlers API).
 
 **Rename deprecated APIs:**
 
 | V2 (Deprecated)                     | V3                                    |
 | ----------------------------------- | ------------------------------------- |
+| `Contract.Event.handler(...)`       | `indexer.onEvent({ contract, event, ...options }, handler)` |
+| `Contract.Event.contractRegister(...)` | `indexer.contractRegister({ contract, event }, handler)` |
+| `onBlock({ chain, ... }, handler)`  | `indexer.onBlock({ name, where? }, handler)` |
+| `context.add(addr)`       | `context.chain..add(addr)`  |
+| `eventFilters` option               | `where` callback returning `{ params: [...] }` |
 | `experimental_createEffect`         | `createEffect`                        |
 | `block.chainId` (in block handlers) | `context.chain.id`                    |
 | `transaction.kind`                  | `transaction.type`                    |
@@ -1353,8 +2207,8 @@ ENVIO_API_TOKEN=your_token_here
 
 **Removed APIs:**
 
-- `getGeneratedByChainId` - use the `indexer.chains[chainId]` instead (see Indexer State & Config)
-- **`getWhere` API** - update to the new GraphQL-style filter syntax:
+- `getGeneratedByChainId` — use the `indexer.chains[chainId]` instead (see Indexer State & Config)
+- **`getWhere` API** — update to the new GraphQL-style filter syntax:
 
 ```typescript
 // Before
@@ -1366,7 +2220,7 @@ const transfers = await context.Transfer.getWhere({ from: { _eq: "0x123..." } })
 const bigTransfers = await context.Transfer.getWhere({ value: { _gt: 1000n } });
 ```
 
-- Lowercased entity types - use capitalized names instead:
+- Lowercased entity types — use capitalized names instead:
 
 ```typescript
 // Before
@@ -1374,6 +2228,11 @@ const bigTransfers = await context.Transfer.getWhere({ value: { _gt: 1000n } });
 // After
 
 ```
+
+**CLI behavior changes:**
+
+- `envio dev` no longer auto-resets the database. If you relied on auto-reset, run `envio dev -r` (or `--restart`) explicitly.
+- `envio start` is now production-only — keep using `envio dev` for local development.
 
 ### Step 6: Test Your Migration
 
@@ -1398,6 +2257,7 @@ pnpm dev
 - [ ] Update Node.js to >=22
 - [ ] **Add `"type": "module"` to `package.json`** ← Required for V3!
 - [ ] Update `envio` dependency to latest `3.0.0-alpha.x`
+- [ ] Remove the `optionalDependencies.generated` entry from `package.json` (alpha.24+)
 - [ ] Update `engines.node` to `>=22.0.0` in `package.json`
 - [ ] Update `tsconfig.json` for ESM support
 - [ ] Migrate from mocha/chai to vitest (recommended) or replace `ts-mocha`/`ts-node` with `tsx`
@@ -1411,6 +2271,8 @@ pnpm dev
 - [ ] Remove `loaders` and `preload_handlers` options
 - [ ] Remove `preRegisterDynamicContracts` option
 - [ ] Remove `event_decoder` option
+- [ ] Remove the `output` option (types are always written to `.envio/`)
+- [ ] If using ClickHouse, add `storage: { postgres: true, clickhouse: true }` (env vars are still required for the connection)
 
 **Environment Variables:**
 
@@ -1418,9 +2280,16 @@ pnpm dev
 - [ ] Remove `UNSTABLE__TEMP_UNORDERED_HEAD_MODE`
 - [ ] Remove `UNORDERED_MULTICHAIN_MODE`
 - [ ] Remove `MAX_BATCH_SIZE` (use `full_batch_size` in config.yaml)
+- [ ] Rename `TUI_OFF=true` to `ENVIO_TUI=false` if you set it
 
 **Handler Code:**
 
+- [ ] **Migrate event handlers** from `Contract.Event.handler(...)` to `indexer.onEvent({ contract, event, ...options }, handler)`
+- [ ] **Migrate dynamic contract registration** from `Contract.Event.contractRegister(...)` to `indexer.contractRegister({ contract, event }, handler)`
+- [ ] **Migrate `context.add(addr)`** to `context.chain..add(addr)`
+- [ ] **Convert `eventFilters`** to the new `where` callback returning `{ params: [...] }`
+- [ ] **Migrate block handlers** from per-chain `onBlock` loops to a single `indexer.onBlock` call (use `where` for chain-specific or interval filters)
+- [ ] Use the new `where.block.number._gte` to override per-event start blocks if needed
 - [ ] Replace `experimental_createEffect` with `createEffect`
 - [ ] Replace `block.chainId` with `context.chain.id` in block handlers
 - [ ] Replace `transaction.kind` with `transaction.type`
@@ -1430,6 +2299,14 @@ pnpm dev
 - [ ] Replace `transaction.chainId` with `context.chain.id` or `event.chainId`
 - [ ] Replace lowercased entity type imports with capitalized versions (e.g., `transfer` → `Transfer`)
 - [ ] Update `getWhere` calls to new GraphQL-style filter syntax (e.g., `getWhere({ field: { _eq: value } })`)
+- [ ] Update any `S.nullable` schema usage — now returns `null` instead of `undefined`
+- [ ] Migrate from `MockDb` to `createTestIndexer()` (see MockDb Migration Cheat Sheet)
+- [ ] Replace contract-specific type exports (`ERC20_Transfer_eventLog`) with generic types (`EvmEvent`)
+
+**CLI:**
+
+- [ ] If you relied on `envio dev` resetting the database automatically, switch to `envio dev -r`
+- [ ] Use `envio dev` for local development (`envio start` is now production-only)
 
 **Verify:**
 
@@ -1443,6 +2320,17 @@ If you encounter any issues during migration, join our Discord community for sup
 
 For detailed release notes, see:
 
+- v3.0.0-rc.0
+- v3.0.0-alpha.24
+- v3.0.0-alpha.23
+- v3.0.0-alpha.22
+- v3.0.0-alpha.21
+- v3.0.0-alpha.20
+- v3.0.0-alpha.19
+- v3.0.0-alpha.18
+- v3.0.0-alpha.17
+- v3.0.0-alpha.16
+- v3.0.0-alpha.15
 - v3.0.0-alpha.14
 - v3.0.0-alpha.13
 - v3.0.0-alpha.12
@@ -1497,10 +2385,10 @@ address: 0xContractAddress
 
 ```yaml
 contracts:
-    - name: MyContract
-      address:
-          - 0xAddress1
-          - 0xAddress2
+  - name: MyContract
+    address:
+      - 0xAddress1
+      - 0xAddress2
 ```
 
 :::tip
@@ -1512,14 +2400,14 @@ You can also avoid repeating addresses by using global contract definitions:
 
 ```yaml
 contracts:
-    - name: Greeter
-      abi: greeter.json
+  - name: Greeter
+    abi: greeter.json
 
 networks:
-    - id: ethereum-mainnet
-      contracts:
-          - name: Greeter
-            address: 0xProxyAddressHere
+  - id: ethereum-mainnet
+    contracts:
+      - name: Greeter
+        address: 0xProxyAddressHere
 ```
 
 
@@ -1529,8 +2417,8 @@ Define specific events to index in a human-readable format:
 
 ```yaml
 events:
-    - event: "NewGreeting(address user, string greeting)"
-    - event: "ClearGreeting(address user)"
+  - event: "NewGreeting(address user, string greeting)"
+  - event: "ClearGreeting(address user)"
 ```
 
 By default, all events defined in the contract are indexed, but you can selectively disable them by removing them from this list.
@@ -1543,9 +2431,9 @@ a more descriptive name in your Envio project.
 
 ```yaml
 events:
-    - event: Assigned(address indexed recipientId, uint256 amount, address token)
-    - event: Assigned(address indexed recipientId, uint256 amount, address token, address sender)
-      name: AssignedWithSender
+  - event: Assigned(address indexed recipientId, uint256 amount, address token)
+  - event: Assigned(address indexed recipientId, uint256 amount, address token, address sender)
+    name: AssignedWithSender
 ```
 
 
@@ -1557,12 +2445,12 @@ To access fields that are not provided by default, specify them using the `field
 
 ```yaml
 events:
-    - event: "Assigned(address indexed user, uint256 amount)"
-      field_selection:
-          transaction_fields:
-              - transactionIndex
-          block_fields:
-              - timestamp
+  - event: "Assigned(address indexed user, uint256 amount)"
+    field_selection:
+      transaction_fields:
+        - transactionIndex
+      block_fields:
+        - timestamp
 ```
 
 See all possible options in the Config File Reference or use IDE autocomplete for your help.
@@ -1573,11 +2461,11 @@ You can also specify fields globally for all events in the root of the config fi
 
 ```yaml
 field_selection:
-    transaction_fields:
-        - hash
-        - gasUsed
-    block_fields:
-        - parentHash
+  transaction_fields:
+    - hash
+    - gasUsed
+  block_fields:
+    - parentHash
 ```
 
 Try to use this option sparingly as it can cause redundant Data Source calls and increased credits usage.
@@ -1604,10 +2492,10 @@ Since `envio@2.9.0`, environment variable interpolation is supported for flexibi
 
 ```yaml
 networks:
-    - id: ${ENVIO_CHAIN_ID:-ethereum-mainnet}
-      contracts:
-          - name: Greeter
-            address: ${ENVIO_GREETER_ADDRESS}
+  - id: ${ENVIO_CHAIN_ID:-ethereum-mainnet}
+    contracts:
+      - name: Greeter
+        address: ${ENVIO_GREETER_ADDRESS}
 ```
 
 Run your indexer with custom environment variables:
@@ -1618,8 +2506,8 @@ ENVIO_CHAIN_ID=optimism ENVIO_GREETER_ADDRESS=0xYourContractAddress pnpm dev
 
 **Interpolation syntax:**
 
--   `${ENVIO_VAR}` – Use the value of `ENVIO_VAR`
--   `${ENVIO_VAR:-default}` – Use `ENVIO_VAR` if set, otherwise use `default`
+- `${ENVIO_VAR}` – Use the value of `ENVIO_VAR`
+- `${ENVIO_VAR:-default}` – Use `ENVIO_VAR` if set, otherwise use `default`
 
 For more detailed information about environment variables, see our Environment Variables Guide.
 
@@ -1639,29 +2527,57 @@ This is an advanced configuration option. When using a custom output directory, 
 :::
 
 
-## Configuration Schema Reference
+## Full config file example
 
-Explore detailed configuration schema parameters here:
+This example indexes events from multiple contracts across multiple networks.
 
--   See the full, deep-linkable reference: Config Schema Reference
+```yaml
+name: envio-indexer
+unordered_multichain_mode: true
+preload_handlers: true
+contracts:
+  - name: PoolManager
+    handler: src/EventHandlers.ts
+    events:
+      - event: Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)
+  - name: PositionManager
+    handler: src/EventHandlers.ts
+    events:
+      - event: Transfer(address indexed from, address indexed to, uint256 indexed id)
+networks:
+  - id: 1
+    # Keep it 0 and HyperSync will automatically find the first block for your contracts
+    start_block: 0
+    contracts:
+      - name: PositionManager
+        address:
+          - 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e
+        start_block: 18500000 # OPTIONAL: Override for contract deployed later
+      - name: PoolManager
+        address:
+          - "0x000000000004444c5dc75cB358380D2e3dE08A90"
+  - id: 10
+    start_block: 0
+    contracts:
+      - name: PositionManager
+        address:
+          - 0x3C3Ea4B57a46241e54610e5f022e5c45859A1017
+      - name: PoolManager
+        address:
+          - 0x9a13F98Cb987694C9F086b1F5eB990EeA8264Ec3
+  - id: 42161
+    start_block: 0
+    contracts:
+      - name: PositionManager
+        address:
+          - 0xd88f38f930b7952f2db2432cb002e7abbf3dd869
+      - name: PoolManager
+        address:
+          - 0x360e68faccca8ca495c1b759fd9eee466db9fb32
+```
 
-:::info For AI/LLM Systems
-**Recommended**: Use the Config Schema Reference for programmatic access to schema information. The interactive viewer below is optimized for human users.
-:::
 
-
-
-
-
-
-
-📋 Hierarchical Interactive Schema Explorer (Click to expand - For human reference only)
-
-
-  
-
-
-
+Now your configuration file is set, you're ready to start indexing with HyperIndex!
 
 ---
 
@@ -2121,7 +3037,7 @@ pool->Option.forEach(pool => {
 
 ### `context.log`
 
-The context object also provides a logger that you can use to log messages to the console. Compared to `console.log` calls, these logs will be displayed on Envio Cloud's runtime logs page.
+The context object also provides a logger that you can use to log messages to the console. Compared to `console.log` calls, these logs will be displayed on our Envio Cloud runtime logs page.
 
 Read more in the Logging Guide.
 
@@ -2401,6 +3317,18 @@ Implement robust error handling for network-specific issues. A failure on one ch
 - Use unordered mode when appropriate for better performance
 - Consider your indexing frequency based on the block times of each chain
 - Monitor resource usage, as indexing multiple chains increases load
+- Adding more chains does **not** linearly degrade performance — chains are indexed in parallel. However, handler logic that writes to shared entities across chains may introduce contention when using ordered mode.
+
+### 5. Adding a New Chain to an Existing Indexer
+
+To add a new chain to a running indexer:
+
+1. Add the new network entry to your `config.yaml` with the appropriate `start_block` and contract addresses
+2. Push the updated code to your deployment branch (for Envio Cloud) or restart locally with `pnpm envio start -r`
+
+On **Envio Cloud**, this creates a new deployment that re-indexes all chains (including the new one). Your previous deployment continues serving queries with zero downtime until the new deployment is fully synced. See the deployment guide for details.
+
+**Locally**, adding a new chain requires a restart and will re-index all chains from their respective start blocks.
 
 ## Troubleshooting Common Issues
 
@@ -2875,6 +3803,55 @@ For more help, see our Troubleshooting Guide.
 
 ---
 
+## MCP Server
+
+**File:** `Guides/mcp-server.md`
+
+Envio provides a Model Context Protocol (MCP) server that lets AI coding assistants search and retrieve documentation directly. This means tools like Claude Code, Cursor, and other MCP-compatible clients can access Envio docs without you needing to copy-paste context manually.
+
+## Endpoint
+
+```
+https://docs.envio.dev/mcp
+```
+
+## Available Tools
+
+The MCP server exposes two tools:
+
+| Tool | Description |
+|------|-------------|
+| `docs_search` | Full-text search across all documentation. Returns matching pages with titles, URLs, and content snippets. |
+| `docs_fetch` | Retrieves the full content of a documentation page as markdown. |
+
+## Setup
+
+### Claude Code
+
+```bash
+claude mcp add --transport http envio-docs https://docs.envio.dev/mcp
+```
+
+### Cursor / VS Code
+
+Add the following to your MCP configuration (`.cursor/mcp.json` or VS Code MCP settings):
+
+```json
+{
+  "mcpServers": {
+    "envio-docs": {
+      "url": "https://docs.envio.dev/mcp"
+    }
+  }
+}
+```
+
+### Other MCP Clients
+
+Point any MCP-compatible client to the endpoint URL above using the **Streamable HTTP** transport.
+
+---
+
 ## Uniswap V4 Multichain Indexer
 
 **File:** `Examples/example-uniswap-v4.md`
@@ -3003,11 +3980,11 @@ These are official indexers maintained by the Sablier team and represent product
 
 ---
 
-## Envio Cloud
+## Hosted Service
 
 **File:** `Hosted_Service/hosted-service.md`
 
-Envio offers a fully managed hosting solution for your blockchain indexers, providing all the infrastructure, scaling, and monitoring needed to run production-grade indexers without operational overhead.
+Envio Cloud (formerly Hosted Service) is a fully managed hosting solution for your blockchain indexers, providing all the infrastructure, scaling, and monitoring needed to run production-grade indexers without operational overhead.
 
 Envio Cloud offers multiple plans to suit different needs, from free development environments to enterprise-grade dedicated hosting. Each plan includes powerful features like static production endpoints, built-in alerts, and production-ready infrastructure.
 
@@ -3016,7 +3993,7 @@ Envio Cloud offers multiple plans to suit different needs, from free development
 
 Envio provides flexibility in how you deploy and host your indexers:
 
-- **Envio Cloud (Fully Managed)**: Let Envio handle everything. The following sections of this page outline Envio Cloud in more detail. This is the recommended deployment method for most users and removes the hosting overhead for your team. See below for the all the awesome features we provide and see the Pricing & Billing page for more information on which Hosting plan suits your indexing needs.
+- **Envio Cloud (Fully Managed)**: Let Envio handle everything. The following sections of this page outline Envio Cloud in more detail. This is the recommended deployment method for most users and removes the hosting overhead for your team. See below for the all the awesome features we provide and see the Pricing & Billing page for more information on which plan suits your indexing needs.
 
 - **Self-Hosting**: Run your indexer on your own infrastructure. This requires advanced setup and infrastructure knowledge not unique to Envio. See the following repository for a simple docker example to get you started. Please note this example does not cover all infrastructure related needs. It is recommended that at least a separate Postgres management tool is used for self-hosting in production. For further instructions see the Self Hosting Guide
 
@@ -3052,11 +4029,12 @@ You can view and manage your hosted indexers in the Envio Explorer.
 
 - **Features** - Learn about all available Envio Cloud features
 - **Deployment Guide** - Step-by-step instructions for deploying your indexer
+- **Envio Cloud CLI** - Manage and monitor your hosted indexers from the command line
 - **Pricing & Billing** - Compare plans and pricing options
 - **Self-Hosting** - Run your indexer on your own infrastructure
 
 :::info
-It is recommended that before deploying to Envio Cloud, the indexer is built and tested locally to ensure it runs smoothly on Envio Cloud.
+It is recommended that before deploying to Envio Cloud, the indexer is built and tested locally to ensure it runs smoothly.
 For a complete list of local CLI commands to develop your indexer, see the CLI Commands documentation.
 :::
 
@@ -3084,13 +4062,13 @@ Organize and identify your deployments with custom key/value tags. Tags help you
 
 **Special `name` Tag:**
 
-The `name` tag has special behavior-when set, its value is displayed directly on the deployment list, making it easy to identify deployments at a glance without navigating into each one.
+The `name` tag has special behavior—when set, its value is displayed directly on the deployment list, making it easy to identify deployments at a glance without navigating into each one.
 
 **Example Use Cases:**
-- `name: staging` or `name: production` - quickly identify deployment purpose
-- `env: staging` / `env: production` - categorize by environment
-- `team: frontend` - organize by team ownership
-- `version: v2` - track deployment versions
+- `name: staging` or `name: production` — quickly identify deployment purpose
+- `env: staging` / `env: production` — categorize by environment
+- `team: frontend` — organize by team ownership
+- `version: v2` — track deployment versions
 
 **Benefits:**
 - Quickly identify deployments in the list view
@@ -3250,17 +4228,28 @@ Envio Cloud provides a seamless git-based deployment workflow, similar to modern
 
 ### Requirements
 
-- **Version Support**: Deployment on Envio Cloud requires at least version `2.21.5`. 
-Additionally, the following versions are not supported: 
+- **Version Support**: We strongly advise using the latest release version for improved deployment performance. Envio Cloud requires a minimum version of at least `2.21.5`.
+Additionally, the following versions are not supported on Envio Cloud: 
   - `2.29.x`
-- **PNPM Support**: deployment must be compatible with pnpm version `9.10.0`
-- **Package.json**: the `package.json` file must be present and include the above two requirements.
-- **Configuration file**: a HyperIndex configuration file must be present (the name can be set in the indexer settings)
-- **GitHub Repository**: The repository must be no larger than `100MB`
+- **PNPM Support**: the deployment must be compatible with pnpm version `10.32.0`
+- **Repository Folder**:
+  - **Package.json**: a `package.json` file must be present in the root folder and support the above two requirements, with the envio version explicitly configured in the dependencies.
+  - **Configuration file**: a HyperIndex configuration file must be present.
 
-Before deploying your indexer, please be aware of the following limits and policies:
+  The root folder and configuration file name can be set in the indexer settings.
+- **GitHub Repository**: The repository must be no larger than `100MB`. Caching between deployments is supported for paid plans using the Effects Api.
+- **Node Version**: It is strongly recommended that the indexer is compatible with node version 24 or higher.
+
+
+
+:::note Fair use and limitations
+Before deploying your indexer, please be aware of the below limits and policies
+:::
 
 ### Deployment Limits
+
+
+
 - **3 development plan indexers** per organization
 - **Deployments per indexer**:  3 deployments per indexer
 - Deployments can be deleted in Envio Cloud to make space for more deployments
@@ -3334,6 +4323,43 @@ If you're working in a monorepo, ensure all your imports are contained within yo
     - Rollback to previous versions if needed
 
 
+## Updating Your Deployment
+
+After your initial deployment, you can update your indexer by pushing new commits to the deployment branch. Each push creates a new deployment version.
+
+### What happens on each push
+
+When you push to your deployment branch, Envio Cloud will:
+
+1. Build your updated indexer code
+2. Start a **new deployment** that re-indexes from the start block
+3. Keep your previous deployment running and serving queries until the new one is fully synced
+
+This means there is **no downtime** during updates — your existing deployment continues serving data while the new one catches up.
+
+### When re-indexing is required
+
+A full re-index from the start block happens on every new deployment. This includes changes to:
+
+- Event handler logic
+- Schema (`schema.graphql`)
+- Configuration (`config.yaml`)
+- ABIs or contract addresses
+
+:::tip
+Use the Effects API cache to speed up re-indexing by caching expensive external calls (like `eth_call` results) across deployments. This is available on paid plans.
+:::
+
+### Adding a new chain to your indexer
+
+To add a new chain, update your `config.yaml` with the new network configuration and push to the deployment branch. The new deployment will index all configured chains, including the new one.
+
+Your previous deployment continues serving data for the existing chains while the new deployment syncs.
+
+### Rolling back to a previous version
+
+If a new deployment introduces issues, you can switch back to a previous version from the Envio Cloud dashboard. Navigate to your indexer and select the version you want to activate.
+
 ## Monitoring
 
 Once your indexer is deployed, you can monitor its health, performance, and progress using several built-in tools including the dashboard, logs, and alerts.
@@ -3351,7 +4377,7 @@ For a robust deployment workflow, we recommend:
 
 ### Continuous Configuration
 
-After deploying your indexer, you can manage its configuration through the `Settings` tab in the Envio dashboard:
+After deploying your indexer, you can manage its configuration through the `Settings` tab in the Envio Cloud dashboard:
 
 #### General Tab
 
@@ -3441,6 +4467,7 @@ Manage indexer configurations and deployments using the sidebar navigation on th
 ## Related Documentation
 
 - **Features** - Learn about all available Envio Cloud features
+- **Envio Cloud CLI** - Deploy and manage indexers from the command line
 - **Pricing & Billing** - Compare plans and see feature availability
 - **Overview** - Introduction to Envio Cloud
 - **Self-Hosting** - Run your indexer on your own infrastructure
@@ -3527,12 +4554,455 @@ When indexing stops, the dashboard clearly surfaces the issue so you can investi
 ## Related Documentation
 
 - **Deploying Your Indexer** - Complete deployment guide
+- **Envio Cloud CLI** - Monitor deployments from the command line with `envio-cloud deployment metrics` and `envio-cloud deployment status`
 - **Features** - Learn about all available Envio Cloud features
 - **Pricing & Billing** - Compare plans and see feature availability
 
 ---
 
-## Envio Cloud Billing
+## Envio Cloud CLI
+
+**File:** `Hosted_Service/envio-cloud-cli.md`
+
+:::warning Alpha Release
+The `envio-cloud` CLI is currently in **alpha**. The tool is under active development and will be iterated on before a stable version 1 release once the final form of the tool's interaction is finalized.
+
+For feature requests, please reach out to us on Telegram or Discord.
+:::
+
+The `envio-cloud` CLI is a command-line tool for interacting with Envio Cloud. It enables you to deploy, manage, and monitor your blockchain indexers directly from the terminal — making it particularly useful for CI/CD pipelines, scripting, and agentic workflows.
+
+## Installation
+
+```bash
+npm install -g envio-cloud
+```
+
+Or run directly without installation:
+
+```bash
+npx envio-cloud 
+```
+
+## Shell Completion
+
+The `envio-cloud` CLI ships with shell completion scripts for `bash`, `zsh`, `fish`, and `powershell`. Completion includes dynamic suggestions for **indexer names** and **commit hashes**, so you can tab-complete them directly from the terminal.
+
+Run the one-liner for your shell to install completions:
+
+| Shell | One-liner |
+|-------|-----------|
+| `zsh` | `echo 'source > ~/.zshrc` |
+| `bash` | `envio-cloud completion bash > ~/.local/share/bash-completion/completions/envio-cloud` |
+| `fish` | `envio-cloud completion fish > ~/.config/fish/completions/envio-cloud.fish` |
+| `powershell` | `envio-cloud completion powershell >> $PROFILE` |
+
+Restart your shell (or `source` your profile) for the completions to take effect. Run `envio-cloud completion --help` for further options.
+
+## Authentication
+
+### Browser Login
+
+```bash
+envio-cloud login
+```
+
+Opens browser-based authentication via envio.dev with a 30-day session duration. Tokens are automatically refreshed when expired.
+
+### Token-Based Login (CI/CD)
+
+```bash
+envio-cloud login --token ghp_YOUR_TOKEN
+```
+
+Or using an environment variable:
+
+```bash
+export ENVIO_GITHUB_TOKEN=ghp_YOUR_TOKEN
+envio-cloud login
+```
+
+Required GitHub token scopes: `read:org`, `read:user`, `user:email`.
+
+### Session Management
+
+```bash
+envio-cloud token    # Check current session
+envio-cloud logout   # Remove credentials
+```
+
+## Context Management
+
+Like `kubectl` namespaces, `envio-cloud` lets you store default values for organisation and indexer so you don't have to pass them on every command. Flags (`--org`, `--indexer`) always override stored context.
+
+```bash
+# Set defaults
+envio-cloud config set-org myorg
+envio-cloud config set-indexer myindexer
+
+# View current context
+envio-cloud config get-context
+
+# Commands now use defaults automatically
+envio-cloud deployment status abc1234          # org and indexer from context
+envio-cloud indexer settings get               # both from context
+
+# Flags override context
+envio-cloud deployment status abc1234 --org other-org
+
+# Clear stored context
+envio-cloud config clear
+```
+
+Context is stored at `~/.envio-cloud/context.json`. Resolution priority:
+
+1. Explicit positional arguments
+2. `--org` / `--indexer` flags
+3. Stored context
+4. GitHub login (organisation only)
+
+| Command | Description |
+|---------|-------------|
+| `config set-org ` | Set default organisation |
+| `config set-indexer ` | Set default indexer |
+| `config get-context` | Show current defaults and where they come from |
+| `config clear` | Remove all stored defaults |
+
+## Commands
+
+### Indexer Commands
+
+#### List Indexers
+
+Lists indexers across every organisation you are a member of. Use `--org` to
+scope to a single organisation. Requires authentication.
+
+```bash
+envio-cloud indexer list
+envio-cloud indexer list --org myorg
+envio-cloud indexer list --limit 10
+envio-cloud indexer list -o json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--org` | Scope to a single organisation you belong to |
+| `--limit` | Limit number of results |
+| `-o, --output` | Output format (`json`) |
+
+#### Get Indexer Details
+
+```bash
+envio-cloud indexer get  [organisation]
+envio-cloud indexer get hyperindex mjyoung114 -o json
+envio-cloud indexer get hyperindex --org mjyoung114
+```
+
+Organisation can be omitted if set via context. Requires authentication — you
+can only view indexers in organisations you are a member of.
+
+#### Add an Indexer
+
+```bash
+envio-cloud indexer add --name my-indexer --repo my-repo
+envio-cloud indexer add --name my-indexer --repo my-repo --branch main --tier development
+envio-cloud indexer add --name my-indexer --repo my-repo --dry-run
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --name` | Indexer name (required) | — |
+| `-r, --repo` | Repository name (required) | — |
+| `-b, --branch` | Deployment branch | `envio` |
+| `-d, --root-dir` | Root directory | `./` |
+| `-c, --config-file` | Config file path | `config.yaml` |
+| `-t, --tier` | Pricing tier | `development` |
+| `-a, --access-type` | Access type | `public` |
+| `-e, --env-file` | Environment file | — |
+| `--auto-deploy` | Enable auto-deploy | `true` |
+| `--dry-run` | Preview without creating | — |
+| `-y, --yes` | Skip confirmation prompts | — |
+
+#### Delete an Indexer
+
+Permanently delete an indexer and **all** of its deployments. Requires typing the indexer name to confirm.
+
+```bash
+envio-cloud indexer delete myindexer myorg
+envio-cloud indexer delete myindexer --org myorg
+envio-cloud indexer delete myindexer myorg --yes   # skip confirmation for CI/CD
+```
+
+:::danger
+This action cannot be undone. All deployments, data, and configuration for the indexer will be permanently removed.
+:::
+
+#### View and Modify Settings
+
+```bash
+# View current settings
+envio-cloud indexer settings get myindexer myorg
+
+# Modify settings (only specified flags are changed)
+envio-cloud indexer settings set myindexer myorg --branch main
+envio-cloud indexer settings set myindexer myorg --auto-deploy=false
+envio-cloud indexer settings set myindexer myorg --config-file config.yaml --branch develop
+```
+
+| Flag (set) | Description |
+|------------|-------------|
+| `--branch` | Git branch for deployments |
+| `--config-file` | Path to config file |
+| `--root-dir` | Root directory within the repository |
+| `--auto-deploy` | Enable or disable auto-deploy on push |
+| `--description` | Indexer description |
+| `--access-type` | `public` or `private` |
+
+#### Manage Environment Variables
+
+Environment variables can be managed from the CLI. All keys must be prefixed with `ENVIO_`. Changes take effect on the next deployment.
+
+```bash
+# List variables (values masked by default)
+envio-cloud indexer env list myindexer myorg
+envio-cloud indexer env list myindexer myorg --show-values
+
+# Set one or more variables
+envio-cloud indexer env set myindexer myorg ENVIO_API_KEY=abc123 ENVIO_DEBUG=true
+
+# Remove a variable
+envio-cloud indexer env delete myindexer myorg ENVIO_DEBUG
+
+# Bulk import from a .env file
+envio-cloud indexer env import myindexer myorg --file .env
+```
+
+The `.env` file format is one `KEY=VALUE` per line. Lines starting with `#` are ignored.
+
+#### Configure IP Whitelisting
+
+Restrict access to your indexer's GraphQL endpoint by IP address. Supports IPv4 addresses and CIDR notation.
+
+```bash
+# View current IP whitelist configuration
+envio-cloud indexer security get myindexer myorg
+
+# Add IPs to the whitelist
+envio-cloud indexer security add-ip myindexer myorg 203.0.113.50
+envio-cloud indexer security add-ip myindexer myorg 10.0.0.0/8
+
+# Enable IP whitelisting (make sure to add IPs first)
+envio-cloud indexer security enable myindexer myorg
+
+# Disable IP whitelisting
+envio-cloud indexer security disable myindexer myorg
+
+# Restrict whitelisting to production deployments only
+envio-cloud indexer security set-prod-only myindexer myorg true
+
+# Remove an IP
+envio-cloud indexer security remove-ip myindexer myorg 203.0.113.50
+```
+
+:::tip
+Add your IP addresses **before** enabling whitelisting — otherwise you may lock yourself out. The CLI will warn you if you try to enable whitelisting with no IPs configured.
+:::
+
+### Deployment Commands
+
+All deployment commands accept arguments as `  [organisation]`. Organisation and indexer can be omitted if set via `envio-cloud config`.
+
+#### Deployment Metrics
+
+```bash
+envio-cloud deployment metrics   [organisation]
+envio-cloud deployment metrics hyperindex b3ead3a mjyoung114 --watch
+envio-cloud deployment metrics hyperindex b3ead3a mjyoung114 -o json
+```
+
+No authentication required.
+
+| Flag | Description |
+|------|-------------|
+| `--watch` | Continuously poll for updates |
+| `-o, --output` | Output format (`json`) |
+
+#### Deployment Status
+
+```bash
+envio-cloud deployment status   [organisation]
+envio-cloud deployment status hyperindex b3ead3a mjyoung114 --watch-till-synced
+```
+
+| Flag | Description |
+|------|-------------|
+| `--watch-till-synced` | Wait until deployment is fully synced |
+
+#### Deployment Info
+
+```bash
+envio-cloud deployment info   [organisation]
+```
+
+#### Get Query Endpoint
+
+Returns the GraphQL query endpoint URL for a deployment. The endpoint is
+computed from deployment parameters and the cluster is resolved from the
+deployment tier via the API. Output is a bare URL, so it composes cleanly with
+shell scripting.
+
+```bash
+envio-cloud deployment endpoint   [organisation]
+envio-cloud deployment endpoint hyperindex b3ead3a mjyoung114
+envio-cloud deployment endpoint hyperindex b3ead3a mjyoung114 -o json
+```
+
+Use the URL directly in a `curl` query:
+
+```bash
+curl "$(envio-cloud deployment endpoint hyperindex b3ead3a mjyoung114)" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ _meta { chainMetadata { chainId } } }"}'
+```
+
+| Flag | Description |
+|------|-------------|
+| `--cluster` | Override cluster (`hyper`, `hypertierchicago`, `ip-projects`, `prodaws`, `staging`) |
+| `-o, --output` | Output format (`json`) |
+
+The `ep` alias is also available: `envio-cloud deployment ep  `.
+
+#### Promote a Deployment
+
+Promote a deployment to the production endpoint. Requires confirmation (`y/N`).
+
+```bash
+envio-cloud deployment promote   [organisation]
+envio-cloud deployment promote myindexer abc1234 myorg --yes
+```
+
+#### Delete a Deployment
+
+Permanently delete a deployment. Requires typing the indexer name to confirm.
+
+```bash
+envio-cloud deployment delete   [organisation]
+envio-cloud deployment delete myindexer abc1234 myorg --yes
+```
+
+:::danger
+This action cannot be undone. The deployment and its data will be permanently removed.
+:::
+
+#### Restart a Deployment
+
+Restart a running deployment. There is a 10-minute cooldown between restarts.
+
+```bash
+envio-cloud deployment restart   [organisation]
+envio-cloud deployment restart myindexer abc1234 myorg --yes
+```
+
+#### Deployment Logs
+
+Show build or runtime logs for a deployment.
+
+```bash
+envio-cloud deployment logs   [organisation]
+envio-cloud deployment logs myindexer abc1234 myorg --build
+envio-cloud deployment logs myindexer abc1234 myorg --level error,warn
+envio-cloud deployment logs myindexer abc1234 myorg --follow
+```
+
+| Flag | Description |
+|------|-------------|
+| `--build` | Show build logs instead of runtime logs |
+| `--level` | Filter by log level (e.g., `error,warn`) |
+| `--limit` | Max number of log lines (default: 100) |
+| `--follow` | Poll for new logs every 10 seconds |
+
+### Repository Commands
+
+#### List Repositories
+
+```bash
+envio-cloud repos
+envio-cloud repos -o json
+```
+
+Requires authentication.
+
+## Confirmation Prompts
+
+Dangerous commands require confirmation before executing:
+
+| Command | Confirmation type |
+|---------|-------------------|
+| `indexer delete` | Type the indexer name |
+| `deployment delete` | Type the indexer name |
+| `deployment promote` | y/N prompt |
+| `deployment restart` | y/N prompt |
+
+All prompts can be skipped with the `--yes` / `-y` flag for CI/CD usage.
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--org` | Override default organisation |
+| `--indexer` | Override default indexer |
+| `-q, --quiet` | Suppress informational messages |
+| `-o, --output` | Output format (`json`) |
+| `--config` | Specify config file path |
+| `-h, --help` | Display command help |
+| `-v, --version` | Show CLI version |
+
+## JSON Output
+
+All commands support JSON output via the `-o json` flag, making the CLI easy to integrate into scripts and automation pipelines.
+
+**Success response:**
+
+```json
+{"ok": true, "data": [ ... ]}
+```
+
+**Error response:**
+
+```json
+{"ok": false, "error": "error message"}
+```
+
+**Example with jq:**
+
+```bash
+# Get event count for a deployment
+envio-cloud deployment metrics hyperindex b3ead3a mjyoung114 -o json | jq '.data[].num_events_processed'
+
+# List all indexer IDs in an org
+envio-cloud indexer list --org enviodev -o json | jq -r '.data[].indexer_id'
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | User error (invalid arguments, authentication required) |
+| `2` | API or server error |
+
+## Related Documentation
+
+- **Envio Cloud Overview** - Introduction to Envio Cloud
+- **Deploying Your Indexer** - Step-by-step deployment guide via the dashboard
+- **Production Features** - Tags, IP whitelisting, caching, and alerts
+- **Monitoring** - Dashboard monitoring and alerts
+- **Envio CLI** - Local development CLI reference
+- **npm package** - Latest version and changelog
+
+---
+
+## Hosted Service Billing
 
 **File:** `Hosted_Service/hosted-service-billing.mdx`
 
@@ -3549,13 +5019,23 @@ Envio Cloud offers flexible pricing plans to match your project's needs, from fr
 For the most up-to-date pricing information, detailed plan comparisons, and feature breakdowns, please visit our official Envio Pricing Page.
 :::
 
-
 **Available Plans:**
-- **Development** - Free plan perfect for testing and development
-- **Production Small** - Paid plan to get started with production deployments
-- **Production Medium** - Paid plan for scaling your indexing operations
-- **Production Large** - Paid plan for high-volume production workloads
-- **Dedicated** - Custom pricing for ultimate performance and control
+
+| Plan                  | Price  | Intended for                                                                                                                                                  |
+| --------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Development**       | Free   | Testing, prototyping, and development. 30-day max lifespan, subject to fair usage limits |
+| **Production Small**  | Paid   | Getting started with production deployments                                                                                                                   |
+| **Production Medium** | Paid   | Scaling your indexing operations with higher limits                                                                                                           |
+| **Production Large**  | Paid   | High-volume production workloads                                                                                                                              |
+| **Dedicated**         | Custom | Ultimate performance, isolated infrastructure, and custom SLAs                                                                                                |
+
+**What's included across paid plans:**
+
+- Higher event processing and storage limits (increases with each tier)
+- Higher query rate limits on your GraphQL endpoint
+- Effect API cache support for faster re-indexing (Medium plans and up)
+- Monitoring, alerts, and deployment management
+- Priority support (Dedicated plan)
 
 :::warning Development Plan Disclaimer
 The free development plan is intended for testing and development purposes only and should not be used as a production environment. Development plan deployments have a maximum life span of 30 days and Envio makes no guarantees regarding uptime, availability, or data persistence for deployments on the development plan. If you choose to use a development plan deployment in a production capacity, you do so entirely at your own risk. Envio assumes no liability or accountability for any downtime, data loss, or service interruptions that may occur on development plan deployments.
@@ -3575,7 +5055,7 @@ For detailed feature explanations, see our Features page. For deployment instruc
 This documentation page is actively being improved. Check back regularly for updates and additional information.
 :::
 
-While Envio offers Envio Cloud as a fully managed hosting solution, you may prefer to run your blockchain indexer on your own infrastructure. This guide covers everything you need to know about self-hosting Envio indexers.
+While Envio offers a fully managed cloud hosting solution via Envio Cloud, you may prefer to run your blockchain indexer on your own infrastructure. This guide covers everything you need to know about self-hosting Envio indexers.
 
 :::note
 We deeply appreciate users who choose Envio Cloud, as it directly supports our team and helps us continue developing and improving Envio's technology. If your use case allows for it, please consider the hosted option.
@@ -3599,7 +5079,7 @@ Before self-hosting, ensure you have:
 - Sufficient storage for blockchain data and the indexer database
 - Adequate CPU and memory resources (requirements vary based on chains and indexing complexity)
 - Required HyperSync and/or RPC endpoints
-- Envio API token for HyperSync access (`ENVIO_API_TOKEN`) - required for continued access. See API Tokens.
+- Envio API token for HyperSync access (`ENVIO_API_TOKEN`) — required for continued access. See API Tokens.
 
 ## Getting Started
 
@@ -4345,7 +5825,7 @@ Once you have verified that the indexer is working for your contracts, then you 
 
 Deploying an indexer to Envio Cloud allows you to extract information via graphQL queries into your front-end or some back-end application.
 
-Navigate to Envio Cloud to start deploying your indexer and refer to this documentation for more information on deploying your indexer.
+Navigate to the Envio Cloud to start deploying your indexer and refer to this documentation for more information on deploying your indexer.
 
 ## What next?
 
@@ -5247,6 +6727,20 @@ NftFactory.SimpleNftCreated.contractRegister(async ({ event, context }) => {
 });
 ```
 
+## Coming from TheGraph?
+
+If you're migrating from a subgraph that uses **data source templates** (`DataSource.create()`), the equivalent in Envio is the `contractRegister` handler.
+
+| TheGraph | Envio (HyperIndex) |
+|---|---|
+| Define a template in `subgraph.yaml` | Define the contract in `config.yaml` without an `address` |
+| Call `MyTemplate.create(address)` in a mapping | Call `context.addMyContract(address)` in a `contractRegister` handler |
+| Templates are triggered from other mappings | `contractRegister` runs before the event handler, on any event |
+
+The key difference is that Envio's `contractRegister` is more flexible — you can add conditional logic, perform async calls, and register contracts from any event, not just from a dedicated factory mapping.
+
+For a step-by-step migration guide, see Migrating from a Subgraph.
+
 ## When to Use Dynamic Contract Registration
 
 Use dynamic contract registration when:
@@ -5890,7 +7384,7 @@ ERC20.Transfer.handler(async ({ event, context }) => {
 });
 ```
 
-**Without Preload Optimization:** If you're processing 5,000 transfer events, each with unique `from` and `to` addresses, this results in **10,000 total database roundtrips**-one for each sender and receiver lookup (2 per event × 5,000 events). This creates a significant bottleneck that slows down your entire indexing process.
+**Without Preload Optimization:** If you're processing 5,000 transfer events, each with unique `from` and `to` addresses, this results in **10,000 total database roundtrips**—one for each sender and receiver lookup (2 per event × 5,000 events). This creates a significant bottleneck that slows down your entire indexing process.
 
 **With Preload Optimization:** During the Preload Phase, all 5,000 events are processed in parallel. HyperIndex batches database reads that occur simultaneously into single database queries - one query for sender lookups and one for receiver lookups. The loaded accounts are cached in memory. After the Preload Phase completes, the second processing phase begins. This phase runs handlers sequentially in on-chain order, but instead of making database calls, it retrieves the data from the in-memory cache.
 
@@ -5928,7 +7422,7 @@ ERC20.Transfer.handler(async ({ event, context }) => {
 });
 ```
 
-**Without Preload Optimization:** If you're processing 5,000 transfer events, each with an external call, this results in **5,000 sequential external calls**-each waiting for the previous one to complete. This can turn a fast indexing process into a slow, sequential crawl.
+**Without Preload Optimization:** If you're processing 5,000 transfer events, each with an external call, this results in **5,000 sequential external calls**—each waiting for the previous one to complete. This can turn a fast indexing process into a slow, sequential crawl.
 
 **With Preload Optimization:** Since handlers run **twice** for each event, making direct external calls can be problematic. The Effect API provides a solution. During the Preload Phase, it batches all external calls and runs them in parallel. Then during the Processing Phase, it runs the handlers sequentially, retrieving the already requested data from the in-memory store.
 
@@ -6136,6 +7630,10 @@ ERC20.Transfer.handler(async ({ event, context }) => {
 });
 ```
 
+### Reading On-Chain State (eth_call)
+
+The Effect API is how you perform `eth_call`-style reads from your handlers — for example, reading a token balance, fetching a contract's name, or querying any view function at a specific block.
+
 ### Viem Transport Batching
 
 You can use `viem` or any other blockchain client inside your effect functions. When doing so, it's highly recommended to enable the `batch` option to group all effect calls into fewer RPC requests:
@@ -6274,6 +7772,62 @@ export const getBalance = createEffect(
 
 Watch the following video to learn more about createEffect and other updates introduced in v2.32.0.
 
+
+### Sending Notifications (Webhooks)
+
+You can use the Effect API to send push notifications or webhook calls when specific events occur. This is useful for alerting systems, Discord/Slack bots, or triggering downstream workflows.
+
+```typescript
+
+export const sendWebhook = createEffect(
+  {
+    name: "sendWebhook",
+    input: {
+      event: S.string,
+      data: S.string,
+    },
+    output: S.boolean,
+    rateLimit: {
+      calls: 10,
+      per: "second",
+    },
+    // Don't cache webhook calls - we want them to fire every time
+    cache: false,
+  },
+  async ({ input, context }) => {
+    try {
+      await fetch("https://your-webhook-url.com/notify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event: input.event, data: input.data }),
+      });
+      return true;
+    } catch (error) {
+      context.log.error(`Webhook failed: ${error}`);
+      return false;
+    }
+  }
+);
+```
+
+Then call it from your handler:
+
+```typescript
+MyContract.LargeTransfer.handler(async ({ event, context }) => {
+  await context.effect(sendWebhook, {
+    event: "large_transfer",
+    data: JSON.stringify({
+      from: event.params.from,
+      to: event.params.to,
+      amount: event.params.value.toString(),
+    }),
+  });
+});
+```
+
+:::warning
+Webhook effects will fire on every indexer re-run unless you set `cache: true`. If you cache them, the webhook will only fire once per unique input. Consider which behavior is appropriate for your use case.
+:::
 
 ### Migrate from Experimental
 
@@ -6960,7 +8514,7 @@ To mitigate these issues:
 
 **File:** `Advanced/hypersync.md`
 
-> **"Beam me up, Scotty!"** 🖖 - Just like the Star Trek transporter, HyperSync delivers your blockchain data at warp speed.
+> **"Beam me up, Scotty!"** 🖖 — Just like the Star Trek transporter, HyperSync delivers your blockchain data at warp speed.
 
 ## What is HyperSync?
 
@@ -7265,7 +8819,7 @@ For more detailed configuration options, refer to the eRPC documentation.
 | Speed           | 10-100x faster                                                     | Baseline                     |
 | Configuration   | Minimal                                                            | Requires tuning              |
 | Rate Limits     | None                                                               | Depends on provider          |
-| Cost            | Included with Envio Cloud                                       | Pay per request/subscription |
+| Cost            | Included with Envio Cloud                                          | Pay per request/subscription |
 | Network Support | Supported networks | Any EVM network              |
 | Maintenance     | Managed by Envio                                                   | Self-managed                 |
 
@@ -7800,6 +9354,10 @@ event_decoder: hypersync-client
 
 This comprehensive reference guide covers all available commands and options in the Envio CLI tool. Use this documentation to explore the full capabilities of the `envio` command and its subcommands for managing your blockchain indexing projects.
 
+:::tip Envio Cloud CLI
+Looking to manage your hosted indexers from the command line? See the **Envio Cloud CLI** for deployment, monitoring, and management commands for Envio Cloud.
+:::
+
 ## Getting Started
 
 The Envio CLI provides a powerful set of tools for creating, developing, and managing your blockchain indexers. Whether you're starting a new project, running a development server, or deploying to production, the CLI offers commands to simplify and automate your workflow.
@@ -7841,9 +9399,9 @@ The base command that provides access to all Envio functionality.
 
 ###### **Options:**
 
-- `-d`, `--directory ` - The directory of the project. Defaults to current dir ("./")
-- `-o`, `--output-directory ` - The directory within the project that generated code should output to (Default: `generated`)
-- `--config ` - The file in the project containing config (Default: `config.yaml`)
+- `-d`, `--directory ` — The directory of the project. Defaults to current dir ("./")
+- `-o`, `--output-directory ` — The directory within the project that generated code should output to (Default: `generated`)
+- `--config ` — The file in the project containing config (Default: `config.yaml`)
 
 ## Initialization Commands
 
@@ -7857,15 +9415,15 @@ Initialize an indexer with one of the initialization options.
 
 ###### **Subcommands:**
 
-- `contract-import` - Initialize Evm indexer by importing config from a contract for a given chain
-- `template` - Initialize Evm indexer from an example template
-- `fuel` - Initialization option for creating Fuel indexer
+- `contract-import` — Initialize Evm indexer by importing config from a contract for a given chain
+- `template` — Initialize Evm indexer from an example template
+- `fuel` — Initialization option for creating Fuel indexer
 
 ###### **Options:**
 
-- `-n`, `--name ` - The name of your project
-- `-l`, `--language ` - The language used to write handlers (Options: `javascript`, `typescript`, `rescript`)
-- `--api-token ` - The hypersync API key to be initialized in your templates .env file
+- `-n`, `--name ` — The name of your project
+- `-l`, `--language ` — The language used to write handlers (Options: `javascript`, `typescript`, `rescript`)
+- `--api-token ` — The hypersync API key to be initialized in your templates .env file
 
 ### `envio init contract-import`
 
@@ -7875,14 +9433,14 @@ Initialize Evm indexer by importing config from a contract for a given chain.
 
 ###### **Subcommands:**
 
-- `explorer` - Initialize by pulling the contract ABI from a block explorer
-- `local` - Initialize from a local json ABI file
+- `explorer` — Initialize by pulling the contract ABI from a block explorer
+- `local` — Initialize from a local json ABI file
 
 ###### **Options:**
 
-- `-c`, `--contract-address ` - Contract address to generate the config from
-- `--single-contract` - If selected, prompt will not ask for additional contracts/addresses/networks
-- `--all-events` - If selected, prompt will not ask to confirm selection of events on a contract
+- `-c`, `--contract-address ` — Contract address to generate the config from
+- `--single-contract` — If selected, prompt will not ask for additional contracts/addresses/networks
+- `--all-events` — If selected, prompt will not ask to confirm selection of events on a contract
 
 ### `envio init contract-import explorer`
 
@@ -7892,7 +9450,7 @@ Initialize by pulling the contract ABI from a block explorer.
 
 ###### **Options:**
 
-- `-b`, `--blockchain ` - Network to import the contract from (Options include `ethereum-mainnet`, `polygon`, `arbitrum-one`, etc. For complete list, run: `envio init contract-import explorer --help`)
+- `-b`, `--blockchain ` — Network to import the contract from (Options include `ethereum-mainnet`, `polygon`, `arbitrum-one`, etc. For complete list, run: `envio init contract-import explorer --help`)
 
 ### `envio init contract-import local`
 
@@ -7902,11 +9460,11 @@ Initialize from a local json ABI file.
 
 ###### **Options:**
 
-- `-a`, `--abi-file ` - The path to a json abi file
-- `--contract-name ` - The name of the contract
-- `-b`, `--blockchain ` - Name or ID of the contract network
-- `-r`, `--rpc-url ` - The rpc url to use if the network id used is unsupported by our hypersync
-- `-s`, `--start-block ` - The start block to use on this network
+- `-a`, `--abi-file ` — The path to a json abi file
+- `--contract-name ` — The name of the contract
+- `-b`, `--blockchain ` — Name or ID of the contract network
+- `-r`, `--rpc-url ` — The rpc url to use if the network id used is unsupported by our hypersync
+- `-s`, `--start-block ` — The start block to use on this network
 
 ### `envio init template`
 
@@ -7916,7 +9474,7 @@ Initialize Evm indexer from an example template.
 
 ###### **Options:**
 
-- `-t`, `--template ` - Template to use (Options: `greeter`, `erc20`)
+- `-t`, `--template ` — Template to use (Options: `greeter`, `erc20`)
 
 ### `envio init fuel`
 
@@ -7926,8 +9484,8 @@ Initialization option for creating Fuel indexer.
 
 ###### **Subcommands:**
 
-- `contract-import` - Initialize Fuel indexer by importing config from a contract
-- `template` - Initialize Fuel indexer from an example template
+- `contract-import` — Initialize Fuel indexer by importing config from a contract
+- `template` — Initialize Fuel indexer from an example template
 
 ### `envio init fuel contract-import`
 
@@ -7937,13 +9495,13 @@ Initialize Fuel indexer by importing config from a contract for a given chain.
 
 ###### **Subcommands:**
 
-- `local` - Initialize from a local json ABI file
+- `local` — Initialize from a local json ABI file
 
 ###### **Options:**
 
-- `-c`, `--contract-address ` - Contract address to generate the config from
-- `--single-contract` - If selected, prompt will not ask for additional contracts/addresses/networks
-- `--all-events` - If selected, prompt will not ask to confirm selection of events on a contract
+- `-c`, `--contract-address ` — Contract address to generate the config from
+- `--single-contract` — If selected, prompt will not ask for additional contracts/addresses/networks
+- `--all-events` — If selected, prompt will not ask to confirm selection of events on a contract
 
 ### `envio init fuel contract-import local`
 
@@ -7953,8 +9511,8 @@ Initialize from a local json ABI file.
 
 ###### **Options:**
 
-- `-a`, `--abi-file ` - The path to a json abi file
-- `--contract-name ` - The name of the contract
+- `-a`, `--abi-file ` — The path to a json abi file
+- `--contract-name ` — The name of the contract
 
 ### `envio init fuel template`
 
@@ -7964,7 +9522,7 @@ Initialize Fuel indexer from an example template.
 
 ###### **Options:**
 
-- `-t`, `--template ` - Name of the template (Options: `greeter`)
+- `-t`, `--template ` — Name of the template (Options: `greeter`)
 
 ## Development Commands
 
@@ -7996,8 +9554,8 @@ Start the indexer without any automatic codegen.
 
 ###### **Options:**
 
-- `-r`, `--restart` - Clear your database and restart indexing from scratch
-- `-b`, `--bench` - Saves benchmark data to a file during indexing
+- `-r`, `--restart` — Clear your database and restart indexing from scratch
+- `-b`, `--bench` — Saves benchmark data to a file during indexing
 
 ## Environment Management Commands
 
@@ -8011,8 +9569,8 @@ Prepare local environment for envio testing.
 
 ###### **Subcommands:**
 
-- `docker` - Local Envio and ganache environment commands
-- `db-migrate` - Local Envio database commands
+- `docker` — Local Envio and ganache environment commands
+- `db-migrate` — Local Envio database commands
 
 ### `envio local docker`
 
@@ -8022,8 +9580,8 @@ Local Envio and ganache environment commands.
 
 ###### **Subcommands:**
 
-- `up` - Create docker images required for local environment
-- `down` - Delete existing docker images on local environment
+- `up` — Create docker images required for local environment
+- `down` — Delete existing docker images on local environment
 
 ### `envio local docker up`
 
@@ -8045,9 +9603,9 @@ Local Envio database commands.
 
 ###### **Subcommands:**
 
-- `up` - Migrate latest schema to database
-- `down` - Drop database schema
-- `setup` - Setup database by dropping schema and then running migrations
+- `up` — Migrate latest schema to database
+- `down` — Drop database schema
+- `setup` — Setup database by dropping schema and then running migrations
 
 ### `envio local db-migrate up`
 
@@ -8267,6 +9825,18 @@ networks:
 ```
 
 By properly configuring reorg support, you ensure that your indexed data remains consistent with the blockchain, even when the chain reorganizes.
+
+## Using HyperSync Directly? Handle Reorgs with the Rollback Guard
+
+If you use HyperSync directly, without HyperIndex, you have to handle reorg detection and rollback yourself using the **rollback guard** returned on each query response.
+
+HyperSync validates block parent hashes internally and re-syncs when it detects a fork, so it always serves canonical chain data. Data you have already fetched can still go stale after a reorg, though. To detect that, compare the `first_parent_hash` of the current response against the `hash` you stored from the previous response. If they differ, a reorg has occurred and you need to re-fetch the affected range.
+
+For full details, including a pseudocode example, see the HyperSync Rollback Guard documentation.
+
+:::tip
+HyperIndex automates all of this: it fetches recent block hashes to pinpoint exactly where a reorg occurred and automatically rolls back database state. Unless you need the full flexibility of raw HyperSync, HyperIndex saves significant implementation effort.
+:::
 
 ---
 
@@ -8840,7 +10410,7 @@ As your indexed data grows, database performance becomes critical to maintaining
 
 ## Understanding Database Indices
 
-Database indices are special data structures that improve the speed of data retrieval operations. Think of them like the index at the back of a book - rather than scanning every page (row) to find what you're looking for, indices allow the database to quickly locate the relevant data.
+Database indices are special data structures that improve the speed of data retrieval operations. Think of them like the index at the back of a book — rather than scanning every page (row) to find what you're looking for, indices allow the database to quickly locate the relevant data.
 
 ### Why Indices Matter
 
@@ -9068,6 +10638,34 @@ query getUpdatedTransfers($lastFetched: BigInt!) {
   }
 }
 ```
+
+## Diagnosing Slow Queries
+
+If your GraphQL queries are returning slowly, follow this workflow:
+
+### 1. Check if you have indices on filtered fields
+
+The most common cause of slow queries is missing indices. If you're filtering or sorting by a field that doesn't have `@index`, add it:
+
+```graphql
+# Before - slow queries on userAddress
+type Transaction {
+  id: ID!
+  userAddress: String!
+}
+
+# After - fast queries on userAddress
+type Transaction {
+  id: ID!
+  userAddress: String! @index
+}
+```
+
+After adding indices, you'll need to redeploy (on Envio Cloud) or restart locally for the schema changes to take effect.
+
+### 2. Reduce result set size
+
+Large unbounded queries are a common cause of slow responses. Always use `limit` and check that you're not requesting more data than needed.
 
 ## Summary
 
@@ -9854,8 +11452,16 @@ This guide helps you identify and resolve common issues you might encounter when
   - Indexer Start Block Issues
   - Tables Not Registered in Hasura
   - RPC-Related Issues
+- Debugging a Stuck Indexer
+  - Indexer Not Making Progress
+- Rate Limiting on Hosted Service
+  - HTTP 429 Errors
+- Hasura Authentication
+  - Cannot Log In to the Hasura Console
 - Infrastructure Conflicts
   - Local Postgres Conflicts
+- Missing Events
+  - Events Not Appearing in Indexed Data
 
 ## Setup and Configuration Issues
 
@@ -10002,6 +11608,90 @@ network:
   rpc_url: "https://mainnet.infura.io/v3/YOUR-API-KEY"
 ```
 
+## Debugging a Stuck Indexer
+
+### Indexer not making progress
+
+**Problem:** Your indexer appears frozen — the block counter stops advancing, or sync has been running far longer than expected with no visible progress.
+
+**First step — check the logs:**
+
+The most important thing to do is check your indexer logs for errors or warnings. Logs will almost always point you to the root cause.
+
+- **Locally:** Check the terminal output from `pnpm dev` for error messages or stack traces.
+- **Envio Cloud:** Go to your deployment in the Envio Cloud dashboard and open the **Logs** tab.
+
+If the logs don't reveal an obvious error, work through the common causes below:
+
+1. **RPC rate limiting or connectivity issues**
+   - If using RPC sync, your provider may be throttling requests. Check your RPC provider's dashboard for 429 errors or usage spikes.
+   - Try switching to a different RPC endpoint or using HyperSync if your network is supported.
+
+2. **Large blocks or high event density**
+   - Some blocks contain an unusually large number of events (e.g., airdrop blocks, protocol launches). The indexer may appear stuck while processing them.
+   - Check the logs for the current block number — if it's advancing slowly rather than frozen, the indexer is likely processing a dense block range.
+
+3. **Handler errors causing silent failures**
+   - An unhandled error in your event handler can cause the indexer to stall. Look for error messages or stack traces in the logs that point to a specific handler or event.
+
+4. **Memory pressure**
+   - Processing very large datasets or having expensive handler logic (e.g., many `eth_call` requests) can cause memory issues. See the performance optimization guide for tuning options.
+
+**If running on Envio Cloud:**
+
+- Check the deployment logs in the Envio Cloud dashboard for error details.
+- If the deployment is unrecoverable, you can delete it and redeploy from the dashboard.
+- Consider running the same configuration locally first to reproduce and debug the issue before redeploying.
+
+## Rate Limiting on Hosted Service
+
+### HTTP 429 errors when querying your endpoint
+
+**Problem:** You receive `429 Too Many Requests` responses when querying your hosted GraphQL endpoint, or your queries are being throttled.
+
+**Cause:** Envio Cloud applies rate limits to GraphQL query endpoints based on your plan tier. This protects shared infrastructure and ensures fair usage across all deployments.
+
+**What to check:**
+
+1. **Confirm it's a query rate limit (not an RPC issue)**
+   - Rate limiting applies to your _GraphQL query endpoint_, not to the indexer's data ingestion. If your indexer is slow to sync, that's a different issue — see Debugging a Stuck Indexer.
+
+2. **Check your plan's limits**
+   - Review your current plan in the Envio Cloud dashboard under your deployment settings. Higher-tier plans include higher query rate limits. See Billing & Plans for details.
+
+3. **Reduce query frequency from your application**
+   - If your frontend or backend polls the endpoint frequently, consider adding caching, reducing poll intervals, or using WebSocket subscriptions for real-time updates instead of polling.
+
+4. **Check for unexpected traffic**
+   - Ensure your endpoint URL hasn't been shared publicly or isn't being hit by an unintended client. You can restrict access — see the Hosted Service features for endpoint security options.
+
+5. **Upgrade your plan**
+   - If you consistently hit rate limits, consider upgrading to a higher tier for increased query throughput.
+
+## Hasura Authentication
+
+### Cannot log in to the Hasura console
+
+**Problem:** You're prompted for an admin secret or password when accessing the Hasura console, and don't know what it is.
+
+**Local development:**
+
+When running locally with `pnpm dev`, the default Hasura admin secret is `testing`. Access the console at `http://localhost:8080` and enter `testing` when prompted.
+
+You can customize this by setting the `HASURA_GRAPHQL_ADMIN_SECRET` environment variable before starting your indexer.
+
+**Envio Cloud (hosted):**
+
+On Envio Cloud, you **do not need the Hasura admin secret** to query your data. Your deployed indexer exposes a public GraphQL endpoint that you can query directly without authentication:
+
+```
+https://indexer.dev.hyperindex.xyz//v1/graphql
+```
+
+The Hasura console UI is not exposed on hosted deployments. To explore your data, use the GraphQL playground available in the Envio Cloud dashboard, or query the endpoint directly from your application or tools like Postman.
+
+If you need to restrict access to your endpoint, see the Hosted Service features for security options.
+
 ## Infrastructure Conflicts
 
 ### Postgres running locally
@@ -10028,6 +11718,34 @@ You can further customize your Postgres connection with these additional environ
 - `ENVIO_PG_PASSWORD`: Set a custom password
 - `ENVIO_PG_USER`: Set a custom username
 - `ENVIO_PG_DATABASE`: Set a custom database name
+
+## Missing Events
+
+### Events not appearing in indexed data
+
+**Problem:** Some expected events are missing from your indexed data, or event counts don't match what you see on-chain.
+
+**Common causes:**
+
+1. **Incorrect `start_block`**
+   - If your `start_block` is set after the block where the event was emitted, it will be missed. Verify that the start block in your `config.yaml` is at or before the contract's deployment block.
+
+2. **ABI mismatch**
+   - If the ABI in your config doesn't match the contract's actual event signature, events won't be decoded. Double-check that your ABI file is up to date and matches the deployed contract.
+
+3. **Missing contract address**
+   - For multi-address or dynamic contract setups, ensure all relevant addresses are registered. If using dynamic contracts, verify that the `contractRegister` handler is correctly adding addresses.
+
+4. **RPC provider issues**
+   - Some RPC providers may return incomplete log data, especially for older blocks. Try switching to a different RPC endpoint or use HyperSync for more reliable data retrieval.
+
+5. **Reorg handling**
+   - During chain reorganizations, events from orphaned blocks may temporarily appear and then be removed. If `rollback_on_reorg` is enabled (default), the indexer will handle this automatically. See Reorg Support.
+
+**How to verify:**
+
+- Check the indexer logs for any skipped blocks or error messages
+- Test with a small block range locally to isolate the issue
 
 ---
 
@@ -11449,7 +13167,7 @@ The Company will retain Your Personal Data only for as long as is necessary for 
 The Company will also retain Usage Data for internal analysis purposes. Usage Data is generally retained for a shorter period of time, except when this data is used to strengthen the security or to improve the functionality of Our Service, or We are legally obligated to retain this data for longer time periods.
 
 Transfer of Your Personal Data
-Your information, including Personal Data, is processed at the Company's operating offices and in any other places where the parties involved in the processing are located. It means that this information may be transferred to - and maintained on - computers located outside of Your state, province, country, or other governmental jurisdiction where the data protection laws may differ than those from Your jurisdiction.
+Your information, including Personal Data, is processed at the Company's operating offices and in any other places where the parties involved in the processing are located. It means that this information may be transferred to — and maintained on — computers located outside of Your state, province, country, or other governmental jurisdiction where the data protection laws may differ than those from Your jurisdiction.
 
 Your consent to this Privacy Policy followed by Your submission of such information represents Your agreement to that transfer.
 
@@ -11521,20 +13239,7 @@ HyperIndex is the fastest blockchain indexer available. In independent benchmark
 
 ### What blockchains does HyperIndex support?
 
-
-## Frequently Asked Questions (FAQ)
-
-### What is HyperIndex?
-
-HyperIndex is Envio's multichain blockchain indexing framework. It lets developers define which smart contract events to track, automatically transforms those on-chain events into structured data, and exposes them via a GraphQL API — giving you a complete, queryable backend for any blockchain application. It is powered by HyperSync, Envio's high-performance data engine.
-
-### How fast is HyperIndex compared to other indexers?
-
-HyperIndex is the fastest blockchain indexer available. In independent benchmarks conducted by Sentio in April 2025, HyperIndex was up to 6x faster than the nearest competitor and over 63x faster than TheGraph in real-world scenarios. For example, indexing LBTC token transfers took 3 minutes with HyperIndex versus 3 hours and 9 minutes with TheGraph.
-
-### What blockchains does HyperIndex support?
-
-HyperIndex supports all EVM-compatible chains. Over <HyperSyncChainCountPlain /> networks have native HyperSync support for maximum performance. For chains without HyperSync, indexing is available via RPC endpoints.
+HyperIndex supports all EVM-compatible chains. Over 70 networks have native HyperSync support for maximum performance. For chains without HyperSync, indexing is available via RPC endpoints.
 
 ### What programming languages can I use?
 
@@ -11542,15 +13247,15 @@ HyperIndex supports TypeScript, JavaScript, and ReScript for writing event handl
 
 ### What are the prerequisites to run HyperIndex locally?
 
-You need Node.js v22 or newer, pnpm v8 or newer, and Docker Desktop. Docker is only required for local development — if you use Envio Cloud, you can skip it. Windows users also need WSL (Windows Subsystem for Linux).
+You need Node.js v22 or newer, pnpm v8 or newer, and Docker Desktop. Docker is only required for local development - if you use Envio's hosted service, you can skip it. Windows users also need WSL (Windows Subsystem for Linux).
 
 ### Do I need an API token?
 
-API tokens are required for local development and self-hosted deployments as of 3 November 2025. You can set your token via the `ENVIO_API_TOKEN` environment variable in your project's `.env` file. Indexers deployed to Envio Cloud have special access and do not require a custom API token.
+API tokens are required for local development and self-hosted deployments as of 3 November 2025. You can set your token via the `ENVIO_API_TOKEN` environment variable in your project's `.env` file. Indexers deployed to Envio's hosted service have special access and do not require a custom API token.
 
 ### How do I get started?
 
-Run the following command and follow the prompts — you can have a working indexer in under 5 minutes:
+Run the following command and follow the prompts - you can have a working indexer in under 5 minutes:
 
 ```bash
 pnpx envio init
@@ -11568,25 +13273,25 @@ Yes. HyperIndex automatically handles blockchain reorganisations by default. Thi
 
 ### Does HyperIndex support multichain indexing?
 
-Yes. HyperIndex natively supports indexing across multiple chains in a single indexer. For the best multichain performance, you can enable `unordered_multichain_mode` in your configuration — this is the most common setup for multichain indexing, though it comes with tradeoffs worth understanding (see the docs).
+Yes. HyperIndex natively supports indexing across multiple chains in a single indexer. For the best multichain performance, you can enable `unordered_multichain_mode` in your configuration - this is the most common setup for multichain indexing, though it comes with tradeoffs worth understanding (see the docs).
 
 ### Can I do wildcard indexing (without a specific contract address)?
 
-Yes. HyperIndex supports wildcard indexing, which lets you index all events matching a given event signature across any contract on the chain — no contract address required.
+Yes. HyperIndex supports wildcard indexing, which lets you index all events matching a given event signature across any contract on the chain - no contract address required.
 
 ### How do I migrate from TheGraph and other indexing solutions?
 
 HyperIndex has a dedicated migration guide for TheGraph subgraphs. The three main steps are: (1) convert your `subgraph.yaml` to `config.yaml`, (2) migrate your schema (near copy-paste), and (3) migrate your event handlers. Run `pnpx envio init` to generate a boilerplate, then follow the Migration Guide.
 
-For developers migrating from other indexing solutions such as Ponder, Ormi, SQD (Subsquid), SubQuery, and others, the core concepts map similarly — define your contracts and events in `config.yaml`, write event handlers, and let HyperIndex generate the GraphQL API. Envio also offers full white glove migration support for teams moving from any indexing stack. Reach out via [Discord](https://discord.gg/envio) to get personalised assistance.
+For developers migrating from other indexing solutions such as Ponder, Ormi, SQD (Subsquid), SubQuery, and others, the core concepts map similarly - define your contracts and events in `config.yaml`, write event handlers, and let HyperIndex generate the GraphQL API. Envio also offers full white glove migration support for teams moving from any indexing stack. Reach out via [Discord](https://discord.gg/envio) to get personalised assistance.
 
-### What does Envio Cloud offer?
+### What does the hosted service offer?
 
-Envio Cloud manages deployment and infrastructure for you. Indexers on Envio Cloud do not require a custom API token for HyperSync access. For pricing details and self-hosted tiered packages, reach out on Discord.
+Envio's hosted service manages deployment and infrastructure for you. Indexers on the hosted service do not require a custom API token for HyperSync access. For pricing details and self-hosted tiered packages, reach out on Discord.
 
 ### Where can I get help?
 
-- **Discord**: [discord.gg/envio](https://discord.gg/envio) — the fastest way to get help from the team and community
-- **Telegram**: [Envio Telegram](https://t.me/+kAIGElzPjApiMjI0) - the official Envio Telegram to get support from the team and community
+- **Discord**: [discord.gg/envio](https://discord.gg/envio) - the fastest way to get help from the team and community
+- **Telegram**: [Envio Telegram](https://t.me/+kAIGElzPjApiMjI0) - the offcial Envio Telegram to get support from the team and community
 - **GitHub**: [github.com/enviodev](https://github.com/enviodev)
 - **Email**: hello@envio.dev

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -681,10 +681,6 @@ Join our Discord if you need support. It is the fastest way to get direct help f
 
 **File:** `migrate-to-v3.md`
 
-:::warning
-HyperIndex V3 is currently in **alpha**. While we don't plan major API changes, some features may still undergo minor breaking changes and developer experience improvements.
-:::
-
 # Migrate to HyperIndex V3 Alpha
 
 15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped 32 minor releases and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -366,13 +366,7 @@ pnpx envio init
 Follow the CLI prompts to set up the boilerplate indexer with the same contracts and events as your existing subgraph.
 
 :::caution
-The Claude skills are only available in HyperIndex v3. If the latest stable version is not v3, you need to specify a v3 version explicitly:
-
-```bash
-pnpx envio@3.0.0-alpha.21 init
-```
-
-Replace `3.0.0-alpha.21` with the latest available v3 version. You can find the latest releases [here](https://github.com/enviodev/hyperindex/releases).
+The Claude skills are only available in HyperIndex v3. See the v3 migration guide for current install guidance.
 :::
 
 ## Step 2: Set Up a Monorepo Structure
@@ -2256,7 +2250,7 @@ pnpm dev
 
 - [ ] Update Node.js to >=22
 - [ ] **Add `"type": "module"` to `package.json`** ← Required for V3!
-- [ ] Update `envio` dependency to latest `3.0.0-alpha.x`
+- [ ] Update `envio` dependency to the latest v3 release
 - [ ] Remove the `optionalDependencies.generated` entry from `package.json` (alpha.24+)
 - [ ] Update `engines.node` to `>=22.0.0` in `package.json`
 - [ ] Update `tsconfig.json` for ESM support

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -1008,7 +1008,7 @@ Join our Discord if you need support. It is the fastest way to get direct help f
 
 15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped 32 minor releases and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.
 
-HyperIndex V3 Alpha focuses on modernizing the codebase and laying the foundation for many more months of development. This guide walks you through upgrading from V2 to V3.
+HyperIndex V3 focuses on modernizing the codebase and laying the foundation for many more months of development. This guide walks you through upgrading from V2 to V3.
 
 ## New Features
 

--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -1275,7 +1275,7 @@ pnpm dev
 
 - [ ] Update Node.js to >=22
 - [ ] **Add `"type": "module"` to `package.json`** ← Required for V3!
-- [ ] Update `envio` dependency to latest `3.0.0-alpha.x`
+- [ ] Update `envio` dependency to the latest v3 release
 - [ ] Remove the `optionalDependencies.generated` entry from `package.json` (alpha.24+)
 - [ ] Update `engines.node` to `>=22.0.0` in `package.json`
 - [ ] Update `tsconfig.json` for ESM support

--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -3,14 +3,14 @@ id: migrate-to-v3
 title: Migrate to HyperIndex V3
 sidebar_label: Migrate to V3
 slug: /migrate-to-v3
-description: Learn how to upgrade from HyperIndex V2 to V3 Alpha, featuring ESM support, top-level await, automatic handler registration, new testing framework, and more.
+description: Learn how to upgrade from HyperIndex V2 to V3, featuring ESM support, top-level await, automatic handler registration, new testing framework, and more.
 ---
 
 # Migrate to HyperIndex V3
 
 15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped [32 minor releases](https://github.com/enviodev/hyperindex/releases) and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.
 
-HyperIndex V3 Alpha focuses on modernizing the codebase and laying the foundation for many more months of development. This guide walks you through upgrading from V2 to V3.
+HyperIndex V3 focuses on modernizing the codebase and laying the foundation for many more months of development. This guide walks you through upgrading from V2 to V3.
 
 ## New Features
 

--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -6,10 +6,6 @@ slug: /migrate-to-v3
 description: Learn how to upgrade from HyperIndex V2 to V3 Alpha, featuring ESM support, top-level await, automatic handler registration, new testing framework, and more.
 ---
 
-:::warning
-HyperIndex V3 is currently in **alpha**. While we don't plan major API changes, some features may still undergo minor breaking changes and developer experience improvements.
-:::
-
 # Migrate to HyperIndex V3
 
 15 full months have passed since the official HyperIndex v2.0.0. Since then, we have shipped [32 minor releases](https://github.com/enviodev/hyperindex/releases) and multiple patches with **zero breaking changes** to the documented API. We also received PRs from 6 external contributors, grew from 1 GitHub star to over 470, and saw many big projects rely on HyperIndex.

--- a/docs/HyperIndex/migrate-with-ai.md
+++ b/docs/HyperIndex/migrate-with-ai.md
@@ -27,13 +27,7 @@ pnpx envio init
 Follow the CLI prompts to set up the boilerplate indexer with the same contracts and events as your existing subgraph.
 
 :::caution
-The Claude skills are only available in HyperIndex v3. If the latest stable version is not v3, you need to specify a v3 version explicitly:
-
-```bash
-pnpx envio@3.0.0-alpha.21 init
-```
-
-Replace `3.0.0-alpha.21` with the latest available v3 version. You can find the latest releases [here](https://github.com/enviodev/hyperindex/releases).
+The Claude skills are only available in HyperIndex v3. See the [v3 migration guide](./migrate-to-v3) for current install guidance.
 :::
 
 ## Step 2: Set Up a Monorepo Structure

--- a/docs/HyperIndex/quickstart-with-ai.md
+++ b/docs/HyperIndex/quickstart-with-ai.md
@@ -25,7 +25,7 @@ If you'd rather drive the CLI yourself, see [Getting Started](./getting-started)
 - An AI coding assistant (we recommend **[Claude Code](https://claude.com/claude-code)**)
 
 :::info HyperIndex v3
-Some features below (notably the **built-in Claude skills**) ship with **HyperIndex v3**, which will be released soon. Until v3 is the default stable release, pin to a v3 version explicitly (e.g. `pnpx envio@3.0.0-alpha.21 ...`). See the [v3 migration guide](./migrate-to-v3) for the latest version.
+Some features below (notably the **built-in Claude skills**) ship with **HyperIndex v3**. See the [v3 migration guide](./migrate-to-v3) for current install guidance.
 :::
 
 ---

--- a/docs/HyperIndex/quickstart-with-ai.md
+++ b/docs/HyperIndex/quickstart-with-ai.md
@@ -25,7 +25,7 @@ If you'd rather drive the CLI yourself, see [Getting Started](./getting-started)
 - An AI coding assistant (we recommend **[Claude Code](https://claude.com/claude-code)**)
 
 :::info HyperIndex v3
-Some features below (notably the **built-in Claude skills**) ship with **HyperIndex v3**, which will be released soon. Until v3 is the default stable release, pin to a v3 version explicitly (e.g. `pnpx envio@3.0.0-alpha.21 ...`). See the [v3 migration guide](./migrate-to-v3) for the latest alpha version.
+Some features below (notably the **built-in Claude skills**) ship with **HyperIndex v3**, which will be released soon. Until v3 is the default stable release, pin to a v3 version explicitly (e.g. `pnpx envio@3.0.0-alpha.21 ...`). See the [v3 migration guide](./migrate-to-v3) for the latest version.
 :::
 
 ---

--- a/scripts/consolidate-hyperindex-docs.js
+++ b/scripts/consolidate-hyperindex-docs.js
@@ -93,8 +93,13 @@ function fixInternalLinks(content, relativePath) {
   content = content.replace(/\[([^\]]+)\]\(\/docs\/HyperIndex\/[^)]+\)/g, "$1");
   content = content.replace(/\[([^\]]+)\]\(\/docs\/HyperSync\/[^)]+\)/g, "$1");
 
-  // Remove any remaining markdown links (but do not touch markdown images: `![alt](...)`)
-  content = content.replace(/(?<!\!)\[([^\]]+)\]\([^)]+\)/g, "$1");
+  // Remove any remaining markdown links to internal/relative paths.
+  // Preserve external URLs (http/https), anchors (#), and mailto: links.
+  // Also do not touch markdown images: `![alt](...)`.
+  content = content.replace(
+    /(?<!\!)\[([^\]]+)\]\((?!https?:\/\/|mailto:|#)[^)]+\)/g,
+    "$1"
+  );
 
   // Remove image references that cause errors - be more aggressive
   content = content.replace(/!\[([^\]]*)\]\([^)]+\)/g, "");


### PR DESCRIPTION
## Summary
Removes the alpha status warning from the HyperIndex V3 migration documentation, indicating that V3 is no longer in alpha and is ready for general use.

## Changes
- Removed the alpha warning callout box from `docs/HyperIndex/migrate-to-v3.md`
- Removed the alpha warning callout box from `docs/HyperIndex-LLM/hyperindex-complete.mdx`

Both files had identical warning blocks that stated "HyperIndex V3 is currently in **alpha**" with notes about potential minor breaking changes. These have been removed as V3 appears to have reached a stable release status.

https://claude.ai/code/session_01NU4uJNAfYFcJrp129fN7wV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised HyperIndex V3 migration guide to remove "alpha" wording and reflect stable V3 messaging.
  * Updated quickstart and migration notes to instruct users to follow the V3 migration guide and reference the latest V3 release.
  * Clarified availability of Claude skills in HyperIndex V3.

* **Chores**
  * Improved docs link consolidation to preserve external links and images while better handling internal links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->