### PR TITLE
Add case-studies tag to GBlast blog

### DIFF
--- a/blog/2024-07-17-case-study-gblast.md
+++ b/blog/2024-07-17-case-study-gblast.md
@@ -2,6 +2,7 @@
 title: "How GBlast Eliminated Data Latency in Their GambleFi Platform"
 sidebar_label: "How GBlast Eliminated Data Latency in Their GambleFi Platform"
 slug: /case-study-gblast
+tags: ["case-studies"]
 description: "How GBlast integrated Envio to eliminate real-time data latency, power their points system, and deliver a responsive GambleFi experience on Blast."
 image: /blog-assets/case-study-gblast.png
 last_update:


### PR DESCRIPTION
GBlast was the only case study post missing the `case-studies` tag. Adding it so the post appears on /blog/tag/case-studies alongside the others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated blog post metadata to include case studies categorization for improved content organization and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->