### PR TITLE
Update CLI commands to use stable v3.0.0 release

### DIFF
--- a/blog/2025-12-16-dev-update-december-2025.md
+++ b/blog/2025-12-16-dev-update-december-2025.md
@@ -134,7 +134,7 @@ Try it out with:
 
 
 ```
-pnpx envio@3.0.0-alpha.3 init solana
+pnpx envio init solana
 ```
 
 

--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -55,7 +55,7 @@ Here's the full workflow an agent ran to deploy a live ERC20 indexer for wstETH 
 ### Step 1: Scaffold the indexer
 
 ```
-pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""
+pnpx envio init template -t erc20 -l typescript -d ./my-indexer
 ```
 
 The `envio` CLI scaffolds a TypeScript ERC20 indexer template. No API token is needed at this stage as authentication is handled through the hosted service at deployment time.
@@ -150,7 +150,7 @@ npm install -g envio-cloud
 Scaffold your first indexer:
 
 ```
-pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""
+pnpx envio init template -t erc20 -l typescript -d ./my-indexer
 ```
 
 Whether you're building on Monad, Ethereum, or any other EVM compatible network, Envio enables agent driven indexing from first prompt to live deployment. The GitHub-native deployment flow means agents that can commit code can deploy indexers in minutes.
@@ -172,7 +172,7 @@ In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Fac
 Envio supports any EVM-compatible chain. HyperSync natively covers <HyperSyncChainCount /> EVM chains for maximum speed, including Ethereum, Base, Arbitrum, Optimism, Polygon, and Monad. Any EVM chain without native HyperSync support can be indexed via standard RPC.
 
 ### How do I get started with agentic indexing on Envio?
-Install the Envio Cloud CLI with `npm install -g envio-cloud`, then scaffold your first indexer with `pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""`. Push to GitHub and deploy with the envio-cloud CLI.
+Install the Envio Cloud CLI with `npm install -g envio-cloud`, then scaffold your first indexer with `pnpx envio init template -t erc20 -l typescript -d ./my-indexer`. Push to GitHub and deploy with the envio-cloud CLI.
 
 ## About Envio Cloud
 

--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -55,7 +55,7 @@ Here's the full workflow an agent ran to deploy a live ERC20 indexer for wstETH 
 ### Step 1: Scaffold the indexer
 
 ```
-pnpx envio@3.0.0-alpha.18 init template -t erc20 -l typescript -d ./my-indexer --api-token ""
+pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""
 ```
 
 The `envio` CLI scaffolds a TypeScript ERC20 indexer template. No API token is needed at this stage as authentication is handled through the hosted service at deployment time.
@@ -150,7 +150,7 @@ npm install -g envio-cloud
 Scaffold your first indexer:
 
 ```
-pnpx envio@3.0.0-alpha.18 init template -t erc20 -l typescript -d ./my-indexer --api-token ""
+pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""
 ```
 
 Whether you're building on Monad, Ethereum, or any other EVM compatible network, Envio enables agent driven indexing from first prompt to live deployment. The GitHub-native deployment flow means agents that can commit code can deploy indexers in minutes.
@@ -172,7 +172,7 @@ In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Fac
 Envio supports any EVM-compatible chain. HyperSync natively covers <HyperSyncChainCount /> EVM chains for maximum speed, including Ethereum, Base, Arbitrum, Optimism, Polygon, and Monad. Any EVM chain without native HyperSync support can be indexed via standard RPC.
 
 ### How do I get started with agentic indexing on Envio?
-Install the Envio Cloud CLI with `npm install -g envio-cloud`, then scaffold your first indexer with `pnpx envio@3.0.0-alpha.18 init template -t erc20 -l typescript -d ./my-indexer --api-token ""`. Push to GitHub and deploy with the envio-cloud CLI.
+Install the Envio Cloud CLI with `npm install -g envio-cloud`, then scaffold your first indexer with `pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""`. Push to GitHub and deploy with the envio-cloud CLI.
 
 ## About Envio Cloud
 

--- a/blog/2026-03-23-dev-update-march-2026.md
+++ b/blog/2026-03-23-dev-update-march-2026.md
@@ -103,7 +103,7 @@ As an example, **400,000+ wstETH events were indexed on Monad in ~20 seconds.**
 Use the following command to scaffold your indexer:
 
 ```bash
-pnpx envio@3.0.0-alpha.18 init template -t erc20 -l typescript -d ./my-indexer --api-token ""
+pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""
 ```
 
 Learn more in our blog and test it yourself here: [https://docs.envio.dev/blog/agentic-blockchain-indexing-envio-hyperindex](https://docs.envio.dev/blog/agentic-blockchain-indexing-envio-hyperindex)

--- a/blog/2026-03-23-dev-update-march-2026.md
+++ b/blog/2026-03-23-dev-update-march-2026.md
@@ -103,7 +103,7 @@ As an example, **400,000+ wstETH events were indexed on Monad in ~20 seconds.**
 Use the following command to scaffold your indexer:
 
 ```bash
-pnpx envio init template -t erc20 -l typescript -d ./my-indexer --api-token ""
+pnpx envio init template -t erc20 -l typescript -d ./my-indexer
 ```
 
 Learn more in our blog and test it yourself here: [https://docs.envio.dev/blog/agentic-blockchain-indexing-envio-hyperindex](https://docs.envio.dev/blog/agentic-blockchain-indexing-envio-hyperindex)

--- a/blog/2026-04-24-clickhouse-storage.md
+++ b/blog/2026-04-24-clickhouse-storage.md
@@ -76,7 +76,7 @@ Do not run multiple indexers writing to the same ClickHouse database at the same
 To scaffold a new V3 alpha indexer, run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 This will set up a fresh project on the latest alpha release. Enable both storage backends in `config.yaml`:

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -983,6 +983,7 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 For detailed release notes, see:
 
 - [v3.0.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0)
+- [v3.0.0-rc.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.0)
 - [v3.0.0-alpha.24](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.24)
 - [v3.0.0-alpha.23](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.23)
 - [v3.0.0-alpha.22](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.22)

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -81,7 +81,7 @@ Upcoming features on our development roadmap:
 
 The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex.
 
-**Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio@3.0.0-rc.0 init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
+**Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
 
 
 ## Getting Started
@@ -89,7 +89,7 @@ The **Quickstart** enables you to instantly autogenerate a powerful blockchain i
 Run the following command to initialize your blockchain indexer:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 You'll then follow interactive prompts to customize your indexer.
@@ -599,12 +599,12 @@ HyperIndex now supports Solana with RPC as a source. This feature is experimenta
 To initialize a Solana project:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init svm
+pnpx envio init svm
 ```
 
 See the Solana documentation for more details.
 
-### `pnpx envio@3.0.0-rc.0 init` Improvements
+### `pnpx envio init` Improvements
 
 - Removed language selection to prefer TypeScript by default
 - Cleaned up templates to follow the latest good practices
@@ -982,7 +982,7 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 
 For detailed release notes, see:
 
-- [v3.0.0-rc.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.0)
+- [v3.0.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0)
 - [v3.0.0-alpha.24](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.24)
 - [v3.0.0-alpha.23](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.23)
 - [v3.0.0-alpha.22](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.22)
@@ -1068,7 +1068,7 @@ HyperIndex v3 includes built-in Claude skills that guide AI programming assistan
 Create a new HyperIndex indexer that indexes the same contracts and events as the subgraph you are migrating. Run the following in a new directory:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 Follow the CLI prompts to set up the boilerplate indexer with the same contracts and events as your existing subgraph.
@@ -1193,13 +1193,13 @@ or run
 
 to verify the indexer is running and indexing correctly.
 
-### 0.5 Use `pnpx envio@3.0.0-rc.0 init` to generate a boilerplate
+### 0.5 Use `pnpx envio init` to generate a boilerplate
 
-As a first step, we recommend using `pnpx envio@3.0.0-rc.0 init` to generate a boilerplate for your project. This will handle the creation of the `config.yaml` file and a basic `schema.graphql` file with generic handler functions.
+As a first step, we recommend using `pnpx envio init` to generate a boilerplate for your project. This will handle the creation of the `config.yaml` file and a basic `schema.graphql` file with generic handler functions.
 
 ### 1. `subgraph.yaml` → `config.yaml`
 
-`pnpx envio@3.0.0-rc.0 init` will generate this for you. It's a simple configuration file conversion. Effectively specifying which contracts to index, which networks to index (multiple networks can be specified with envio) and which events from those contracts to index.
+`pnpx envio init` will generate this for you. It's a simple configuration file conversion. Effectively specifying which contracts to index, which networks to index (multiple networks can be specified with envio) and which events from those contracts to index.
 
 Take the following conversion as an example, where the `subgraph.yaml` file is converted to `config.yaml` the below comparisons is for the Uniswap v4 pool manager subgraph.
 
@@ -1558,7 +1558,7 @@ This Migration consists of 4 major steps:
 Start by spinning up a basic HyperIndex project with this command:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template --name alchemy-migration --directory alchemy-migration --template  greeter --api-token "YOUR_ENVIO_API_KEY"
+pnpx envio init template --name alchemy-migration --directory alchemy-migration --template  greeter --api-token "YOUR_ENVIO_API_KEY"
 ```
 
 Once the project is created, drop your API key into the .env file and you’re good to go.
@@ -1757,7 +1757,7 @@ Update Node.js to **22 or higher** (24 is recommended). Earlier versions are no 
        "node": ">=22.0.0"
      },
      "dependencies": {
-       "envio": "3.0.0-rc.0"
+       "envio": "3.0.0"
      },
      "devDependencies": {
        "@types/node": "24.12.2",
@@ -3178,7 +3178,7 @@ If you prefer to explore by example, the Greeter template includes complete test
 1. Generate `greeter` template in TypeScript using Envio CLI
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template -l typescript -d greeter -t greeter -n greeter
+pnpx envio init template -l typescript -d greeter -t greeter -n greeter
 ```
 
 2. Run tests
@@ -4895,7 +4895,7 @@ Before starting, ensure you have the following installed:
 1. Open your terminal in an empty directory and run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 2. Name your indexer (we'll use "optimism-bridge-indexer" in this example):
@@ -5092,7 +5092,7 @@ Before starting, ensure you have the following installed:
 1. Open your terminal in an empty directory and run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 2. Name your indexer (we'll use "usdc-base-transfer-indexer" in this example):
@@ -5284,7 +5284,7 @@ Now that you have installed the prerequisite packages let's begin the practical 
 Open your terminal in an empty directory and initialize a new indexer by running the command:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 In the following prompt, choose the directory where you want to set up your project. The default is the current directory, but in the tutorial, I'll use the indexer name:
@@ -5615,7 +5615,7 @@ First, let's create a new project using Envio's Greeter template:
 1. Open your terminal and run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 2. When prompted for a directory, you can press Enter to use the current directory or specify another path:
@@ -6015,7 +6015,7 @@ Now let's build an indexer that compares all three methods when tracking Uniswap
 Create a new Envio indexer project:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 ### Step 2: Configure Your Indexer
@@ -7423,7 +7423,7 @@ For a gentle introduction to viem with a similar example, check out this [medium
 First, create a new indexer:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 When prompted, enter the Ethereum mainnet Uniswap V3 Factory address: `0x1F98431c8aD98523631AE4a59f267346ea31F984`
@@ -7719,7 +7719,7 @@ First, let's create a basic indexer that tracks NFT ownership:
 ### Initialize the Indexer
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 When prompted, enter the Bored Ape Yacht Club contract address: `0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D`
@@ -9174,11 +9174,11 @@ These examples show the full command with all options to initialize and start an
 Create and start a USDC indexer on Ethereum:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init contract-import explorer -n usdc-indexer -c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 -b ethereum-mainnet --single-contract --all-events -l typescript -d usdc-indexer --api-token "your-api-token" && cd usdc-indexer && pnpm dev
+pnpx envio init contract-import explorer -n usdc-indexer -c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 -b ethereum-mainnet --single-contract --all-events -l typescript -d usdc-indexer --api-token "your-api-token" && cd usdc-indexer && pnpm dev
 ```
 
 **What each part does:**
-- `pnpx envio@3.0.0-rc.0 init contract-import explorer` - Initialize from block explorer
+- `pnpx envio init contract-import explorer` - Initialize from block explorer
 - `-n usdc-indexer` - Project name
 - `-c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` - USDC contract address
 - `-b ethereum-mainnet` - Network
@@ -9195,11 +9195,11 @@ pnpx envio@3.0.0-rc.0 init contract-import explorer -n usdc-indexer -c 0xA0b8699
 For unverified contracts or custom networks:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init contract-import local -n my-indexer -a ./abis/MyContract.json -c 0xYourContractAddress -b ethereum-mainnet --contract-name MyContract --single-contract --all-events -l typescript -d my-indexer --api-token "your-api-token" && cd my-indexer && pnpm dev
+pnpx envio init contract-import local -n my-indexer -a ./abis/MyContract.json -c 0xYourContractAddress -b ethereum-mainnet --contract-name MyContract --single-contract --all-events -l typescript -d my-indexer --api-token "your-api-token" && cd my-indexer && pnpm dev
 ```
 
 **What each part does:**
-- `pnpx envio@3.0.0-rc.0 init contract-import local` - Initialize from local ABI file
+- `pnpx envio init contract-import local` - Initialize from local ABI file
 - `-a ./abis/MyContract.json` - Path to ABI file
 - `--contract-name MyContract` - Name for the contract
 - `-b ethereum-mainnet` - Network name (or use chain ID for local import)
@@ -9210,11 +9210,11 @@ pnpx envio@3.0.0-rc.0 init contract-import local -n my-indexer -a ./abis/MyContr
 Quick start with an ERC20 template:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template -n erc20-example -t erc20 -l typescript -d erc20-indexer --api-token "your-api-token" && cd erc20-indexer && pnpm dev
+pnpx envio init template -n erc20-example -t erc20 -l typescript -d erc20-indexer --api-token "your-api-token" && cd erc20-indexer && pnpm dev
 ```
 
 **What each part does:**
-- `pnpx envio@3.0.0-rc.0 init template` - Initialize from template
+- `pnpx envio init template` - Initialize from template
 - `-t erc20` - Use ERC20 template
 - Other flags same as above
 
@@ -12007,7 +12007,7 @@ Can’t find what you’re looking for or need support? Reach out to us on [Disc
 
 **File:** `solana/solana.md`
 
-> Experimental. Available since 3.0.0-alpha.3.  
+> Experimental. Available since 3.0.0.  
 > RPC-only source. HyperSync for Solana is not available yet; we’ll consider it if there’s demand.
 
 ## What’s supported
@@ -12019,7 +12019,7 @@ Can’t find what you’re looking for or need support? Reach out to us on [Disc
 ## Quickstart
 
 ```bash
-pnpx envio@3.0.0-alpha.14 init svm
+pnpx envio init svm
 ```
 
 ## Notes

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -12008,7 +12008,7 @@ Can’t find what you’re looking for or need support? Reach out to us on [Disc
 
 **File:** `solana/solana.md`
 
-> Experimental. Available since 3.0.0.  
+> Experimental.  
 > RPC-only source. HyperSync for Solana is not available yet; we’ll consider it if there’s demand.
 
 ## What’s supported

--- a/docs/HyperIndex/Guides/cli-commands.md
+++ b/docs/HyperIndex/Guides/cli-commands.md
@@ -339,11 +339,11 @@ These examples show the full command with all options to initialize and start an
 Create and start a USDC indexer on Ethereum:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init contract-import explorer -n usdc-indexer -c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 -b ethereum-mainnet --single-contract --all-events -l typescript -d usdc-indexer --api-token "your-api-token" && cd usdc-indexer && pnpm dev
+pnpx envio init contract-import explorer -n usdc-indexer -c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 -b ethereum-mainnet --single-contract --all-events -l typescript -d usdc-indexer --api-token "your-api-token" && cd usdc-indexer && pnpm dev
 ```
 
 **What each part does:**
-- `pnpx envio@3.0.0-rc.0 init contract-import explorer` - Initialize from block explorer
+- `pnpx envio init contract-import explorer` - Initialize from block explorer
 - `-n usdc-indexer` - Project name
 - `-c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` - USDC contract address
 - `-b ethereum-mainnet` - Network
@@ -360,11 +360,11 @@ pnpx envio@3.0.0-rc.0 init contract-import explorer -n usdc-indexer -c 0xA0b8699
 For unverified contracts or custom networks:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init contract-import local -n my-indexer -a ./abis/MyContract.json -c 0xYourContractAddress -b ethereum-mainnet --contract-name MyContract --single-contract --all-events -l typescript -d my-indexer --api-token "your-api-token" && cd my-indexer && pnpm dev
+pnpx envio init contract-import local -n my-indexer -a ./abis/MyContract.json -c 0xYourContractAddress -b ethereum-mainnet --contract-name MyContract --single-contract --all-events -l typescript -d my-indexer --api-token "your-api-token" && cd my-indexer && pnpm dev
 ```
 
 **What each part does:**
-- `pnpx envio@3.0.0-rc.0 init contract-import local` - Initialize from local ABI file
+- `pnpx envio init contract-import local` - Initialize from local ABI file
 - `-a ./abis/MyContract.json` - Path to ABI file
 - `--contract-name MyContract` - Name for the contract
 - `-b ethereum-mainnet` - Network name (or use chain ID for local import)
@@ -375,11 +375,11 @@ pnpx envio@3.0.0-rc.0 init contract-import local -n my-indexer -a ./abis/MyContr
 Quick start with an ERC20 template:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template -n erc20-example -t erc20 -l typescript -d erc20-indexer --api-token "your-api-token" && cd erc20-indexer && pnpm dev
+pnpx envio init template -n erc20-example -t erc20 -l typescript -d erc20-indexer --api-token "your-api-token" && cd erc20-indexer && pnpm dev
 ```
 
 **What each part does:**
-- `pnpx envio@3.0.0-rc.0 init template` - Initialize from template
+- `pnpx envio init template` - Initialize from template
 - `-t erc20` - Use ERC20 template
 - Other flags same as above
 

--- a/docs/HyperIndex/Guides/contract-state.md
+++ b/docs/HyperIndex/Guides/contract-state.md
@@ -57,7 +57,7 @@ For a gentle introduction to viem with a similar example, check out this [medium
 First, create a new indexer:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 When prompted, enter the Ethereum mainnet Uniswap V3 Factory address: `0x1F98431c8aD98523631AE4a59f267346ea31F984`

--- a/docs/HyperIndex/Guides/environment-variables.md
+++ b/docs/HyperIndex/Guides/environment-variables.md
@@ -24,6 +24,7 @@ To ensure continued access to HyperSync, set an Envio API token in your environm
 
 - Use `ENVIO_API_TOKEN` to provide your token at runtime
 - See the API Tokens guide for how to generate a token: [API Tokens](/docs/HyperSync/api-tokens)
+- A token is only required when using Envio as the data provider (HyperSync). Indexers that source data from an external RPC don't need one.
 
 ## Envio-specific environment variables
 

--- a/docs/HyperIndex/Guides/ipfs.md
+++ b/docs/HyperIndex/Guides/ipfs.md
@@ -31,7 +31,7 @@ First, let's create a basic indexer that tracks NFT ownership:
 ### Initialize the Indexer
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 When prompted, enter the Bored Ape Yacht Club contract address: `0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D`

--- a/docs/HyperIndex/Guides/running-locally.md
+++ b/docs/HyperIndex/Guides/running-locally.md
@@ -8,7 +8,7 @@ description: Learn how to start, run, and manage the Envio indexer locally with 
 
 ## Starting the Indexer
 
-Remember to `cd` into your project directory if you have defined one during `pnpx envio@3.0.0-rc.0 init`.
+Remember to `cd` into your project directory if you have defined one during `pnpx envio init`.
 
 Before running the Envio CLI command to start the indexer locally, please make sure you have [Docker](https://www.docker.com/products/docker-desktop/) running.
 

--- a/docs/HyperIndex/Guides/testing.mdx
+++ b/docs/HyperIndex/Guides/testing.mdx
@@ -24,7 +24,7 @@ If you prefer to explore by example, the Greeter template includes complete test
 1. Generate `greeter` template in TypeScript using Envio CLI
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template -l typescript -d greeter -t greeter -n greeter
+pnpx envio init template -l typescript -d greeter -t greeter -n greeter
 ```
 
 2. Run tests

--- a/docs/HyperIndex/Tutorials/greeter-tutorial.md
+++ b/docs/HyperIndex/Tutorials/greeter-tutorial.md
@@ -39,7 +39,7 @@ First, let's create a new project using Envio's Greeter template:
 1. Open your terminal and run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 2. When prompted for a directory, you can press Enter to use the current directory or specify another path:

--- a/docs/HyperIndex/Tutorials/price-data.md
+++ b/docs/HyperIndex/Tutorials/price-data.md
@@ -219,7 +219,7 @@ Now let's build an indexer that compares all three methods when tracking Uniswap
 Create a new Envio indexer project:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 ### Step 2: Configure Your Indexer

--- a/docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md
+++ b/docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md
@@ -29,7 +29,7 @@ Before starting, ensure you have the following installed:
 1. Open your terminal in an empty directory and run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 2. Name your indexer (we'll use "usdc-base-transfer-indexer" in this example):

--- a/docs/HyperIndex/Tutorials/tutorial-indexing-fuel.md
+++ b/docs/HyperIndex/Tutorials/tutorial-indexing-fuel.md
@@ -37,7 +37,7 @@ Now that you have installed the prerequisite packages let's begin the practical 
 Open your terminal in an empty directory and initialize a new indexer by running the command:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 In the following prompt, choose the directory where you want to set up your project. The default is the current directory, but in the tutorial, I'll use the indexer name:

--- a/docs/HyperIndex/Tutorials/tutorial-op-bridge-deposits.md
+++ b/docs/HyperIndex/Tutorials/tutorial-op-bridge-deposits.md
@@ -29,7 +29,7 @@ Before starting, ensure you have the following installed:
 1. Open your terminal in an empty directory and run:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 2. Name your indexer (we'll use "optimism-bridge-indexer" in this example):

--- a/docs/HyperIndex/contract-import.md
+++ b/docs/HyperIndex/contract-import.md
@@ -8,7 +8,7 @@ description: Learn to quickly autogenerate and configure a HyperIndex indexer fo
 
 The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex.
 
-**Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio@3.0.0-rc.0 init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
+**Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
 
 ---
 
@@ -31,7 +31,7 @@ The **Quickstart** enables you to instantly autogenerate a powerful blockchain i
 Run the following command to initialize your blockchain indexer:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 You'll then follow interactive prompts to customize your indexer.
@@ -252,5 +252,5 @@ Next step: [Running your Indexer locally](./running-locally) or [Deploying to En
 
 Contract Import is the recommended path, but you can also bootstrap an indexer from:
 
-- **Templates** — pre-built `ERC20` or [Greeter](./greeter-tutorial) projects, selectable from the `pnpx envio@3.0.0-rc.0 init` interactive prompt.
+- **Templates** — pre-built `ERC20` or [Greeter](./greeter-tutorial) projects, selectable from the `pnpx envio init` interactive prompt.
 - **Examples** — copy and adapt an existing indexer from the [Envio Explorer](https://envio.dev/explorer), our [Tutorials](./tutorial-erc20-token-transfers), or the [GitHub repositories](https://github.com/enviodev).

--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -42,7 +42,7 @@ This Migration consists of 4 major steps:
 Start by spinning up a basic HyperIndex project with this command:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template --name alchemy-migration --directory alchemy-migration --template  greeter --api-token "YOUR_ENVIO_API_KEY"
+pnpx envio init template --name alchemy-migration --directory alchemy-migration --template  greeter --api-token "YOUR_ENVIO_API_KEY"
 ```
 
 Once the project is created, drop your API key into the .env file and you’re good to go.

--- a/docs/HyperIndex/migrate-from-ponder.md
+++ b/docs/HyperIndex/migrate-from-ponder.md
@@ -44,7 +44,7 @@ pnpm dev             # run the indexer locally
 ## Step 0: Bootstrap the Project
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 This generates a `config.yaml`, a starter `schema.graphql`, and handler stubs. Use your Ponder project as the source of truth for contract addresses, ABIs, and events, then fill in the generated files.

--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -52,7 +52,7 @@ Update Node.js to **22 or higher** (24 is recommended). Earlier versions are no 
        "node": ">=22.0.0"
      },
      "dependencies": {
-       "envio": "3.0.0-rc.0"
+       "envio": "3.0.0"
      },
      "devDependencies": {
        "@types/node": "24.12.2",

--- a/docs/HyperIndex/migrate-with-ai.md
+++ b/docs/HyperIndex/migrate-with-ai.md
@@ -21,7 +21,7 @@ HyperIndex v3 includes built-in Claude skills that guide AI programming assistan
 Create a new HyperIndex indexer that indexes the same contracts and events as the subgraph you are migrating. Run the following in a new directory:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init
+pnpx envio init
 ```
 
 Follow the CLI prompts to set up the boilerplate indexer with the same contracts and events as your existing subgraph.

--- a/docs/HyperIndex/migration-guide.md
+++ b/docs/HyperIndex/migration-guide.md
@@ -54,13 +54,13 @@ or run
 
 to verify the indexer is running and indexing correctly.
 
-### 0.5 Use `pnpx envio@3.0.0-rc.0 init` to generate a boilerplate
+### 0.5 Use `pnpx envio init` to generate a boilerplate
 
-As a first step, we recommend using `pnpx envio@3.0.0-rc.0 init` to generate a boilerplate for your project. This will handle the creation of the `config.yaml` file and a basic `schema.graphql` file with generic handler functions.
+As a first step, we recommend using `pnpx envio init` to generate a boilerplate for your project. This will handle the creation of the `config.yaml` file and a basic `schema.graphql` file with generic handler functions.
 
 ### 1. `subgraph.yaml` → `config.yaml`
 
-`pnpx envio@3.0.0-rc.0 init` will generate this for you. It's a simple configuration file conversion. Effectively specifying which contracts to index, which networks to index (multiple networks can be specified with envio) and which events from those contracts to index.
+`pnpx envio init` will generate this for you. It's a simple configuration file conversion. Effectively specifying which contracts to index, which networks to index (multiple networks can be specified with envio) and which events from those contracts to index.
 
 Take the following conversion as an example, where the `subgraph.yaml` file is converted to `config.yaml` the below comparisons is for the Uniswap v4 pool manager subgraph.
 

--- a/docs/HyperIndex/quickstart-with-ai.md
+++ b/docs/HyperIndex/quickstart-with-ai.md
@@ -66,8 +66,7 @@ Full setup details in the [MCP Server guide](./mcp-server). If your assistant do
 pnpx envio init template \
   -t erc20 \
   -l typescript \
-  -d ./working-indexer \
-  --api-token ""
+  -d ./working-indexer
 ```
 
 ### Option B: Import a verified contract from an explorer
@@ -87,11 +86,11 @@ All `init` subcommands and flags are documented in the [Envio CLI reference](./c
 
 ### About the `--api-token` flag
 
-`--api-token` is the flag for your **HyperSync API token**. Passing it (even as an empty string, as in Option A above) skips the interactive prompt so the assistant can run `init` unattended. A few things to know:
+`--api-token` is the flag for your **HyperSync API token**. A few things to know:
 
 - The token **can't currently be created programmatically**. You generate one by logging in to [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens) and copying it into `ENVIO_API_TOKEN` in your indexer's `.env`.
 - It's **only required for local development and self-hosted deployments**. Indexers running on **Envio Cloud** get special access and don't need a custom token.
-- If you passed `--api-token ""` during init and want to run `pnpm dev` locally, generate a token from the link above and set `ENVIO_API_TOKEN` in `.env` before starting the indexer.
+- To run `pnpm dev` locally, generate a token from the link above and set `ENVIO_API_TOKEN` in `.env` before starting the indexer.
 
 See [API Tokens](/docs/HyperSync/api-tokens) and [Environment Variables](./environment-variables) for full details.
 

--- a/docs/HyperIndex/quickstart-with-ai.md
+++ b/docs/HyperIndex/quickstart-with-ai.md
@@ -90,6 +90,7 @@ All `init` subcommands and flags are documented in the [Envio CLI reference](./c
 
 - The token **can't currently be created programmatically**. You generate one by logging in to [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens) and copying it into `ENVIO_API_TOKEN` in your indexer's `.env`.
 - It's **only required for local development and self-hosted deployments**. Indexers running on **Envio Cloud** get special access and don't need a custom token.
+- It's **required when using Envio as the data provider (HyperSync)**. If you only use an external RPC as the data source, no token is needed — you can pass an empty string to skip the prompt.
 - To run `pnpm dev` locally, generate a token from the link above and set `ENVIO_API_TOKEN` in `.env` before starting the indexer.
 
 See [API Tokens](/docs/HyperSync/api-tokens) and [Environment Variables](./environment-variables) for full details.

--- a/docs/HyperIndex/quickstart-with-ai.md
+++ b/docs/HyperIndex/quickstart-with-ai.md
@@ -58,12 +58,12 @@ Full setup details in the [MCP Server guide](./mcp-server). If your assistant do
 
 ## Step 2. Initialize the Indexer Non-Interactively
 
-`pnpx envio@3.0.0-rc.0 init` normally walks you through an interactive wizard. When an AI assistant is driving the terminal, it's much easier to skip the prompts with flags so the assistant can run the command end-to-end without blocking on human input.
+`pnpx envio init` normally walks you through an interactive wizard. When an AI assistant is driving the terminal, it's much easier to skip the prompts with flags so the assistant can run the command end-to-end without blocking on human input.
 
 ### Option A: Start from a template
 
 ```bash
-pnpx envio@3.0.0-rc.0 init template \
+pnpx envio init template \
   -t erc20 \
   -l typescript \
   -d ./working-indexer \
@@ -73,7 +73,7 @@ pnpx envio@3.0.0-rc.0 init template \
 ### Option B: Import a verified contract from an explorer
 
 ```bash
-pnpx envio@3.0.0-rc.0 init contract-import explorer \
+pnpx envio init contract-import explorer \
   -n usdc-indexer \
   -c 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   -b ethereum-mainnet \

--- a/docs/HyperIndex/solana/solana.md
+++ b/docs/HyperIndex/solana/solana.md
@@ -6,7 +6,7 @@ slug: /solana
 description: Experimental Solana support in HyperIndex. Supports Slot Handler, Effect API, and Envio Cloud.
 ---
 
-> Experimental. Available since 3.0.0-alpha.3.  
+> Experimental. Available since 3.0.0.  
 > RPC-only source. HyperSync for Solana is not available yet; we’ll consider it if there’s demand.
 
 ## What’s supported
@@ -18,7 +18,7 @@ description: Experimental Solana support in HyperIndex. Supports Slot Handler, E
 ## Quickstart
 
 ```bash
-pnpx envio@3.0.0-alpha.14 init svm
+pnpx envio init svm
 ```
 
 ## Notes

--- a/docs/HyperIndex/solana/solana.md
+++ b/docs/HyperIndex/solana/solana.md
@@ -6,7 +6,7 @@ slug: /solana
 description: Experimental Solana support in HyperIndex. Supports Slot Handler, Effect API, and Envio Cloud.
 ---
 
-> Experimental. Available since 3.0.0.  
+> Experimental.  
 > RPC-only source. HyperSync for Solana is not available yet; we’ll consider it if there’s demand.
 
 ## What’s supported

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -731,6 +731,7 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 For detailed release notes, see:
 
 - [v3.0.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0)
+- [v3.0.0-rc.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.0)
 - [v3.0.0-alpha.24](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.24)
 - [v3.0.0-alpha.23](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.23)
 - [v3.0.0-alpha.22](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.22)

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -344,12 +344,12 @@ HyperIndex now supports Solana with RPC as a source. This feature is experimenta
 To initialize a Solana project:
 
 ```bash
-pnpx envio@3.0.0-rc.0 init svm
+pnpx envio init svm
 ```
 
 See the [Solana documentation](/docs/HyperIndex/solana) for more details.
 
-### `pnpx envio@3.0.0-rc.0 init` Improvements
+### `pnpx envio init` Improvements
 
 - Removed language selection to prefer TypeScript by default
 - Cleaned up templates to follow the latest good practices
@@ -730,7 +730,7 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 
 For detailed release notes, see:
 
-- [v3.0.0-rc.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.0)
+- [v3.0.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0)
 - [v3.0.0-alpha.24](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.24)
 - [v3.0.0-alpha.23](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.23)
 - [v3.0.0-alpha.22](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.22)

--- a/docs/HyperIndexV2/Guides/environment-variables.md
+++ b/docs/HyperIndexV2/Guides/environment-variables.md
@@ -24,6 +24,7 @@ To ensure continued access to HyperSync, set an Envio API token in your environm
 
 - Use `ENVIO_API_TOKEN` to provide your token at runtime
 - See the API Tokens guide for how to generate a token: [API Tokens](/docs/HyperSync/api-tokens)
+- A token is only required when using Envio as the data provider (HyperSync). Indexers that source data from an external RPC don't need one.
 
 ## Envio-specific environment variables
 

--- a/docs/HyperIndexV2/quickstart-with-ai.md
+++ b/docs/HyperIndexV2/quickstart-with-ai.md
@@ -66,8 +66,7 @@ Full setup details in the [MCP Server guide](./mcp-server). If your assistant do
 pnpx envio@2 init template \
   -t erc20 \
   -l typescript \
-  -d ./working-indexer \
-  --api-token ""
+  -d ./working-indexer
 ```
 
 ### Option B: Import a verified contract from an explorer
@@ -87,11 +86,11 @@ All `init` subcommands and flags are documented in the [Envio CLI reference](./c
 
 ### About the `--api-token` flag
 
-`--api-token` is the flag for your **HyperSync API token**. Passing it (even as an empty string, as in Option A above) skips the interactive prompt so the assistant can run `init` unattended. A few things to know:
+`--api-token` is the flag for your **HyperSync API token**. A few things to know:
 
 - The token **can't currently be created programmatically**. You generate one by logging in to [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens) and copying it into `ENVIO_API_TOKEN` in your indexer's `.env`.
 - It's **only required for local development and self-hosted deployments**. Indexers running on **Envio Cloud** get special access and don't need a custom token.
-- If you passed `--api-token ""` during init and want to run `pnpm dev` locally, generate a token from the link above and set `ENVIO_API_TOKEN` in `.env` before starting the indexer.
+- To run `pnpm dev` locally, generate a token from the link above and set `ENVIO_API_TOKEN` in `.env` before starting the indexer.
 
 See [API Tokens](/docs/HyperSync/api-tokens) and [Environment Variables](./environment-variables) for full details.
 

--- a/docs/HyperIndexV2/quickstart-with-ai.md
+++ b/docs/HyperIndexV2/quickstart-with-ai.md
@@ -90,6 +90,7 @@ All `init` subcommands and flags are documented in the [Envio CLI reference](./c
 
 - The token **can't currently be created programmatically**. You generate one by logging in to [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens) and copying it into `ENVIO_API_TOKEN` in your indexer's `.env`.
 - It's **only required for local development and self-hosted deployments**. Indexers running on **Envio Cloud** get special access and don't need a custom token.
+- It's **required when using Envio as the data provider (HyperSync)**. If you only use an external RPC as the data source, no token is needed — you can pass an empty string to skip the prompt.
 - To run `pnpm dev` locally, generate a token from the link above and set `ENVIO_API_TOKEN` in `.env` before starting the indexer.
 
 See [API Tokens](/docs/HyperSync/api-tokens) and [Environment Variables](./environment-variables) for full details.

--- a/docs/HyperIndexV2/solana/solana.md
+++ b/docs/HyperIndexV2/solana/solana.md
@@ -6,7 +6,7 @@ slug: /solana
 description: Experimental Solana support in HyperIndex. Supports Slot Handler, Effect API, and Envio Cloud.
 ---
 
-> Experimental. Available since 3.0.0-alpha.3.  
+> Experimental. Available since 3.0.0.  
 > RPC-only source. HyperSync for Solana is not available yet; we’ll consider it if there’s demand.
 
 ## What’s supported
@@ -18,7 +18,7 @@ description: Experimental Solana support in HyperIndex. Supports Slot Handler, E
 ## Quickstart
 
 ```bash
-pnpx envio@3.0.0-alpha.14 init svm
+pnpx envio init svm
 ```
 
 ## Notes

--- a/docs/HyperIndexV2/solana/solana.md
+++ b/docs/HyperIndexV2/solana/solana.md
@@ -6,7 +6,7 @@ slug: /solana
 description: Experimental Solana support in HyperIndex. Supports Slot Handler, Effect API, and Envio Cloud.
 ---
 
-> Experimental. Available since 3.0.0.  
+> Experimental.  
 > RPC-only source. HyperSync for Solana is not available yet; we’ll consider it if there’s demand.
 
 ## What’s supported


### PR DESCRIPTION
## Summary
This PR updates documentation across multiple files to reflect the stable v3.0.0 release of Envio. All references to the release candidate version (`3.0.0-rc.0`) and alpha versions are replaced with the stable `3.0.0` version or simplified to use the latest version via `pnpx envio init`.

## Key Changes

- **CLI command simplification**: Replaced all instances of `pnpx envio@3.0.0-rc.0` with `pnpx envio` to use the latest stable version by default
- **Version references**: Updated package.json examples to reference `envio: "3.0.0"` instead of `3.0.0-rc.0`
- **Release notes**: Added v3.0.0 stable release link to the release notes section
- **API token documentation**: Clarified that `--api-token` flag is optional when using external RPC sources and removed misleading examples of passing empty strings
- **Solana support**: Removed version-specific references (e.g., "Available since 3.0.0-alpha.3") to indicate stable support
- **Blog posts**: Updated example commands in blog posts to use the stable release syntax

## Notable Details

- The changes maintain backward compatibility - using `pnpx envio init` will automatically resolve to the latest stable version
- Documentation now emphasizes that API tokens are only required when using HyperSync as the data provider, not when using external RPC sources
- All tutorial and guide examples have been updated consistently across HyperIndex v3, v2, and blog content

https://claude.ai/code/session_019gANhHF3h2PqMMB554zFWQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified CLI initialization commands across guides and tutorials to use latest stable release syntax without version pinning.
  * Clarified API token requirements: `ENVIO_API_TOKEN` is only needed when using Envio's HyperSync as data provider, not required for external RPC indexers.
  * Updated Solana command syntax to `pnpx envio init svm`.
  * Updated migration guidance to specify stable v3.0.0 release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/918)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->