### PR TITLE
Docs: Expand ClickHouse storage and new CLI commands

### DIFF
--- a/docs/HyperIndex/Advanced/config-schema-reference.md
+++ b/docs/HyperIndex/Advanced/config-schema-reference.md
@@ -205,7 +205,13 @@ full_batch_size: 5000
 
 ### storage {#storage}
 
-Configures which storage backends the indexer writes to. Postgres is enabled by default; enable ClickHouse by setting `clickhouse: true`.
+Configures which storage backends the indexer writes to. Postgres is enabled by default; enable ClickHouse by setting `clickhouse: true`. When both backends are enabled, route each entity explicitly via the `@storage` directive in `schema.graphql`:
+
+```graphql
+type Transfer @storage(postgres: true, clickhouse: true) {
+  id: ID!
+}
+```
 
 - **type**: `anyOf(object<Storage> | null)`
 

--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -207,34 +207,6 @@ full_batch_size: 5000
 
 Move handler files to `src/handlers/` and remove the explicit `handler` paths from `config.yaml`. The explicit `handler` field still works if you'd rather not move files immediately.
 
-### Optional: ClickHouse storage
-
-If using ClickHouse, enable both backends in `config.yaml`:
-
-```yaml
-storage:
-  postgres: true
-  clickhouse: true
-```
-
-Then route each entity explicitly in `schema.graphql` via the `@storage` directive — V3 requires per-entity routing when both backends are enabled:
-
-```graphql
-type Transfer @storage(postgres: true, clickhouse: true) {
-  id: ID!
-  from: String!
-  to: String!
-  value: BigInt!
-}
-
-type Snapshot @storage(postgres: false, clickhouse: true) {
-  id: ID!
-  blockNumber: BigInt!
-}
-```
-
-The connection environment variables (`ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, `ENVIO_CLICKHOUSE_PASSWORD`) are still required for `envio start`. To enable replicated table engines, also set `ENVIO_CLICKHOUSE_REPLICATED=true` and optionally `ENVIO_CLICKHOUSE_DATABASE_ENGINE`. For local development, `envio dev` ships with playground-friendly defaults so the Hasura/playground connection works without a password.
-
 ## Step 5: Update Environment Variables
 
 ### Add
@@ -547,13 +519,13 @@ Postgres column type changes (`raw_events.event_id`: `NUMERIC` → `BIGINT`, `ra
 
 ## Step 10: Update Agent Skills
 
-Once the indexer is running, refresh the Claude/Cursor skills bundled with your project so agent-driven development stays aligned with V3's APIs:
+Once the indexer is running, refresh the agent skills bundled with your project so agent-driven development stays aligned with V3's APIs:
 
 ```bash
 pnpx envio skills update
 ```
 
-This pulls the latest skill files into your project. Re-run it whenever a new HyperIndex release ships new APIs.
+This populates a `.claude/skills` folder in your project. The skills are consumed by Claude, Cursor, and other compatible agentic tooling. Re-run it whenever a new HyperIndex release ships new APIs.
 
 ## Quick Migration Checklist
 
@@ -584,7 +556,6 @@ This pulls the latest skill files into your project. Re-run it whenever a new Hy
 - [ ] Remove `preRegisterDynamicContracts`
 - [ ] Remove `event_decoder`
 - [ ] Remove `output` (types always written to `.envio/`)
-- [ ] If using ClickHouse, add `storage: { postgres: true, clickhouse: true }` and route each entity via `@storage(postgres: ..., clickhouse: ...)` in `schema.graphql`
 
 **Environment variables:**
 

--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -209,7 +209,7 @@ Move handler files to `src/handlers/` and remove the explicit `handler` paths fr
 
 ### Optional: ClickHouse storage
 
-If using ClickHouse, add:
+If using ClickHouse, enable both backends in `config.yaml`:
 
 ```yaml
 storage:
@@ -217,7 +217,23 @@ storage:
   clickhouse: true
 ```
 
-The connection environment variables (`ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, `ENVIO_CLICKHOUSE_PASSWORD`) are still required for `envio start`.
+Then route each entity explicitly in `schema.graphql` via the `@storage` directive — V3 requires per-entity routing when both backends are enabled:
+
+```graphql
+type Transfer @storage(postgres: true, clickhouse: true) {
+  id: ID!
+  from: String!
+  to: String!
+  value: BigInt!
+}
+
+type Snapshot @storage(postgres: false, clickhouse: true) {
+  id: ID!
+  blockNumber: BigInt!
+}
+```
+
+The connection environment variables (`ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, `ENVIO_CLICKHOUSE_PASSWORD`) are still required for `envio start`. To enable replicated table engines, also set `ENVIO_CLICKHOUSE_REPLICATED=true` and optionally `ENVIO_CLICKHOUSE_DATABASE_ENGINE`. For local development, `envio dev` ships with playground-friendly defaults so the Hasura/playground connection works without a password.
 
 ## Step 5: Update Environment Variables
 
@@ -529,6 +545,16 @@ pnpm dev
 
 Postgres column type changes (`raw_events.event_id`: `NUMERIC` → `BIGINT`, `raw_events.serial`: `SERIAL` → `BIGSERIAL`, `envio_chains.events_processed`: `INTEGER` → `BIGINT`, `envio_checkpoints.id`: `INTEGER` → `BIGINT`) are applied automatically — no action required. The deprecated `envio_chains._num_batches_fetched` column always returns `0`.
 
+## Step 10: Update Agent Skills
+
+Once the indexer is running, refresh the Claude/Cursor skills bundled with your project so agent-driven development stays aligned with V3's APIs:
+
+```bash
+pnpx envio skills update
+```
+
+This pulls the latest skill files into your project. Re-run it whenever a new HyperIndex release ships new APIs.
+
 ## Quick Migration Checklist
 
 **Prepare (on V2):**
@@ -558,7 +584,7 @@ Postgres column type changes (`raw_events.event_id`: `NUMERIC` → `BIGINT`, `ra
 - [ ] Remove `preRegisterDynamicContracts`
 - [ ] Remove `event_decoder`
 - [ ] Remove `output` (types always written to `.envio/`)
-- [ ] If using ClickHouse, add `storage: { postgres: true, clickhouse: true }`
+- [ ] If using ClickHouse, add `storage: { postgres: true, clickhouse: true }` and route each entity via `@storage(postgres: ..., clickhouse: ...)` in `schema.graphql`
 
 **Environment variables:**
 
@@ -602,6 +628,10 @@ Postgres column type changes (`raw_events.event_id`: `NUMERIC` → `BIGINT`, `ra
 **Verify:**
 
 - [ ] Run `pnpm envio codegen` and `pnpm dev`
+
+**Agent skills:**
+
+- [ ] Run `pnpx envio skills update` to refresh Claude/Cursor skills
 
 ## Getting Help
 

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -307,7 +307,7 @@ chains:
 
 HyperIndex can now run with multiple storage backends at the same time. Postgres remains the primary database, and entities can additionally be written to a ClickHouse database that is restart- and reorg-resistant. Prometheus metrics carry a storage-name label so you can distinguish backends.
 
-Enable both backends in `config.yaml`:
+Enable backends in `config.yaml` and route each entity explicitly via the `@storage` directive in `schema.graphql`:
 
 ```yaml
 storage:
@@ -315,7 +315,28 @@ storage:
   clickhouse: true
 ```
 
-`envio dev` automatically spins up a ClickHouse Docker container for local development. For `envio start`, provide your own connection via the environment variables `ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, and `ENVIO_CLICKHOUSE_PASSWORD`. Currently supported only on Dedicated Plan.
+```graphql
+type Transfer @storage(postgres: true, clickhouse: true) {
+  id: ID!
+  from: String!
+  to: String!
+  value: BigInt!
+}
+
+type Snapshot @storage(postgres: false, clickhouse: true) {
+  id: ID!
+  blockNumber: BigInt!
+}
+```
+
+Per-entity routing is more verbose but lets you write some entities to Postgres and others to ClickHouse only.
+
+`envio dev` automatically spins up a ClickHouse Docker container for local development with playground-friendly defaults — the Hasura/playground connection works without configuring a password. For `envio start`, provide your own connection via the environment variables `ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, and `ENVIO_CLICKHOUSE_PASSWORD`. Currently supported only on Dedicated Plan.
+
+ClickHouse replication is supported via two additional environment variables:
+
+- `ENVIO_CLICKHOUSE_REPLICATED` — set to `true` to use replicated table engines.
+- `ENVIO_CLICKHOUSE_DATABASE_ENGINE` — override the database engine (for example, `Replicated`).
 
 :::warning
 Do not run multiple indexers writing to the same ClickHouse database at the same time.
@@ -377,7 +398,9 @@ Preload optimization is now enabled by default, replacing the previous `loaders`
 
 We gave our TUI some love, making it look more beautiful and compact. It also consumes fewer resources, shares a link to the Hasura playground, and dynamically adjusts to the terminal width.
 
-The TUI is now auto-disabled in CI environments and when running under AI agents, so logs stay clean without manual configuration. The legacy `TUI_OFF=true` environment variable was renamed to `ENVIO_TUI=false`.
+The TUI now shows an **events-per-second** indicator during backfill so you can see indexing throughput at a glance.
+
+The TUI is also auto-disabled in CI environments and when running under AI agents, so logs stay clean without manual configuration. The legacy `TUI_OFF=true` environment variable was renamed to `ENVIO_TUI=false`.
 
 ![TUI](/img/sync.gif)
 
@@ -652,6 +675,26 @@ After switching to a fallback source, HyperIndex now attempts to recover to the 
 
 `envio codegen` is now near-instant. We no longer run `pnpm i` for the `generated` package, and we no longer recompile ReScript every time you change `config.yaml` or `schema.graphql`. The output is also a lot quieter.
 
+### `envio skills update` Command
+
+Pull the latest Claude/Cursor skills into your project so agent-driven development stays in sync with the latest HyperIndex APIs:
+
+```bash
+pnpx envio skills update
+```
+
+### `envio config view` Command (Experimental)
+
+Inspect your fully resolved indexer configuration as JSON — useful for debugging configuration issues and for tooling that needs to consume the resolved config:
+
+```bash
+pnpx envio config view
+```
+
+### Improved TypeScript Error Messages
+
+When generated types are missing, the TypeScript error now explicitly suggests running `envio codegen` instead of leaving you to puzzle out the cause.
+
 ### Smaller `envio` Package (-88MB)
 
 By eliminating dynamically generated ReScript code, we no longer need to ship or run a ReScript compiler at runtime. The published npm package shrank from 141MB to 53MB.
@@ -725,12 +768,14 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 - Fixed an edge case where a multichain indexer could freeze during a rollback on reorg (also backported to v2.32.10)
 - Fixed external Postgres database support via `ENVIO_PG_HOST`
 - Fixed `S.nullable` schema type to be `T | null` instead of `T | undefined`
+- Fixed `createTestIndexer` `getWhere` filtering by foreign key column names
 
 ## Release Notes
 
 For detailed release notes, see:
 
 - [v3.0.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0)
+- [v3.0.0-rc.1](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.1)
 - [v3.0.0-rc.0](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-rc.0)
 - [v3.0.0-alpha.24](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.24)
 - [v3.0.0-alpha.23](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0-alpha.23)

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -316,6 +316,7 @@ storage:
 ```
 
 ```graphql
+# Stored in both Postgres and ClickHouse
 type Transfer @storage(postgres: true, clickhouse: true) {
   id: ID!
   from: String!
@@ -323,7 +324,8 @@ type Transfer @storage(postgres: true, clickhouse: true) {
   value: BigInt!
 }
 
-type Snapshot @storage(postgres: false, clickhouse: true) {
+# Stored only in ClickHouse
+type Snapshot @storage(clickhouse: true) {
   id: ID!
   blockNumber: BigInt!
 }
@@ -331,9 +333,11 @@ type Snapshot @storage(postgres: false, clickhouse: true) {
 
 Per-entity routing is more verbose but lets you write some entities to Postgres and others to ClickHouse only.
 
-`envio dev` automatically spins up a ClickHouse Docker container for local development with playground-friendly defaults — the Hasura/playground connection works without configuring a password. For `envio start`, provide your own connection via the environment variables `ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, and `ENVIO_CLICKHOUSE_PASSWORD`. Currently supported only on Dedicated Plan.
+`envio dev` automatically spins up a ClickHouse Docker container for local development with playground-friendly defaults so you can connect to it without configuring a password. For `envio start`, provide your own connection via the environment variables `ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, and `ENVIO_CLICKHOUSE_PASSWORD`.
 
-ClickHouse replication is supported via two additional environment variables:
+Envio Cloud currently supports ClickHouse on the Dedicated Plan.
+
+For high-availability ClickHouse setups, HyperIndex supports two additional environment variables:
 
 - `ENVIO_CLICKHOUSE_REPLICATED` — set to `true` to use replicated table engines.
 - `ENVIO_CLICKHOUSE_DATABASE_ENGINE` — override the database engine (for example, `Replicated`).
@@ -768,7 +772,6 @@ For large multichain indexers, HyperIndex now throttles chains that have already
 - Fixed an edge case where a multichain indexer could freeze during a rollback on reorg (also backported to v2.32.10)
 - Fixed external Postgres database support via `ENVIO_PG_HOST`
 - Fixed `S.nullable` schema type to be `T | null` instead of `T | undefined`
-- Fixed `createTestIndexer` `getWhere` filtering by foreign key column names
 
 ## Release Notes
 


### PR DESCRIPTION
## Summary
Updated documentation for HyperIndex v3 to clarify ClickHouse storage configuration with per-entity routing, document new CLI commands, and improve migration guidance.

## Key Changes

### ClickHouse Storage Documentation
- Added explicit `@storage` directive examples in `schema.graphql` showing how to route entities to specific backends (Postgres, ClickHouse, or both)
- Clarified that per-entity routing is required when using multiple backends
- Updated `envio dev` description to mention playground-friendly defaults for local ClickHouse development
- Added documentation for two new environment variables:
  - `ENVIO_CLICKHOUSE_REPLICATED` — for replicated table engines
  - `ENVIO_CLICKHOUSE_DATABASE_ENGINE` — for custom database engine overrides
- Separated Envio Cloud support note (Dedicated Plan only)

### New CLI Commands
- Documented `envio skills update` command for pulling latest Claude/Cursor skills
- Documented `envio config view` command (experimental) for inspecting resolved configuration as JSON
- Added note about improved TypeScript error messages suggesting `envio codegen`

### TUI Improvements
- Added mention of new events-per-second indicator during backfill

### Migration Guide Updates
- Removed outdated ClickHouse storage configuration step (now handled via `@storage` directive)
- Added Step 10 for updating agent skills post-migration
- Updated migration checklist to remove ClickHouse config item and add agent skills step
- Added v3.0.0-rc.1 release notes link

### Config Schema Reference
- Updated storage section with `@storage` directive example and explanation of per-entity routing requirement

https://claude.ai/code/session_01Ay4KiB1LYZTtSzLCqRrKwd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated storage configuration documentation with per-entity routing examples for Postgres and ClickHouse backends
  * Added migration step for updating agent skills via `pnpx envio skills update`
  * Enhanced TUI with events-per-second indicator during backfill
  * Introduced new commands documentation for agent skills and config viewing
  * Updated environment variable naming (`ENVIO_TUI` replacing legacy `TUI_OFF`)
  * Added ClickHouse high-availability configuration variables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/919)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->