### PR TITLE
blog: update Polymarket event count across AI blogs

### DIFF
--- a/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
+++ b/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
@@ -48,7 +48,7 @@ HyperIndex addresses all four problems by being a blockchain indexing framework 
 
 - **Reorg safety at the framework level.** Entity state history, automatic rollback, no reorg logic required in handlers. Learn more in [Indexing and Reorgs](https://docs.envio.dev/blog/indexing-and-reorgs).
 - **Structured GraphQL output.** Entities, relationships, aggregations, time-windowed views, all queryable from one endpoint. Agents read GraphQL, not raw logs.
-- **HyperSync historical throughput.** Up to 2,000x faster than RPC. The Polymarket reference indexer synced 4,000,000,000 events in 6 days.
+- **HyperSync historical throughput.** Up to 2,000x faster than RPC. The Polymarket reference indexer synced its first 4,000,000,000 events in 6 days and has indexed over 6,500,000,000 to date.
 - **Multichain in one config.** <HyperSyncChainCount /> have native HyperSync coverage, any EVM chain accessible via standard RPC, all in a single `config.yaml`.
 
 That is the read side. The act side is what makes HyperIndex an agent's infrastructure, not just an agent's data layer.

--- a/blog/2026-05-14-ai-onchain-app-hyperindex-claude.md
+++ b/blog/2026-05-14-ai-onchain-app-hyperindex-claude.md
@@ -19,7 +19,7 @@ last_update:
 
 - HyperIndex is Envio's multichain blockchain indexing framework for EVM chains. With Claude Code pointed at a HyperIndex project, the agent has the docs (via the docs MCP server) and the patterns (via the auto-discovered `.claude/skills/` directory shipped with every v3 rc project) to scaffold, code, deploy, and run an indexer end to end.
 - The CLI surface is `pnpx envio init` for scaffold, `TUI_OFF=true pnpm dev` for local, and the GitHub-native `envio-cloud indexer add` flow for hosted deployments. Every command is scriptable and agent-friendly.
-- The Polymarket reference at [github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer) is the public production example. 8 subgraphs replaced with 1; 4,000,000,000 events synced in 6 days.
+- The Polymarket reference at [github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer) is the public production example. 8 subgraphs replaced with 1; the first 4,000,000,000 events synced in 6 days, over 6,500,000,000 indexed to date.
 - Anything in this blog is reproducible today against the current HyperIndex release tracked at [github.com/enviodev/hyperindex/releases](https://github.com/enviodev/hyperindex/releases).
 
 :::
@@ -268,7 +268,7 @@ TUI_OFF=true pnpm dev # run indexer (TUI_OFF gives AI-friendly stdout)
 
 Source for these exact commands: [polymarket-indexer/AGENTS.md](https://github.com/enviodev/polymarket-indexer/blob/main/AGENTS.md).
 
-The local dev environment spins up a Postgres and a Hasura GraphQL instance. The indexer starts pulling events from both chains via HyperSync. Sync rates of 25,000 events per second on historical backfill are standard. The [Polymarket case study](https://docs.envio.dev/blog/polymarket-hyperindex-case-study) documents 4,000,000,000 events synced in 6 days on Polygon.
+The local dev environment spins up a Postgres and a Hasura GraphQL instance. The indexer starts pulling events from both chains via HyperSync. Sync rates of 25,000 events per second on historical backfill are standard. The [Polymarket case study](https://docs.envio.dev/blog/polymarket-hyperindex-case-study) documents 4,000,000,000 events synced in 6 days on Polygon; the indexer has since indexed over 6,500,000,000 in total.
 
 The Hasura GraphQL endpoint is available locally. Once the indexer is at chain head, queries like:
 
@@ -398,7 +398,7 @@ Any EVM chain. <HyperSyncChainCount /> have native HyperSync coverage for maximu
 
 ### Where can I see a public production reference?
 
-The [Polymarket reference indexer](https://github.com/enviodev/polymarket-indexer). Synced 4,000,000,000 events from block 3,764,531 in 6 days, replacing 8 separate subgraphs. Live at [envio.dev/app/moose-code/polymarket-indexer/7cad3ad](https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad).
+The [Polymarket reference indexer](https://github.com/enviodev/polymarket-indexer). Synced its first 4,000,000,000 events from block 3,764,531 in 6 days, replacing 8 separate subgraphs, and has indexed over 6,500,000,000 to date. Live at [envio.dev/app/moose-code/polymarket-indexer/7cad3ad](https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad).
 
 ## Build With Envio
 

--- a/blog/2026-05-14-ai-subgraph-migration-hyperindex-claude.md
+++ b/blog/2026-05-14-ai-subgraph-migration-hyperindex-claude.md
@@ -19,7 +19,7 @@ last_update:
 
 - HyperIndex is Envio's multichain blockchain indexing framework for EVM chains. It accepts subgraph YAML and ABIs as input, scaffolds a HyperIndex project, and ships a TypeScript handler skeleton that AssemblyScript handler logic can be ported into.
 - Claude (running with the Envio docs MCP server and the auto-discovered `.claude/skills/` directory, including the dedicated `migrate-from-subgraph` skill) handles the AssemblyScript-to-TypeScript rewrite end to end. Skills auto-discover for Cursor, Claude Code, and Codex.
-- The Polymarket reference indexer is the public production-scale example: 8 subgraphs' worth of logic consolidated into one TypeScript indexer that synced 4,000,000,000 events in 6 days on Polygon.
+- The Polymarket reference indexer is the public production-scale example: 8 subgraphs' worth of logic consolidated into one TypeScript indexer that synced its first 4,000,000,000 events in 6 days on Polygon and has indexed over 6,500,000,000 to date.
 
 :::
 
@@ -274,7 +274,7 @@ The reason teams move off The Graph is performance and developer experience. Fro
 
 Full benchmark comparison at [docs.envio.dev/docs/HyperIndex/benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarks).
 
-Polymarket's full historical sync, 4,000,000,000 events on Polygon, completed in 6 days. The same workload on a single subgraph in the Polymarket setup would have been measured in months and would still leave eight separate APIs to query.
+Polymarket's full historical sync, 4,000,000,000 events on Polygon, completed in 6 days, and the indexer has since indexed over 6,500,000,000 events in total. The same workload on a single subgraph in the Polymarket setup would have been measured in months and would still leave eight separate APIs to query.
 
 Speed is one half of the story. Developer experience is the other. TypeScript handlers, native npm package use, generated types, real test runners, multichain configuration in a single file, dynamic contract registration without redeployment. Once a team has been on HyperIndex for a sprint, the subgraph workflow stops feeling like a viable alternative.
 
@@ -310,7 +310,7 @@ Single multichain config (subgraphs are single-chain). Native TypeScript handler
 
 ### Where is the production reference for a large subgraph migration?
 
-The [Polymarket HyperIndex reference indexer](https://github.com/enviodev/polymarket-indexer). 8 subgraphs' worth of logic consolidated into one indexer, 4,000,000,000 events synced in 6 days. The full repo is public on GitHub and the case study can be found in [our blog](https://docs.envio.dev/blog/polymarket-hyperindex-case-study).
+The [Polymarket HyperIndex reference indexer](https://github.com/enviodev/polymarket-indexer). 8 subgraphs' worth of logic consolidated into one indexer, with the first 4,000,000,000 events synced in 6 days and over 6,500,000,000 indexed to date. The full repo is public on GitHub and the case study can be found in [our blog](https://docs.envio.dev/blog/polymarket-hyperindex-case-study).
 
 ## Get Started
 


### PR DESCRIPTION
## Summary

Propagates the Polymarket event-count correction from #920 to the three other recently merged AI blogs. @DZakh flagged on #914 that the "4,000,000,000 events" figure is stale ("It's 6,509,376,000 now"); the same understated figure appeared across the other three posts.

The 4B-in-6-days number is the **initial historical sync** milestone (still true, documented in the Polymarket case study). The indexer has kept running and is now past 6.5B. Each occurrence now keeps the verifiable sync milestone and adds the current total.

## Changes — 7 occurrences across 3 blogs

**`ai-subgraph-migration-hyperindex-claude.md`** (3)
- TL;DR, the "full historical sync" paragraph, and the FAQ

**`ai-onchain-app-hyperindex-claude.md`** (3)
- TL;DR, the local-dev paragraph, and the FAQ
- Note: the local-dev line attributes the figure to the Polymarket case study — kept "4,000,000,000 ... in 6 days" as what the case study documents (accurate) and added the current total as a separate clause, rather than misattributing 6.5B to the case study.

**`ai-agents-acting-onchain-indexer.md`** (1)
- The "HyperSync historical throughput" bullet

## Wording

"over 6,500,000,000" / "over 6.5B" rather than the exact `6,509,376,000` — the count grows continuously, so an exact figure is stale on publish. Consistent with the phrasing used in #920.

## Pre-flight checks

- [x] `scripts/validate-blog-social-images.js` passes (65 posts)
- [x] All 7 occurrences updated
- [x] Case-study attribution kept accurate (no misattribution of the 6.5B figure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)