### PR TITLE
Update HyperIndex v3 label from 'rc' to 'latest'

### DIFF
--- a/src/theme/NavbarItem/HyperIndexVersionDropdown.js
+++ b/src/theme/NavbarItem/HyperIndexVersionDropdown.js
@@ -6,7 +6,7 @@ const V2_PREFIX = '/docs/v2/HyperIndex';
 const V3_PREFIX = '/docs/HyperIndex';
 
 const ITEMS = [
-  { key: 'v3', label: 'v3 (rc)', to: '/docs/HyperIndex/overview' },
+  { key: 'v3', label: 'v3 (latest)', to: '/docs/HyperIndex/overview' },
   { key: 'v2', label: 'v2', to: '/docs/v2/HyperIndex/overview' },
 ];
 


### PR DESCRIPTION
## Summary
Updated the version dropdown label for HyperIndex v3 to reflect that it is now the latest stable release rather than a release candidate.

## Changes
- Changed the v3 dropdown label from `'v3 (rc)'` to `'v3 (latest)'` in the HyperIndex version selector

## Details
This change updates the navbar version dropdown to accurately represent the current release status of HyperIndex v3, indicating it is now the latest version available to users.

https://claude.ai/code/session_01RqMZEnu6choW9Krbc1UKUR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the HyperIndex version dropdown label to reflect the current release status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->