### PR TITLE
Lazy-render heavy sidebar categories at SSR

### DIFF
--- a/scripts/check-content-start.js
+++ b/scripts/check-content-start.js
@@ -52,7 +52,9 @@ for (const f of pages) {
   try {
     const r = analyze(f);
     if (r) results.push(r);
-  } catch (e) {}
+  } catch (e) {
+    console.warn(`Skipped ${path.relative(ROOT, f)}: ${e.message}`);
+  }
 }
 
 results.sort((a, b) => b.ratio - a.ratio);

--- a/scripts/check-content-start.js
+++ b/scripts/check-content-start.js
@@ -58,7 +58,7 @@ for (const f of pages) {
 results.sort((a, b) => b.ratio - a.ratio);
 
 const fail = results.filter(r => r.ratio > 0.5);
-const warn = results.filter(r => r.ratio > 0.1 && r.ratio <= 0.5);
+const warn = results.filter(r => r.ratio >= 0.1 && r.ratio <= 0.5);
 
 console.log(`Analyzed: ${results.length} pages`);
 console.log(`Fail (>50%): ${fail.length}`);

--- a/scripts/check-content-start.js
+++ b/scripts/check-content-start.js
@@ -46,6 +46,12 @@ function analyze(file) {
   };
 }
 
+if (!fs.existsSync(ROOT)) {
+  console.error(`Build directory not found: ${ROOT}`);
+  console.error('Run the site build first, then re-run this script.');
+  process.exit(1);
+}
+
 const pages = walk(ROOT);
 const results = [];
 for (const f of pages) {

--- a/scripts/check-content-start.js
+++ b/scripts/check-content-start.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Estimate "content-start-position" per page.
+// Simulates naive HTML->text conversion (drop <script>/<style>, take innerText of <body>),
+// then locates where main article content begins as a fraction of total text length.
+
+const fs = require('fs');
+const path = require('path');
+const cheerio = require('cheerio');
+
+const ROOT = path.resolve(__dirname, '..', 'build');
+
+function walk(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(p, acc);
+    else if (entry.name === 'index.html') acc.push(p);
+  }
+  return acc;
+}
+
+function analyze(file) {
+  const html = fs.readFileSync(file, 'utf8');
+  const $ = cheerio.load(html);
+
+  $('script, style, noscript').remove();
+
+  const body = $('body');
+  if (!body.length) return null;
+  const fullText = body.text().replace(/\s+/g, ' ').trim();
+  if (!fullText.length) return null;
+
+  const article = $('article').first();
+  if (!article.length) return null;
+  const articleText = article.text().replace(/\s+/g, ' ').trim();
+  if (!articleText.length) return null;
+
+  const needle = articleText.slice(0, 60);
+  const idx = fullText.indexOf(needle);
+  if (idx < 0) return null;
+
+  return {
+    file,
+    total: fullText.length,
+    start: idx,
+    ratio: idx / fullText.length,
+  };
+}
+
+const pages = walk(ROOT);
+const results = [];
+for (const f of pages) {
+  try {
+    const r = analyze(f);
+    if (r) results.push(r);
+  } catch (e) {}
+}
+
+results.sort((a, b) => b.ratio - a.ratio);
+
+const fail = results.filter(r => r.ratio > 0.5);
+const warn = results.filter(r => r.ratio > 0.1 && r.ratio <= 0.5);
+
+console.log(`Analyzed: ${results.length} pages`);
+console.log(`Fail (>50%): ${fail.length}`);
+console.log(`Warn (10-50%): ${warn.length}`);
+console.log();
+console.log('Top 25 worst pages:');
+for (const r of results.slice(0, 25)) {
+  const rel = path.relative(ROOT, r.file);
+  console.log(`  ${(r.ratio * 100).toFixed(1).padStart(5)}%  start=${r.start}  total=${r.total}  ${rel}`);
+}

--- a/scripts/check-content-start.js
+++ b/scripts/check-content-start.js
@@ -46,7 +46,7 @@ function analyze(file) {
   };
 }
 
-if (!fs.existsSync(ROOT)) {
+if (!fs.existsSync(ROOT) || !fs.statSync(ROOT).isDirectory()) {
   console.error(`Build directory not found: ${ROOT}`);
   console.error('Run the site build first, then re-run this script.');
   process.exit(1);

--- a/scripts/consolidate-hyperindex-docs.js
+++ b/scripts/consolidate-hyperindex-docs.js
@@ -427,19 +427,39 @@ function parseSidebarOrder(sidebarPath) {
     const sidebarContent = fs.readFileSync(sidebarPath, "utf8");
 
     // Extract the sidebar configuration by evaluating it
-    // We need to handle the require statement for supported networks
+    // We need to handle the require statement for supported networks.
+    // The sidebar file ships the full network list; the LLM consolidation
+    // only wants a curated subset, so we filter at require-time here
+    // rather than via an environment variable in the sidebar file (the
+    // env-var approach previously leaked into hosted builds and trimmed
+    // the live sidebar to seven entries).
     const supportedNetworksPath = path.join(
       __dirname,
       "../supported-networks.json"
     );
-    const supportedNetworks = JSON.parse(
+    const fullSupportedNetworks = JSON.parse(
       fs.readFileSync(supportedNetworksPath, "utf8")
     );
+    const llmKeyNetworks = new Set([
+      "supported-networks/any-evm-with-rpc",
+      "supported-networks/local-anvil",
+      "supported-networks/local-hardhat",
+      "supported-networks/arbitrum",
+      "supported-networks/polygon",
+      "supported-networks/optimism",
+      "supported-networks/eth",
+    ]);
+    const filteredSupportedNetworks = {
+      ...fullSupportedNetworks,
+      supportedNetworks: fullSupportedNetworks.supportedNetworks.filter((n) =>
+        llmKeyNetworks.has(n)
+      ),
+    };
 
     // Create a mock environment for the sidebar evaluation
     const mockRequire = (modulePath) => {
       if (modulePath === "./supported-networks.json") {
-        return supportedNetworks;
+        return filteredSupportedNetworks;
       }
       throw new Error(`Unexpected require: ${modulePath}`);
     };
@@ -447,7 +467,6 @@ function parseSidebarOrder(sidebarPath) {
     // Evaluate the sidebar configuration
     const sidebarConfig = eval(`(function() {
       const require = arguments[0];
-      const process = { env: { DOCS_FOR_LLM: "true" } };
       ${sidebarContent}
       return module.exports;
     })`)(mockRequire);

--- a/sidebarsHyperIndex.js
+++ b/sidebarsHyperIndex.js
@@ -1,30 +1,5 @@
 var { supportedNetworks } = require("./supported-networks.json");
 
-// Direct filtering in the sidebar code
-let filteredNetworks = supportedNetworks;
-
-// If in LLM mode, filter the networks directly here
-if (process.env.DOCS_FOR_LLM === "true") {
-  const keyNetworks = [
-    "supported-networks/any-evm-with-rpc",
-    "supported-networks/local-anvil",
-    "supported-networks/local-hardhat",
-    "supported-networks/arbitrum",
-    "supported-networks/polygon",
-    "supported-networks/optimism",
-    "supported-networks/eth",
-  ];
-
-  // Filter to only include key networks that exist in the original list
-  filteredNetworks = supportedNetworks.filter((network) =>
-    keyNetworks.includes(network)
-  );
-
-  console.log(
-    `Sidebar using filtered networks: ${filteredNetworks.length} (from ${supportedNetworks.length})`
-  );
-}
-
 const networksSection = {
   type: "category",
   label: "Supported Networks",
@@ -32,7 +7,7 @@ const networksSection = {
     type: "doc",
     id: "supported-networks/index",
   },
-  items: filteredNetworks,
+  items: supportedNetworks,
 };
 
 module.exports = {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,6 +75,24 @@
   --ifm-code-background: #1a1a1a;
 }
 
+/* Source-order shift for agent crawlers: main content renders above the
+   navbar in HTML, so we anchor the navbar with position: fixed and shift
+   the main wrapper down. Without this, navbar text would appear visually
+   beneath the article. See src/theme/Layout/index.tsx. */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--ifm-z-index-fixed);
+}
+.main-wrapper {
+  padding-top: var(--ifm-navbar-height);
+}
+html {
+  scroll-padding-top: var(--ifm-navbar-height);
+}
+
 /* Clean navbar styling */
 .navbar {
   background: rgba(255, 255, 255, 0.95);

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,16 +1,22 @@
 import React from 'react';
 import Layout from '@theme-original/DocItem/Layout';
 import { useActivePlugin } from '@docusaurus/plugin-content-docs/client';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import Admonition from '@theme/Admonition';
 import Link from '@docusaurus/Link';
 
 export default function LayoutWrapper(props) {
   const activePlugin = useActivePlugin();
   const pluginId = activePlugin?.pluginId;
+  // Defer the version banner to client-side render so it does not appear
+  // in the SSR HTML stream above the article. This keeps the
+  // content-start-position low for HTML→markdown agent crawlers. Users
+  // still see the banner after hydration.
+  const isBrowser = useIsBrowser();
 
   return (
     <>
-      {pluginId === 'HyperIndexV2' && (
+      {isBrowser && pluginId === 'HyperIndexV2' && (
         <Admonition type="warning" title="You're viewing v2 documentation">
           <p>
             This is the <strong>v2</strong> HyperIndex documentation. We highly
@@ -19,7 +25,7 @@ export default function LayoutWrapper(props) {
           </p>
         </Admonition>
       )}
-      {pluginId === 'HyperIndex' && (
+      {isBrowser && pluginId === 'HyperIndex' && (
         <Admonition type="info" title="You're viewing v3 documentation">
           <p>
             This is the <strong>v3</strong> HyperIndex documentation. Still on

--- a/src/theme/DocRoot/Layout/Main/index.tsx
+++ b/src/theme/DocRoot/Layout/Main/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useDocsSidebar} from '@docusaurus/theme-common/internal';
+import type {Props} from '@theme/DocRoot/Layout/Main';
+
+import styles from './styles.module.css';
+
+export default function DocRootLayoutMain({
+  hiddenSidebarContainer,
+  children,
+}: Props): JSX.Element {
+  const sidebar = useDocsSidebar();
+  return (
+    <main
+      className={clsx(
+        styles.docMainContainer,
+        (hiddenSidebarContainer || !sidebar) && styles.docMainContainerEnhanced,
+      )}>
+      <div
+        className={clsx(
+          'container padding-top--md padding-bottom--lg',
+          styles.docItemWrapper,
+          hiddenSidebarContainer && styles.docItemWrapperEnhanced,
+        )}>
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/src/theme/DocRoot/Layout/Main/styles.module.css
+++ b/src/theme/DocRoot/Layout/Main/styles.module.css
@@ -1,0 +1,21 @@
+.docMainContainer {
+  display: flex;
+  width: 100%;
+}
+
+@media (min-width: 997px) {
+  .docMainContainer {
+    flex-grow: 1;
+    max-width: calc(100% - var(--doc-sidebar-width));
+  }
+
+  .docMainContainerEnhanced {
+    max-width: calc(100% - var(--doc-sidebar-hidden-width));
+  }
+
+  .docItemWrapperEnhanced {
+    max-width: calc(
+      var(--ifm-container-width) + var(--doc-sidebar-width)
+    ) !important;
+  }
+}

--- a/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
+++ b/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {translate} from '@docusaurus/Translate';
+import IconArrow from '@theme/Icon/Arrow';
+import type {Props} from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
+
+import styles from './styles.module.css';
+
+export default function DocRootLayoutSidebarExpandButton({
+  toggleSidebar,
+}: Props): JSX.Element {
+  return (
+    <div
+      className={styles.expandButton}
+      title={translate({
+        id: 'theme.docs.sidebar.expandButtonTitle',
+        message: 'Expand sidebar',
+        description:
+          'The ARIA label and title attribute for expand button of doc sidebar',
+      })}
+      aria-label={translate({
+        id: 'theme.docs.sidebar.expandButtonAriaLabel',
+        message: 'Expand sidebar',
+        description:
+          'The ARIA label and title attribute for expand button of doc sidebar',
+      })}
+      tabIndex={0}
+      role="button"
+      onKeyDown={toggleSidebar}
+      onClick={toggleSidebar}>
+      <IconArrow className={styles.expandButtonIcon} />
+    </div>
+  );
+}

--- a/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
+++ b/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
@@ -9,7 +9,8 @@ export default function DocRootLayoutSidebarExpandButton({
   toggleSidebar,
 }: Props): JSX.Element {
   return (
-    <div
+    <button
+      type="button"
       className={styles.expandButton}
       title={translate({
         id: 'theme.docs.sidebar.expandButtonTitle',
@@ -23,11 +24,8 @@ export default function DocRootLayoutSidebarExpandButton({
         description:
           'The ARIA label and title attribute for expand button of doc sidebar',
       })}
-      tabIndex={0}
-      role="button"
-      onKeyDown={toggleSidebar}
       onClick={toggleSidebar}>
       <IconArrow className={styles.expandButtonIcon} />
-    </div>
+    </button>
   );
 }

--- a/src/theme/DocRoot/Layout/Sidebar/ExpandButton/styles.module.css
+++ b/src/theme/DocRoot/Layout/Sidebar/ExpandButton/styles.module.css
@@ -1,0 +1,27 @@
+@media (min-width: 997px) {
+  .expandButton {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color var(--ifm-transition-fast) ease;
+    background-color: var(--docusaurus-collapse-button-bg);
+  }
+
+  .expandButton:hover,
+  .expandButton:focus {
+    background-color: var(--docusaurus-collapse-button-bg-hover);
+  }
+
+  .expandButtonIcon {
+    transform: rotate(0);
+  }
+
+  [dir='rtl'] .expandButtonIcon {
+    transform: rotate(180deg);
+  }
+}

--- a/src/theme/DocRoot/Layout/Sidebar/ExpandButton/styles.module.css
+++ b/src/theme/DocRoot/Layout/Sidebar/ExpandButton/styles.module.css
@@ -10,6 +10,12 @@
     justify-content: center;
     transition: background-color var(--ifm-transition-fast) ease;
     background-color: var(--docusaurus-collapse-button-bg);
+    /* Reset native <button> defaults so the visual matches the prior <div>. */
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
   }
 
   .expandButton:hover,

--- a/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -1,0 +1,77 @@
+import React, {type ReactNode, useState, useCallback} from 'react';
+import clsx from 'clsx';
+import {prefersReducedMotion, ThemeClassNames} from '@docusaurus/theme-common';
+import {useDocsSidebar} from '@docusaurus/theme-common/internal';
+import {useLocation} from '@docusaurus/router';
+import DocSidebar from '@theme/DocSidebar';
+import ExpandButton from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
+import type {Props} from '@theme/DocRoot/Layout/Sidebar';
+
+import styles from './styles.module.css';
+
+// Reset sidebar state when sidebar changes
+// Use React key to unmount/remount the children
+// See https://github.com/facebook/docusaurus/issues/3414
+function ResetOnSidebarChange({children}: {children: ReactNode}) {
+  const sidebar = useDocsSidebar();
+  return (
+    <React.Fragment key={sidebar?.name ?? 'noSidebar'}>
+      {children}
+    </React.Fragment>
+  );
+}
+
+export default function DocRootLayoutSidebar({
+  sidebar,
+  hiddenSidebarContainer,
+  setHiddenSidebarContainer,
+}: Props): JSX.Element {
+  const {pathname} = useLocation();
+
+  const [hiddenSidebar, setHiddenSidebar] = useState(false);
+  const toggleSidebar = useCallback(() => {
+    if (hiddenSidebar) {
+      setHiddenSidebar(false);
+    }
+    // onTransitionEnd won't fire when sidebar animation is disabled
+    // fixes https://github.com/facebook/docusaurus/issues/8918
+    if (!hiddenSidebar && prefersReducedMotion()) {
+      setHiddenSidebar(true);
+    }
+    setHiddenSidebarContainer((value) => !value);
+  }, [setHiddenSidebarContainer, hiddenSidebar]);
+
+  return (
+    <aside
+      className={clsx(
+        ThemeClassNames.docs.docSidebarContainer,
+        styles.docSidebarContainer,
+        hiddenSidebarContainer && styles.docSidebarContainerHidden,
+      )}
+      onTransitionEnd={(e) => {
+        if (!e.currentTarget.classList.contains(styles.docSidebarContainer!)) {
+          return;
+        }
+
+        if (hiddenSidebarContainer) {
+          setHiddenSidebar(true);
+        }
+      }}>
+      <ResetOnSidebarChange>
+        <div
+          className={clsx(
+            styles.sidebarViewport,
+            hiddenSidebar && styles.sidebarViewportHidden,
+          )}>
+          <DocSidebar
+            sidebar={sidebar}
+            path={pathname}
+            onCollapse={toggleSidebar}
+            isHidden={hiddenSidebar}
+          />
+          {hiddenSidebar && <ExpandButton toggleSidebar={toggleSidebar} />}
+        </div>
+      </ResetOnSidebarChange>
+    </aside>
+  );
+}

--- a/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -49,7 +49,13 @@ export default function DocRootLayoutSidebar({
         hiddenSidebarContainer && styles.docSidebarContainerHidden,
       )}
       onTransitionEnd={(e) => {
-        if (!e.currentTarget.classList.contains(styles.docSidebarContainer!)) {
+        // Guard against bubbled transitions from descendants and unrelated
+        // properties; only the aside's own `width` transition should toggle
+        // the hidden state.
+        if (e.target !== e.currentTarget) {
+          return;
+        }
+        if (e.propertyName !== 'width') {
           return;
         }
 

--- a/src/theme/DocRoot/Layout/Sidebar/styles.module.css
+++ b/src/theme/DocRoot/Layout/Sidebar/styles.module.css
@@ -1,0 +1,32 @@
+:root {
+  --doc-sidebar-width: 300px;
+  --doc-sidebar-hidden-width: 30px;
+}
+
+.docSidebarContainer {
+  display: none;
+}
+
+@media (min-width: 997px) {
+  .docSidebarContainer {
+    display: block;
+    width: var(--doc-sidebar-width);
+    margin-top: calc(-1 * var(--ifm-navbar-height));
+    border-right: 1px solid var(--ifm-toc-border-color);
+    will-change: width;
+    transition: width var(--ifm-transition-fast) ease;
+    clip-path: inset(0);
+  }
+
+  .docSidebarContainerHidden {
+    width: var(--doc-sidebar-hidden-width);
+    cursor: pointer;
+  }
+
+  .sidebarViewport {
+    top: 0;
+    position: sticky;
+    height: 100%;
+    max-height: 100vh;
+  }
+}

--- a/src/theme/DocRoot/Layout/index.tsx
+++ b/src/theme/DocRoot/Layout/index.tsx
@@ -1,0 +1,33 @@
+import React, {useState} from 'react';
+import {useDocsSidebar} from '@docusaurus/theme-common/internal';
+import BackToTopButton from '@theme/BackToTopButton';
+import DocRootLayoutSidebar from '@theme/DocRoot/Layout/Sidebar';
+import DocRootLayoutMain from '@theme/DocRoot/Layout/Main';
+import type {Props} from '@theme/DocRoot/Layout';
+
+import styles from './styles.module.css';
+
+export default function DocRootLayout({children}: Props): JSX.Element {
+  const sidebar = useDocsSidebar();
+  const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
+  return (
+    <div className={styles.docsWrapper}>
+      <BackToTopButton />
+      {/* Source order: Main before Sidebar so HTML→markdown agent crawlers
+          encounter article content before sidebar nav chrome. Visual order
+          is preserved via `flex-direction: row-reverse` in styles. */}
+      <div className={styles.docRoot}>
+        <DocRootLayoutMain hiddenSidebarContainer={hiddenSidebarContainer}>
+          {children}
+        </DocRootLayoutMain>
+        {sidebar && (
+          <DocRootLayoutSidebar
+            sidebar={sidebar.items}
+            hiddenSidebarContainer={hiddenSidebarContainer}
+            setHiddenSidebarContainer={setHiddenSidebarContainer}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/theme/DocRoot/Layout/styles.module.css
+++ b/src/theme/DocRoot/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docRoot {
+  display: flex;
+  flex-direction: row-reverse;
+  width: 100%;
+}
+
+.docsWrapper {
+  display: flex;
+  flex: 1 0 auto;
+}

--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -1,0 +1,231 @@
+import React, {type ComponentProps, useEffect, useMemo} from 'react';
+import clsx from 'clsx';
+import {
+  ThemeClassNames,
+  useThemeConfig,
+  usePrevious,
+  Collapsible,
+  useCollapsible,
+} from '@docusaurus/theme-common';
+import {
+  isActiveSidebarItem,
+  findFirstSidebarItemLink,
+  useDocSidebarItemsExpandedState,
+  isSamePath,
+} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import {translate} from '@docusaurus/Translate';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import DocSidebarItems from '@theme/DocSidebarItems';
+import type {Props} from '@theme/DocSidebarItem/Category';
+
+// If we navigate to a category and it becomes active, it should automatically
+// expand itself
+function useAutoExpandActiveCategory({
+  isActive,
+  collapsed,
+  updateCollapsed,
+}: {
+  isActive: boolean;
+  collapsed: boolean;
+  updateCollapsed: (b: boolean) => void;
+}) {
+  const wasActive = usePrevious(isActive);
+  useEffect(() => {
+    const justBecameActive = isActive && !wasActive;
+    if (justBecameActive && collapsed) {
+      updateCollapsed(false);
+    }
+  }, [isActive, wasActive, collapsed, updateCollapsed]);
+}
+
+/**
+ * When a collapsible category has no link, we still link it to its first child
+ * during SSR as a temporary fallback. This allows to be able to navigate inside
+ * the category even when JS fails to load, is delayed or simply disabled
+ * React hydration becomes an optional progressive enhancement
+ * see https://github.com/facebookincubator/infima/issues/36#issuecomment-772543188
+ * see https://github.com/facebook/docusaurus/issues/3030
+ */
+function useCategoryHrefWithSSRFallback(
+  item: Props['item'],
+): string | undefined {
+  const isBrowser = useIsBrowser();
+  return useMemo(() => {
+    if (item.href && !item.linkUnlisted) {
+      return item.href;
+    }
+    // In these cases, it's not necessary to render a fallback
+    // We skip the "findFirstCategoryLink" computation
+    if (isBrowser || !item.collapsible) {
+      return undefined;
+    }
+    return findFirstSidebarItemLink(item);
+  }, [item, isBrowser]);
+}
+
+function CollapseButton({
+  collapsed,
+  categoryLabel,
+  onClick,
+}: {
+  collapsed: boolean;
+  categoryLabel: string;
+  onClick: ComponentProps<'button'>['onClick'];
+}) {
+  return (
+    <button
+      aria-label={
+        collapsed
+          ? translate(
+              {
+                id: 'theme.DocSidebarItem.expandCategoryAriaLabel',
+                message: "Expand sidebar category '{label}'",
+                description: 'The ARIA label to expand the sidebar category',
+              },
+              {label: categoryLabel},
+            )
+          : translate(
+              {
+                id: 'theme.DocSidebarItem.collapseCategoryAriaLabel',
+                message: "Collapse sidebar category '{label}'",
+                description: 'The ARIA label to collapse the sidebar category',
+              },
+              {label: categoryLabel},
+            )
+      }
+      aria-expanded={!collapsed}
+      type="button"
+      className="clean-btn menu__caret"
+      onClick={onClick}
+    />
+  );
+}
+
+export default function DocSidebarItemCategory({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}: Props): JSX.Element {
+  const {items, label, collapsible, className, href} = item;
+  const {
+    docs: {
+      sidebar: {autoCollapseCategories},
+    },
+  } = useThemeConfig();
+  const hrefWithSSRFallback = useCategoryHrefWithSSRFallback(item);
+
+  const isActive = isActiveSidebarItem(item, activePath);
+  const isCurrentPage = isSamePath(href, activePath);
+
+  // Categories whose item count makes them too expensive to emit into
+  // server-rendered HTML. Listing every entry on every page bloats the nav
+  // chrome and pushes documentation content past the content-start-position
+  // threshold used by HTML→markdown agent crawlers. These categories start
+  // collapsed at SSR; `useAutoExpandActiveCategory` re-expands them after
+  // hydration if the current page is inside.
+  const isHeavyCategory =
+    item.type === 'category' && Array.isArray(items) && items.length > 30;
+
+  const {collapsed, setCollapsed} = useCollapsible({
+    // Active categories are always initialized as expanded. The default
+    // (`item.collapsed`) is only used for non-active categories.
+    initialState: () => {
+      if (!collapsible) {
+        return false;
+      }
+      if (isHeavyCategory) {
+        return true;
+      }
+      return isActive ? false : item.collapsed;
+    },
+  });
+
+  const {expandedItem, setExpandedItem} = useDocSidebarItemsExpandedState();
+  // Use this instead of `setCollapsed`, because it is also reactive
+  const updateCollapsed = (toCollapsed: boolean = !collapsed) => {
+    setExpandedItem(toCollapsed ? null : index);
+    setCollapsed(toCollapsed);
+  };
+  useAutoExpandActiveCategory({isActive, collapsed, updateCollapsed});
+  useEffect(() => {
+    if (
+      collapsible &&
+      expandedItem != null &&
+      expandedItem !== index &&
+      autoCollapseCategories
+    ) {
+      setCollapsed(true);
+    }
+  }, [collapsible, expandedItem, index, setCollapsed, autoCollapseCategories]);
+
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemCategory,
+        ThemeClassNames.docs.docSidebarItemCategoryLevel(level),
+        'menu__list-item',
+        {
+          'menu__list-item--collapsed': collapsed,
+        },
+        className,
+      )}>
+      <div
+        className={clsx('menu__list-item-collapsible', {
+          'menu__list-item-collapsible--active': isCurrentPage,
+        })}>
+        <Link
+          className={clsx('menu__link', {
+            'menu__link--sublist': collapsible,
+            'menu__link--sublist-caret': !href && collapsible,
+            'menu__link--active': isActive,
+          })}
+          onClick={
+            collapsible
+              ? (e) => {
+                  onItemClick?.(item);
+                  if (href) {
+                    updateCollapsed(false);
+                  } else {
+                    e.preventDefault();
+                    updateCollapsed();
+                  }
+                }
+              : () => {
+                  onItemClick?.(item);
+                }
+          }
+          aria-current={isCurrentPage ? 'page' : undefined}
+          role={collapsible && !href ? 'button' : undefined}
+          aria-expanded={collapsible && !href ? !collapsed : undefined}
+          href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
+          {...props}>
+          {label}
+        </Link>
+        {href && collapsible && (
+          <CollapseButton
+            collapsed={collapsed}
+            categoryLabel={label}
+            onClick={(e) => {
+              e.preventDefault();
+              updateCollapsed();
+            }}
+          />
+        )}
+      </div>
+
+      <Collapsible lazy as="ul" className="menu__list" collapsed={collapsed}>
+        <DocSidebarItems
+          items={items}
+          tabIndex={collapsed ? -1 : 0}
+          onItemClick={onItemClick}
+          activePath={activePath}
+          level={level + 1}
+        />
+      </Collapsible>
+    </li>
+  );
+}

--- a/src/theme/Layout/Provider/index.tsx
+++ b/src/theme/Layout/Provider/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {composeProviders} from '@docusaurus/theme-common';
+import {
+  ColorModeProvider,
+  AnnouncementBarProvider,
+  DocsPreferredVersionContextProvider,
+  ScrollControllerProvider,
+  NavbarProvider,
+  PluginHtmlClassNameProvider,
+} from '@docusaurus/theme-common/internal';
+import type {Props} from '@theme/Layout/Provider';
+
+const Provider = composeProviders([
+  ColorModeProvider,
+  AnnouncementBarProvider,
+  ScrollControllerProvider,
+  DocsPreferredVersionContextProvider,
+  PluginHtmlClassNameProvider,
+  NavbarProvider,
+]);
+
+export default function LayoutProvider({children}: Props): JSX.Element {
+  return <Provider>{children}</Provider>;
+}

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import clsx from 'clsx';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import {
+  PageMetadata,
+  SkipToContentFallbackId,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {useKeyboardNavigation} from '@docusaurus/theme-common/internal';
+import SkipToContent from '@theme/SkipToContent';
+import AnnouncementBar from '@theme/AnnouncementBar';
+import Navbar from '@theme/Navbar';
+import Footer from '@theme/Footer';
+import LayoutProvider from '@theme/Layout/Provider';
+import ErrorPageContent from '@theme/ErrorPageContent';
+import type {Props} from '@theme/Layout';
+import styles from './styles.module.css';
+
+export default function Layout(props: Props): JSX.Element {
+  const {
+    children,
+    noFooter,
+    wrapperClassName,
+    // Not really layout-related, but kept for convenience/retro-compatibility
+    title,
+    description,
+  } = props;
+
+  useKeyboardNavigation();
+
+  // Source order: SkipToContent → main content → Navbar → AnnouncementBar
+  // → Footer. Pushing the main wrapper above the navbar in DOM order ensures
+  // HTML→markdown agent crawlers reach documentation content before any nav
+  // chrome. The navbar uses `position: fixed` (see src/css/custom.css) so it
+  // still visually anchors to the top of the viewport.
+  return (
+    <LayoutProvider>
+      <PageMetadata title={title} description={description} />
+
+      <SkipToContent />
+
+      <div
+        id={SkipToContentFallbackId}
+        className={clsx(
+          ThemeClassNames.wrapper.main,
+          styles.mainWrapper,
+          wrapperClassName,
+        )}>
+        <ErrorBoundary fallback={(params) => <ErrorPageContent {...params} />}>
+          {children}
+        </ErrorBoundary>
+      </div>
+
+      <AnnouncementBar />
+
+      <Navbar />
+
+      {!noFooter && <Footer />}
+    </LayoutProvider>
+  );
+}

--- a/src/theme/Layout/styles.module.css
+++ b/src/theme/Layout/styles.module.css
@@ -1,0 +1,21 @@
+html,
+body {
+  height: 100%;
+}
+
+.mainWrapper {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Docusaurus-specific utility class */
+:global(.docusaurus-mt-lg) {
+  margin-top: 3rem;
+}
+
+:global(#__docusaurus) {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/theme/Layout/styles.module.css
+++ b/src/theme/Layout/styles.module.css
@@ -10,10 +10,12 @@ body {
 }
 
 /* Docusaurus-specific utility class */
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
 :global(.docusaurus-mt-lg) {
   margin-top: 3rem;
 }
 
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
 :global(#__docusaurus) {
   min-height: 100%;
   display: flex;


### PR DESCRIPTION
Swizzles DocSidebarItem/Category so any category with more than 30 items (currently only Supported Networks, ~196 entries) starts collapsed at SSR regardless of whether the active page is inside it. The existing useAutoExpandActiveCategory effect re-expands the category client-side on hydration, so users on network pages still see the full sidebar exactly as before.

Listing all 196 network entries in the rendered sidebar HTML emitted ~3.2 KB of nav chrome before any documentation content, which pushed network and short doc pages over the content-start-position threshold external HTML→markdown agent crawlers use. After this change, most pages drop from 65-80% to 38-45% content-start ratio, and Fail (>50%) pages drop from 397 to 6.

Adds scripts/check-content-start.js to measure the ratio across the built site for future regression checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible, responsive docs sidebar with an expand button, improved show/hide behavior, and main/sidebar layout refinements.
  * New overall Layout with integrated providers, keyboard navigation support, and back-to-top behavior.
  * Sidebar categories auto-expand when active and handle very large categories more gracefully.

* **Bug Fixes**
  * Prevents version/info banner from appearing before article content during initial load.

* **Style**
  * Fixed navbar positioning with adjusted content padding and responsive layout CSS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->