### PR TITLE
  Auto-generate llms.txt and improve AI agent discoverability

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -441,152 +441,238 @@ const config = {
     [
       require.resolve("./plugins/plugin-generate-llms"),
       {
-        // Only the V3 (HyperIndex) docs should land in llms.txt / llms-full.txt
-        // and the build's .md copies.
-        excludePluginIds: ["HyperIndexV2"],
+        // LLM-mirror plugins are bundled re-exports of other docs — skip them
+        // entirely to avoid duplication.
+        excludePluginIds: [
+          "HyperIndex-LLM",
+          "HyperSync-LLM",
+          "HyperRPC-LLM",
+        ],
+        // V2 is listed in llms.txt for discoverability but stays out of
+        // llms-full.txt and the per-page .md copies.
+        excludeFromFullPluginIds: ["HyperIndexV2"],
         filesConfigs: [
           {
-            main: true, // this will become llms.txt
+            main: true, // becomes llms.txt
             name: "envio",
-            root: `
+            header: `
 # Envio: Fast, Multi-Chain Blockchain Indexer
 
 > Envio is a real-time multichain blockchain indexer. HyperIndex is a multichain indexer supporting any EVM chain, plus Solana and Fuel. HyperSync is a high-throughput data layer natively available on 70+ EVM chains and Fuel, and supports any EVM chain via RPC. HyperRPC is a read-only JSON-RPC endpoint powered by HyperSync, up to 5x faster than traditional nodes. Benchmark: Envio 1 min vs The Graph 143 min (Uniswap V2 Factory, [Sentio, May 2025](https://docs.envio.dev/docs/HyperIndex/benchmarks.md)).
 
-This file contains links to documentation sections following the llmstxt.org standard.
-
-## HyperIndex
-
-### Core
-
-- [Configuration Schema Reference](https://docs.envio.dev/docs/HyperIndex/config-schema-reference.md): Detailed reference for every field and option in the Envio \`config.yaml\` configuration file used to configure HyperIndex indexers.
-- [Loading Dynamic Contracts / Factories](https://docs.envio.dev/docs/HyperIndex/dynamic-contracts.md): Learn how to track and index dynamically created contracts from factory contracts.
-- [Effect API](https://docs.envio.dev/docs/HyperIndex/effect-api.md): Learn how to use the Effect API for external calls in handlers.
-- [Generated Indexing Files](https://docs.envio.dev/docs/HyperIndex/generated-files.md): Learn how generated files handle type-safe data access, event processing, and runtime indexing.
-- [HyperSync as Data Source](https://docs.envio.dev/docs/HyperIndex/hypersync.md): Learn how HyperSync is used in HyperIndex to fetch raw blockchain data.
-- [Loaders](https://docs.envio.dev/docs/HyperIndex/loaders.md): Learn how Loaders improved database access performance for event handlers.
-- [Metadata Query](https://docs.envio.dev/docs/HyperIndex/metadata-query.md): See indexing progress and metadata per chain using HyperIndex _meta query.
-- [Multichain Indexing](https://docs.envio.dev/docs/HyperIndex/multichain-indexing.md): Learn how to index and process events across multiple chains with HyperIndex.
-- [Benchmarking Your Indexer](https://docs.envio.dev/docs/HyperIndex/benchmarking.md): Learn how to benchmark your indexer to identify bottlenecks and optimize performance.
-- [Database Performance Optimization](https://docs.envio.dev/docs/HyperIndex/database-performance-optimization.md): Learn how to optimize HyperIndex databases with indices and schema design for faster queries.
-- [Historical Sync](https://docs.envio.dev/docs/HyperIndex/historical-sync.md): Learn how to optimize historical sync with HyperIndex for fast and efficient data retrieval.
-- [Performance Optimization](https://docs.envio.dev/docs/HyperIndex/performance.md): Learn how to optimize HyperIndex performance for syncing, indexing, and querying data.
-- [Understanding Chain Head Latency](https://docs.envio.dev/docs/HyperIndex/latency-at-head.md): Learn how Envio keeps blockchain indexers updated with low latency and reliable multi-chain sync.
-- [Preload Optimization](https://docs.envio.dev/docs/HyperIndex/preload-optimization.md): Learn how preload optimization improves event handlers with batched reads and parallel external calls.
-- [Query Conversion Guide](https://docs.envio.dev/docs/HyperIndex/query-conversion.md): Learn how to convert queries from TheGraph's custom GraphQL syntax to Envio's standard GraphQL syntax.
-- [Chain Reorganization Support](https://docs.envio.dev/docs/HyperIndex/reorgs-support.md): Learn how to handle chain reorgs and keep your indexed data consistent.
-- [RPC as Data Source](https://docs.envio.dev/docs/HyperIndex/rpc-sync.md): Learn how to index any EVM blockchain using RPC and optimize performance with HyperIndex.
-- [Terminology & Key Concepts](https://docs.envio.dev/docs/HyperIndex/terminology.md): Explore key terms for fast reference and blockchain indexer development.
-- [Using WebSockets with GraphQL](https://docs.envio.dev/docs/HyperIndex/websockets.md): Learn how to use WebSocket connections with your HyperIndex GraphQL endpoint.
-- [Wildcard Indexing & Topic Filtering](https://docs.envio.dev/docs/HyperIndex/wildcard-indexing.md): Learn how to index events using wildcard indexing feature and topic based filtering.
-- [Block Handlers](https://docs.envio.dev/docs/HyperIndex/block-handlers.md): Learn how to run custom logic on every blockchain block or at set intervals using onBlock.
-- [Envio CLI Reference](https://docs.envio.dev/docs/HyperIndex/cli-commands.md): Explore and manage indexer projects with Envio CLI, from setup to development and benchmarking.
-- [Configuration File (config.yaml)](https://docs.envio.dev/docs/HyperIndex/configuration-file.md): Learn how to configure HyperIndex with contracts, events, networks, and advanced indexing options.
-- [Accessing Contract State in Event Handlers](https://docs.envio.dev/docs/HyperIndex/contract-state.md): Learn how to efficiently fetch and store token contract data from events using RPC, multicall, and caching.
-- [Environment Variables](https://docs.envio.dev/docs/HyperIndex/environment-variables.md): Learn how to configure and manage Envio environment variables for your blockchain indexer.
-- [Event Handlers (src/EventHandlers.*)](https://docs.envio.dev/docs/HyperIndex/event-handlers.md): Learn how to register and manage event handlers for efficient data indexing.
-- [Using IPFS with Envio Indexers](https://docs.envio.dev/docs/HyperIndex/ipfs.md): Learn how to fetch and index NFT metadata from IPFS using Envio for complete on-chain and off-chain data.
-- [Navigating Hasura](https://docs.envio.dev/docs/HyperIndex/navigating-hasura.md): Explore and interact with your locally indexed blockchain data using Hasura GraphQL.
-- [Running The Indexer Locally](https://docs.envio.dev/docs/HyperIndex/running-locally.md): Learn how to start, run, and manage the Envio indexer locally with Docker and Hasura.
-- [Entities Schema (schema.graphql)](https://docs.envio.dev/docs/HyperIndex/schema.md): Learn how to define GraphQL schemas, manage entities, and handle different types in HyperIndex.
-- [Testing](https://docs.envio.dev/docs/HyperIndex/testing.md): Learn to test HyperIndex indexers with mock databases, simulated events, and full workflow validation.
-
-### Envio Cloud
-
-- [Pricing & Billing](https://docs.envio.dev/docs/HyperIndex/hosted-service-billing.md): Explore Envio's flexible pricing tiers, from free development plans to scalable production options.
-- [Deploying Your Indexer](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment.md): Learn how to deploy, manage, and version your indexers effortlessly using git workflow.
-- [Features](https://docs.envio.dev/docs/HyperIndex/hosted-service-features.md): Explore production-ready features of the Envio Cloud including monitoring, zero-downtime rollbacks, and deployment management.
-- [Monitoring Your Indexer](https://docs.envio.dev/docs/HyperIndex/hosted-service-monitoring.md): Monitor your deployed indexer health, sync progress, and performance using the Envio Cloud dashboard.
-- [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service.md): Explore Envio's fully managed hosting for indexers with easy Git deployments, monitoring, and multi-chain support.
-- [Organisation Setup](https://docs.envio.dev/docs/HyperIndex/organisation-setup.md): Learn how to create an organisation in the Envio Cloud and manage team members.
-- [Self-Hosting Guide](https://docs.envio.dev/docs/HyperIndex/self-hosting.md): Learn how to self-host Envio indexers with Docker, PostgreSQL, and Hasura for full control.
-
-### Troubleshooting
-
-- [Common Issues](https://docs.envio.dev/docs/HyperIndex/common-issues.md): Discover quick fixes and proven solutions for setup, runtime, and configuration issues in Envio.
-- [Error Codes](https://docs.envio.dev/docs/HyperIndex/error-codes.md): Explore Envio HyperIndex error codes with clear explanations and quick fixes for common issues.
-- [Logging](https://docs.envio.dev/docs/HyperIndex/logging.md): Learn how to configure and use Envio HyperIndex logging to monitor performance and troubleshoot efficiently.
-- [Reserved Words](https://docs.envio.dev/docs/HyperIndex/reserved-words.md): Learn which reserved words in Envio cause validation errors and how to rename them safely.
-
-### Tutorials & Examples
-
-- [Velodrome & Aerodrome Indexer](https://docs.envio.dev/docs/HyperIndex/example-aerodrome-dex-indexer.md): Explore multi-chain Velodrome & Aerodrome DEX data with real-time tracking of pools, swaps, and liquidity.
-- [Cross-Chain Messaging](https://docs.envio.dev/docs/HyperIndex/example-cross-chain-messaging.md): Explore cross-chain messaging and track events across multiple chains efficiently.
-- [Sablier Protocol Indexers](https://docs.envio.dev/docs/HyperIndex/example-sablier.md): Explore Sablier protocol indexers to track token streams and distributions across multiple chains.
-- [Uniswap V4 Multichain indexer](https://docs.envio.dev/docs/HyperIndex/example-uniswap-v4-multi-chain-indexer.md): Explore real-time Uniswap V4 data across multiple chains with Envio.
-- [Indexing Greeter Contract Using Envio](https://docs.envio.dev/docs/HyperIndex/greeter-tutorial.md): Learn how to build and run a multi-chain indexer that tracks Greeter contract events using Envio.
-- [Getting Price Data in Your Indexer](https://docs.envio.dev/docs/HyperIndex/price-data.md): Learn how to fetch and integrate token price data in your indexer using oracles, DEX pools, and APIs.
-- [Indexing ERC20 Token Transfers on Base](https://docs.envio.dev/docs/HyperIndex/tutorial-erc20-token-transfers.md): Learn how to index and query USDC ERC20 transfers on Base using Envio.
-- [Indexing Sway Farm on the Fuel Network](https://docs.envio.dev/docs/HyperIndex/tutorial-indexing-fuel.md): Learn how to index Sway Farm on Fuel and track player events with Envio.
-- [Indexing Optimism Bridge Deposits](https://docs.envio.dev/docs/HyperIndex/tutorial-op-bridge-deposits.md): Learn to quickly index Optimism Bridge deposits and explore OP Bridge event data.
-- [Scaffold-Eth-2 Envio Extension](https://docs.envio.dev/docs/HyperIndex/scaffold-eth-2-extension-tutorial.md): Scaffold-ETH Extension: Get a boilerplate indexer for your deployed smart contracts and start tracking events instantly.
-- [HyperIndex Benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarks.md): Discover HyperIndex benchmarks and see why it's the fastest blockchain data indexer.
-- [HyperIndex Quickstart](https://docs.envio.dev/docs/HyperIndex/contract-import.md): Learn to quickly autogenerate and configure a HyperIndex indexer for any smart contract.
-- [Fuel](https://docs.envio.dev/docs/HyperIndex/fuel.md): Explore how to index and query real-time and historical data on Fuel Network with HyperIndex.
-- [Licensing](https://docs.envio.dev/docs/HyperIndex/licensing.md): Learn how Envio's licensing lets developers self-host, use generated code, and stay open while protecting Envio Cloud.
-- [Migrate from Alchemy to Envio](https://docs.envio.dev/docs/HyperIndex/migrate-from-alchemy.md): Easily migrate your existing Alchemy subgraphs to Envio for 143x faster indexing than subgraphs, multichain support, and a better developer experience.
-- [Migrate to HyperIndex V3](https://docs.envio.dev/docs/HyperIndex/migrate-to-v3.md): Step-by-step instructions for upgrading an existing HyperIndex V2 project to V3.
-- [What's New in HyperIndex V3](https://docs.envio.dev/docs/HyperIndex/whats-new-in-v3.md): Discover the new features in HyperIndex V3 — unified handlers API, ESM support, top-level await, automatic handler registration, new testing framework, ClickHouse storage, Solana support, and more.
-- [Migrate from The Graph to Envio](https://docs.envio.dev/docs/HyperIndex/migration-guide.md): Easily migrate your existing subgraph to HyperIndex for up to 100x faster indexing speeds, multichain support, and a better developer experience.
-- [HyperIndex: Fast Multichain Blockchain Indexer](https://docs.envio.dev/docs/HyperIndex/overview.md): Explore HyperIndex, a blazing-fast multichain indexer for real-time blockchain data.
-- [Solana](https://docs.envio.dev/docs/HyperIndex/solana.md): Experimental Solana support in HyperIndex. Supports Block Handler, Effect API, and Envio Cloud.
-
-## HyperSync
-
-- [HyperSync](https://docs.envio.dev/docs/HyperSync/overview.md): Explore HyperSync for ultra-fast blockchain data access and flexible queries across 70+ networks.
-- [HyperSync Quickstart](https://docs.envio.dev/docs/HyperSync/hypersync-quickstart.md): Get started quickly with HyperSync to stream and filter blockchain events.
-- [Using HyperSync](https://docs.envio.dev/docs/HyperSync/hypersync-usage.md): Learn how to fetch, filter, and decode blockchain data using HyperSync.
-- [HyperSync Clients](https://docs.envio.dev/docs/HyperSync/hypersync-clients.md): Explore HyperSync clients for fast blockchain data access in Node.js, Python, Rust, and Go.
-- [HyperSync Query](https://docs.envio.dev/docs/HyperSync/hypersync-query.md): Explore HyperSync queries to efficiently retrieve, filter, and join blockchain data.
-- [Preset Queries](https://docs.envio.dev/docs/HyperSync/hypersync-presets.md): Explore ready-to-use HyperSync query presets to fetch blocks, transactions, and logs efficiently.
-- [Using curl with HyperSync](https://docs.envio.dev/docs/HyperSync/hypersync-curl-examples.md): Explore how to quickly fetch blockchain data using curl commands with HyperSync.
-- [API Tokens](https://docs.envio.dev/docs/HyperSync/api-tokens.md): Learn how to generate and use HyperSync API tokens for secure access.
-- [Supported Networks](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks.md): See all networks currently supported by HyperSync, including coverage tiers, reliability notes and the criteria we use when adding new chains.
-- [Analyzing All Transactions To and From an Address](https://docs.envio.dev/docs/HyperSync/tutorial-address-transactions.md): Explore all transactions, token balances, and approvals for any EVM address with HyperSync.
-- [HyperFuel](https://docs.envio.dev/docs/HyperSync/hyperfuel.md): HyperFuel gives you a high performance way to query and sync Fuel network data using HyperSync. Access real-time and historical data with flexible queries across contracts, events and state.
-- [HyperFuel Query](https://docs.envio.dev/docs/HyperSync/hyperfuel-query.md): Explore all fields and parameters for HyperFuel queries.
-
-## HyperRPC
-
-- [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc.md): Ultra-fast read-only RPC built on top of HyperSync, offering up to 5x faster performance than traditional nodes for data-intensive operations like eth_getLogs, block queries, and transaction lookups. Use as a drop-in replacement for existing JSON-RPC tooling, no code changes needed. Covers supported methods, API tokens, performance benchmarks, and getting started.
-
-## Supported Networks
-
-- [HyperIndex Supported Networks](https://docs.envio.dev/docs/HyperIndex/supported-networks.md): Full list of networks supported by HyperIndex, including EVM chains, L2s, and testnets. Also covers using any EVM chain via RPC and local development networks.
-- [HyperSync Supported Networks](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks.md): Full list of networks supported by HyperSync, including coverage tiers, reliability notes, and the criteria used when adding new chains.
-- [HyperRPC Supported Networks](https://docs.envio.dev/docs/HyperRPC/hyperrpc-supported-networks.md): Full list of networks supported by HyperRPC, including endpoints, network IDs, and trace support.
-
-## Case Studies
-
-- [Indexing 4 Billion Polymarket Events](https://docs.envio.dev/blog/polymarket-hyperindex-case-study.md): How Envio HyperIndex replaced 8 Polymarket subgraphs with one TypeScript indexer on Polygon, syncing 4 billion events in 6 days.
-- [Sablier: One Indexer Across 27 Chains](https://docs.envio.dev/blog/case-study-sablier.md): How Sablier replaced 12 separate indexer deployments with one Envio multichain indexer spanning 27 chains, cutting costs and accelerating feature delivery.
-- [Limitless: Real-Time Prediction Market on Base](https://docs.envio.dev/blog/case-study-limitless-prediction-market.md): How Limitless Exchange uses Envio to power a daily prediction market on Base with real-time onchain data, custom GraphQL APIs, and a seamless transaction feed.
-- [Bridgg: 12 OP Superchain Networks, One API](https://docs.envio.dev/blog/case-study-bridgg-op-superchain.md): How Bridgg uses Envio to aggregate deposit and withdrawal data across 12 OP Superchain networks into a single API, indexing 11 million events in one deployment.
-- [zkPass: Multichain ZKP Identity Verification](https://docs.envio.dev/blog/zkpass-shaping-future-of-data-privacy.md): How zkPass uses zero knowledge proofs with Envio to verify identity and transactions across 8 EVM networks while keeping user data private.
-- [GBlast: Eliminating Data Latency on Blast](https://docs.envio.dev/blog/case-study-gblast.md): How GBlast integrated Envio to eliminate real-time data latency, power their points system, and deliver a responsive GambleFi experience on Blast.
-
-## Legal
-
-- [Privacy Policy](https://docs.envio.dev/docs/HyperIndex/privacy-policy.md): Read Envio's Privacy Policy covering how we collect, use, store, and protect your personal data when you use our website and services.
-- [Terms of Service](https://docs.envio.dev/docs/HyperIndex/terms-of-service.md): Read the Terms and Conditions for using Envio services.
-
-## Optional
-
-- [Envio website](https://envio.dev): Product overview and landing page.
-- [Envio root llms.txt](https://envio.dev/llms.txt): Marketing-facing llms.txt summary.
-- [Pricing](https://envio.dev/pricing): Envio Cloud plans and billing.
-- [Supported chains overview](https://envio.dev/chains): Canonical chains page across all products.
-- [GitHub organization](https://github.com/enviodev): Public repositories.
-- [HyperIndex repo](https://github.com/enviodev/hyperindex): Source and issues.
-- [Releases](https://github.com/enviodev/hyperindex/releases): HyperIndex changelog.
-- [Quickstart with AI](https://docs.envio.dev/docs/HyperIndex/quickstart-with-ai.md): End-to-end guide for building an indexer with Claude Code, Cursor, or any MCP-compatible AI coding assistant.
-- [MCP Server](https://docs.envio.dev/docs/HyperIndex/mcp-server.md): Model Context Protocol server for AI coding assistants. Endpoint: https://docs.envio.dev/mcp
-- [X](https://x.com/envio_indexer): Social updates.
-- [Telegram](https://t.me/+5mI61oZibEM5OGQ8): Community chat.
-- [Discord](https://discord.gg/envio): Community support.
-- [LinkedIn](https://www.linkedin.com/company/envio_indexer): Company page.
-- [YouTube](https://www.youtube.com/@envio_indexer): Video content.
+This file is generated from page frontmatter at build time and follows the llmstxt.org standard.
 `,
+            sections: [
+              {
+                heading: "HyperIndex",
+                subsections: [
+                  {
+                    heading: "Core",
+                    include: [
+                      "docs/HyperIndex/Advanced/**/*.{md,mdx}",
+                      "docs/HyperIndex/Guides/**/*.{md,mdx}",
+                    ],
+                    // mcp-server lives under Guides but is more useful in the
+                    // Optional section as an AI-assistant entry point.
+                    exclude: ["**/mcp-server.{md,mdx}"],
+                  },
+                  {
+                    heading: "Envio Cloud",
+                    include: ["docs/HyperIndex/Hosted_Service/**/*.{md,mdx}"],
+                  },
+                  {
+                    heading: "Troubleshooting",
+                    include: ["docs/HyperIndex/Troubleshoot/**/*.{md,mdx}"],
+                  },
+                  {
+                    heading: "Tutorials & Examples",
+                    include: [
+                      "docs/HyperIndex/Examples/**/*.{md,mdx}",
+                      "docs/HyperIndex/Tutorials/**/*.{md,mdx}",
+                      "docs/HyperIndex/overview.{md,mdx}",
+                      "docs/HyperIndex/contract-import.{md,mdx}",
+                      "docs/HyperIndex/benchmarks.{md,mdx}",
+                      "docs/HyperIndex/fuel/**/*.{md,mdx}",
+                      "docs/HyperIndex/solana/**/*.{md,mdx}",
+                      "docs/HyperIndex/licensing.{md,mdx}",
+                      "docs/HyperIndex/whats-new-in-v3.{md,mdx}",
+                      "docs/HyperIndex/migrate-to-v3.{md,mdx}",
+                      "docs/HyperIndex/migrate-from-alchemy.{md,mdx}",
+                      "docs/HyperIndex/migrate-from-ponder.{md,mdx}",
+                      "docs/HyperIndex/migrate-with-ai.{md,mdx}",
+                      "docs/HyperIndex/migration-guide.{md,mdx}",
+                    ],
+                  },
+                ],
+              },
+              {
+                heading: "HyperSync",
+                include: ["docs/HyperSync/**/*.{md,mdx}"],
+                // Supported-networks page is grouped under its own heading.
+                exclude: ["**/hypersync-supported-networks.{md,mdx}"],
+              },
+              {
+                heading: "HyperRPC",
+                include: ["docs/HyperRPC/**/*.{md,mdx}"],
+                exclude: ["**/hyperrpc-supported-networks.{md,mdx}"],
+              },
+              {
+                heading: "Supported Networks",
+                include: [
+                  "docs/HyperIndex/supported-networks/index.{md,mdx}",
+                  "docs/HyperSync/hypersync-supported-networks.{md,mdx}",
+                  "docs/HyperRPC/hyperrpc-supported-networks.{md,mdx}",
+                ],
+              },
+              {
+                heading: "Blog",
+                source: "blog",
+                subsections: [
+                  {
+                    heading: "Case Studies",
+                    source: "blog",
+                    tags: ["case-studies"],
+                  },
+                  {
+                    heading: "Tutorials",
+                    source: "blog",
+                    tags: ["tutorials"],
+                  },
+                  {
+                    heading: "AI",
+                    source: "blog",
+                    tags: ["ai"],
+                  },
+                  {
+                    heading: "Product Updates",
+                    source: "blog",
+                    tags: ["product-updates"],
+                  },
+                  {
+                    heading: "Announcements",
+                    source: "blog",
+                    tags: ["announcements"],
+                  },
+                  {
+                    heading: "Articles",
+                    source: "blog",
+                    catchAll: true,
+                  },
+                ],
+              },
+              {
+                heading: "HyperIndex V2 (legacy)",
+                subsections: [
+                  {
+                    heading: "Core",
+                    include: [
+                      "docs/HyperIndexV2/Advanced/**/*.{md,mdx}",
+                      "docs/HyperIndexV2/Guides/**/*.{md,mdx}",
+                    ],
+                  },
+                  {
+                    heading: "Envio Cloud",
+                    include: [
+                      "docs/HyperIndexV2/Hosted_Service/**/*.{md,mdx}",
+                    ],
+                  },
+                  {
+                    heading: "Troubleshooting",
+                    include: ["docs/HyperIndexV2/Troubleshoot/**/*.{md,mdx}"],
+                  },
+                  {
+                    heading: "Tutorials & Examples",
+                    include: [
+                      "docs/HyperIndexV2/Examples/**/*.{md,mdx}",
+                      "docs/HyperIndexV2/Tutorials/**/*.{md,mdx}",
+                      "docs/HyperIndexV2/*.{md,mdx}",
+                      "docs/HyperIndexV2/fuel/**/*.{md,mdx}",
+                    ],
+                    // Legal/policy pages share a dedicated section.
+                    exclude: [
+                      "**/privacy-policy.{md,mdx}",
+                      "**/terms-of-service.{md,mdx}",
+                    ],
+                  },
+                ],
+              },
+              {
+                heading: "Legal",
+                include: [
+                  "docs/HyperIndex/privacy-policy.{md,mdx}",
+                  "docs/HyperIndex/terms-of-service.{md,mdx}",
+                ],
+              },
+            ],
+            optional: [
+              {
+                label: "Envio website",
+                href: "https://envio.dev",
+                description: "Product overview and landing page.",
+              },
+              {
+                label: "Envio root llms.txt",
+                href: "https://envio.dev/llms.txt",
+                description: "Marketing-facing llms.txt summary.",
+              },
+              {
+                label: "Pricing",
+                href: "https://envio.dev/pricing",
+                description: "Envio Cloud plans and billing.",
+              },
+              {
+                label: "Supported chains overview",
+                href: "https://envio.dev/chains",
+                description: "Canonical chains page across all products.",
+              },
+              {
+                label: "GitHub organization",
+                href: "https://github.com/enviodev",
+                description: "Public repositories.",
+              },
+              {
+                label: "HyperIndex repo",
+                href: "https://github.com/enviodev/hyperindex",
+                description: "Source and issues.",
+              },
+              {
+                label: "Releases",
+                href: "https://github.com/enviodev/hyperindex/releases",
+                description: "HyperIndex changelog.",
+              },
+              {
+                label: "Quickstart with AI",
+                href: "https://docs.envio.dev/docs/HyperIndex/quickstart-with-ai.md",
+                description:
+                  "End-to-end guide for building an indexer with Claude Code, Cursor, or any MCP-compatible AI coding assistant.",
+              },
+              {
+                label: "MCP Server",
+                href: "https://docs.envio.dev/docs/HyperIndex/mcp-server.md",
+                description:
+                  "Model Context Protocol server for AI coding assistants. Endpoint: https://docs.envio.dev/mcp",
+              },
+              {
+                label: "Telegram",
+                href: "https://t.me/+5mI61oZibEM5OGQ8",
+                description: "Community chat.",
+              },
+              {
+                label: "Discord",
+                href: "https://discord.gg/envio",
+                description: "Community support.",
+              },
+              {
+                label: "LinkedIn",
+                href: "https://www.linkedin.com/company/envio_indexer",
+                description: "Company page.",
+              },
+              {
+                label: "YouTube",
+                href: "https://www.youtube.com/@envio_indexer",
+                description: "Video content.",
+              },
+            ],
           },
         ],
         blog: true,

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -62,8 +62,39 @@ const minimatch = typeof _minimatch === "function" ? _minimatch : _minimatch.min
 // - The `.md` copies are saved at the same relative path as the doc's URL.
 
 function GenerateLLMSPlugin(context, options) {
+    const llmsTxtPath = options.llmsTxtPath || "/llms.txt";
+
     return {
         name: "docusaurus-plugin-generate-llms",
+
+        // Inject an agent-facing directive into the HTML of every page so
+        // agents discovering a single page can find the documentation index.
+        // Matches the agentdocsspec "llms-txt-directive-html" check.
+        injectHtmlTags() {
+            return {
+                headTags: [
+                    {
+                        tagName: "link",
+                        attributes: {
+                            rel: "alternate",
+                            type: "text/plain",
+                            href: llmsTxtPath,
+                            title: "Documentation index for AI agents (llms.txt)",
+                        },
+                    },
+                ],
+                preBodyTags: [
+                    {
+                        tagName: "div",
+                        attributes: {
+                            "data-llms-directive": "true",
+                            style: "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;",
+                        },
+                        innerHTML: `For AI agents: the documentation index is at <a href="${llmsTxtPath}">${llmsTxtPath}</a>. Markdown versions of pages are available by appending <code>.md</code> to the URL.`,
+                    },
+                ],
+            };
+        },
 
         async postBuild({ siteConfig }) {
             const { url, plugins } = siteConfig;

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -70,6 +70,11 @@ function GenerateLLMSPlugin(context, options) {
 
             const filesConfigs = options.filesConfigs || [];
             const excludePluginIds = new Set(options.excludePluginIds || []);
+            // Plugin IDs collected for the llms.txt index but kept out of
+            // llms-full.txt and the per-page .md copies (e.g. legacy V2 docs).
+            const excludeFromFullPluginIds = new Set(
+                options.excludeFromFullPluginIds || []
+            );
 
             let collectedDocs = [];
 
@@ -109,12 +114,22 @@ function GenerateLLMSPlugin(context, options) {
                             ""
                         )}`;
 
+                        const filePath = path.join(config.path, file);
+                        const relativePath = toPosix(
+                            path.relative(context.siteDir, fullPath)
+                        );
+
                         collectedDocs.push({
-                            filePath: path.join(config.path, file),
+                            filePath,
+                            relativePath,
                             title,
                             description,
                             pageUrl,
                             source: "docs",
+                            pluginId: config.id || "",
+                            tags: Array.isArray(parsed.data.tags)
+                                ? parsed.data.tags
+                                : [],
                         });
                     }
                 }
@@ -175,12 +190,21 @@ function GenerateLLMSPlugin(context, options) {
                             ""
                         )}/${slug.replace(/^\//, "")}`;
 
+                        const relativePath = toPosix(
+                            path.relative(context.siteDir, fullPath)
+                        );
+
                         collectedDocs.push({
                             filePath: fullPath,
+                            relativePath,
                             title,
                             description,
                             pageUrl,
                             source: "blog",
+                            pluginId: "blog",
+                            tags: Array.isArray(parsed.data.tags)
+                                ? parsed.data.tags
+                                : [],
                         });
                     }
                 }
@@ -222,14 +246,145 @@ function GenerateLLMSPlugin(context, options) {
             function renderLLMS(rootText, docs) {
                 let output = rootText.trim() + "\n\n";
                 for (const doc of docs) {
-                    const desc =
-                        doc.description ||
-                        (doc.title.length > 20
-                            ? `${doc.title} section of the docs.`
-                            : "");
-                    output += `- [${doc.title}](${doc.pageUrl}.md): ${desc}\n`;
+                    output += `${formatDocBullet(doc)}\n`;
                 }
                 return output;
+            }
+
+            function formatDocBullet(doc) {
+                const desc =
+                    doc.description ||
+                    (doc.title.length > 20
+                        ? `${doc.title} section of the docs.`
+                        : "");
+                return `- [${doc.title}](${doc.pageUrl}.md): ${desc}`;
+            }
+
+            // Match a doc against a section/subsection node. Returns docs that
+            // match include patterns + tags, minus exclude patterns, with each
+            // doc claimed at most once across the whole file (first match wins).
+            function selectDocs(node, claimed) {
+                const include = node.include || [];
+                const exclude = node.exclude || [];
+                const source = node.source || "docs";
+                const tags = node.tags;
+                const out = [];
+
+                for (const doc of collectedDocs) {
+                    if (claimed.has(doc.relativePath)) continue;
+                    if (doc.source !== source) continue;
+
+                    if (tags && tags.length > 0) {
+                        const docTags = doc.tags || [];
+                        if (!tags.some((t) => docTags.includes(t))) continue;
+                    }
+
+                    if (include.length > 0) {
+                        const matched = include.some((p) =>
+                            minimatch(doc.relativePath, toPosix(p))
+                        );
+                        if (!matched) continue;
+                    } else if (
+                        (!tags || tags.length === 0) &&
+                        !node.catchAll
+                    ) {
+                        // No selectors and not a catch-all → skip rather than
+                        // match every doc of this source.
+                        continue;
+                    }
+
+                    if (
+                        exclude.some((p) =>
+                            minimatch(doc.relativePath, toPosix(p))
+                        )
+                    ) {
+                        continue;
+                    }
+
+                    out.push(doc);
+                    claimed.add(doc.relativePath);
+                }
+
+                // Deterministic order: by include-pattern order, then by title
+                // within each pattern bucket.
+                if (node.include && node.include.length > 0) {
+                    const bucketOf = (doc) => {
+                        for (let i = 0; i < node.include.length; i++) {
+                            if (
+                                minimatch(
+                                    doc.relativePath,
+                                    toPosix(node.include[i])
+                                )
+                            )
+                                return i;
+                        }
+                        return node.include.length;
+                    };
+                    out.sort((a, b) => {
+                        const ba = bucketOf(a);
+                        const bb = bucketOf(b);
+                        if (ba !== bb) return ba - bb;
+                        return a.title.localeCompare(b.title);
+                    });
+                } else if (node.source === "blog") {
+                    // Blog filenames are date-prefixed (YYYY-MM-DD-...). Sort
+                    // by relativePath descending so newest posts surface first.
+                    out.sort((a, b) =>
+                        b.relativePath.localeCompare(a.relativePath)
+                    );
+                } else {
+                    out.sort((a, b) => a.title.localeCompare(b.title));
+                }
+
+                return out;
+            }
+
+            function renderLLMSStructured(cfg) {
+                const {
+                    header = "",
+                    sections = [],
+                    optional = [],
+                } = cfg;
+                const claimed = new Set();
+                const parts = [header.trim(), ""];
+
+                const renderLeaf = (node) => {
+                    const docs = selectDocs(node, claimed);
+                    if (docs.length === 0) {
+                        console.warn(
+                            `[plugin-generate-llms] section "${node.heading}" matched 0 docs`
+                        );
+                    }
+                    return docs.map(formatDocBullet).join("\n");
+                };
+
+                for (const sec of sections) {
+                    parts.push(`## ${sec.heading}`);
+                    parts.push("");
+                    if (sec.subsections && sec.subsections.length > 0) {
+                        for (const sub of sec.subsections) {
+                            parts.push(`### ${sub.heading}`);
+                            parts.push("");
+                            parts.push(renderLeaf(sub));
+                            parts.push("");
+                        }
+                    } else {
+                        parts.push(renderLeaf(sec));
+                        parts.push("");
+                    }
+                }
+
+                if (optional.length > 0) {
+                    parts.push("## Optional");
+                    parts.push("");
+                    for (const o of optional) {
+                        const desc = o.description ? `: ${o.description}` : "";
+                        parts.push(`- [${o.label}](${o.href})${desc}`);
+                    }
+                    parts.push("");
+                }
+
+                return parts.join("\n");
             }
 
             // Concatenate every item's stripped markdown content into a single
@@ -281,15 +436,25 @@ function GenerateLLMSPlugin(context, options) {
 
             // 2. generate files
             for (const cfg of filesConfigs) {
-                const { main, name, root = "", includeOrder = [] } = cfg;
+                const {
+                    main,
+                    name,
+                    root = "",
+                    includeOrder = [],
+                    sections,
+                } = cfg;
 
-                // Order docs based on includeOrder patterns
-                const orderedDocs = orderDocs(includeOrder);
-
-                // Inject "## Table of Contents" after root text
-                const tocRoot = root.trim() + "";
-
-                const output = renderLLMS(tocRoot, orderedDocs);
+                // Structured mode: header + sections + optional. Used when the
+                // config provides explicit section grouping. Falls back to the
+                // legacy flat `root` + `includeOrder` mode otherwise.
+                let output;
+                if (Array.isArray(sections) && sections.length > 0) {
+                    output = renderLLMSStructured(cfg);
+                } else {
+                    const orderedDocs = orderDocs(includeOrder);
+                    const tocRoot = root.trim() + "";
+                    output = renderLLMS(tocRoot, orderedDocs);
+                }
 
                 // Use llms.txt for the first/main config, others as llms-<name>.txt
                 const outFileName = cfg.main ? "llms.txt" : `llms-${name}.txt`;
@@ -301,15 +466,23 @@ function GenerateLLMSPlugin(context, options) {
                 // Write .md copies for ALL collected docs so every link in the
                 // static root text resolves — not just those in includeOrder.
                 if (main) {
+                    // All collected docs get .md copies so every link in
+                    // llms.txt resolves. llms-full.txt is restricted further
+                    // to keep V2 (and similar legacy content) out of the
+                    // concatenated knowledge dump.
                     writeMarkdownCopies(collectedDocs);
+
+                    const fullDocsPool = collectedDocs.filter(
+                        (d) => !excludeFromFullPluginIds.has(d.pluginId)
+                    );
 
                     // Generate llms-full variants: one for docs, one for blog.
                     // Agents that cannot browse mid-conversation (Claude Projects,
                     // Cursor) paste these into their context window for full recall.
-                    const docsItems = collectedDocs.filter(
+                    const docsItems = fullDocsPool.filter(
                         (d) => d.source === "docs"
                     );
-                    const blogItems = collectedDocs.filter(
+                    const blogItems = fullDocsPool.filter(
                         (d) => d.source === "blog"
                     );
 

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -409,6 +409,15 @@ function GenerateLLMSPlugin(context, options) {
 
             // --- NEW: write .md copies into build folder ---
             function writeMarkdownCopies(docs) {
+                // Discovery directive prepended to every .md copy so agents
+                // fetching a single page can find the full index.
+                // Matches the agentdocsspec "llms-txt-directive-md" check.
+                const llmsTxtUrl = `${siteConfig.url.replace(
+                    /\/$/,
+                    ""
+                )}/llms.txt`;
+                const directive = `> For the complete documentation index, see [llms.txt](${llmsTxtUrl}).\n\n`;
+
                 for (const doc of docs) {
                     const rawContent = fs.readFileSync(doc.filePath, "utf-8");
 
@@ -430,7 +439,11 @@ function GenerateLLMSPlugin(context, options) {
                     );
 
                     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-                    fs.writeFileSync(targetPath, cleanContent, "utf-8");
+                    fs.writeFileSync(
+                        targetPath,
+                        directive + cleanContent,
+                        "utf-8"
+                    );
                 }
             }
 

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
       "destination": "/api/mcp"
     },
     {
-      "source": "/docs/:path*",
+      "source": "/docs/:path+",
       "has": [
         {
           "type": "header",
@@ -18,7 +18,7 @@
           "value": ".*text/markdown.*"
         }
       ],
-      "destination": "/docs/:path*.md"
+      "destination": "/docs/:path+.md"
     },
     {
       "source": "/blog/:slug",

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,28 @@
     {
       "source": "/mcp",
       "destination": "/api/mcp"
+    },
+    {
+      "source": "/docs/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/docs/:path*.md"
+    },
+    {
+      "source": "/blog/:slug",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/blog/:slug.md"
     }
   ],
   "redirects": [
@@ -15,6 +37,26 @@
       "source": "/blog/tags/:tag*",
       "destination": "/blog/tag/:tag*",
       "permanent": true
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*).md",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/llms(.*).txt",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/plain; charset=utf-8"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
 ## Summary

  - Refactor `plugin-generate-llms` to auto-generate `llms.txt` from page
  frontmatter via a structured `sections` config, replacing the 130-line
  hardcoded link list that had drifted out of sync with actual slugs (e.g.
  quickstart linked via `contract-import.md`).
  - Restructured `llms.txt` order: HyperIndex (v3) → HyperSync → HyperRPC →
  Supported Networks → Blog (Case Studies / Tutorials / AI / Product Updates /
  Announcements / Articles) → HyperIndex V2 (legacy) → Legal → Optional. Blog
  now uses tag-based subsections with a `catchAll` bucket so every post appears
  exactly once.
  - Add HyperIndex V2 section back to `llms.txt` (was missing). V2 ships
  per-page `.md` copies so links resolve, but stays out of `llms-full.txt` via a
   new `excludeFromFullPluginIds` plugin option to keep the concatenated dump
  V3-focused.
  - Prepend an agent-facing blockquote (`> For the complete documentation index,
   see llms.txt`) to every `.md` page copy.
  - Inject an HTML discovery directive on every rendered page: `<link
  rel="alternate" type="text/plain" href="/llms.txt">` in `<head>` plus a
  visually-hidden `<div>` at the top of `<body>` pointing agents at `/llms.txt`
  and noting `.md` URL availability.
  - Add Vercel content negotiation: `Accept: text/markdown` rewrites
  `/docs/:path*` and `/blog/:slug` to their `.md` counterparts. Pin
  `Content-Type: text/markdown` on `.md` responses and `text/plain` on
  `llms*.txt`.

  Addresses the failing agentdocsspec checks:
  - `llms-txt-directive-html` (was: 0/50 sampled pages had directive)
  - `llms-txt-directive-md`
  - `content-negotiation`
  - `llms-txt-links-markdown` (links in `llms.txt` already point to `.md` URLs
  via the generator)

  ## Test plan

  - [ ] `yarn build` succeeds; no "matched 0 docs" warnings from plugin
  - [ ] `build/llms.txt` contains all 8 sections in expected order
  - [ ] `build/llms-full.txt` size stable (V2 not included)
  - [ ] V2 `.md` copies exist under `build/docs/v2/HyperIndex/`
  - [ ] Each `.md` copy starts with the `> For the complete documentation
  index...` blockquote (sample docs, blog, and V2)
  - [ ] Built HTML pages contain `<link rel="alternate" type="text/plain"
  href="/llms.txt">` and the hidden `data-llms-directive` div
  - [ ] On Vercel preview: `curl -H "Accept: text/markdown" -i
  <preview>/docs/HyperIndex/overview` returns markdown body with `Content-Type:
  text/markdown; charset=utf-8`
  - [ ] On Vercel preview: `curl -i <preview>/llms.txt` returns `Content-Type:
  text/plain; charset=utf-8`
  - [ ] Re-run the external agentdocsspec checker against the preview;
  previously-failing checks now pass

  Commits going up:
  - aa211b0 Auto-generate llms.txt from page frontmatter
  - 38271a5 Prepend llms.txt directive to .md page copies
  - 784f875 Inject llms.txt discovery directive into page HTML
  - a4349f7 Serve markdown via Accept: text/markdown content negotiation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured LLM documentation output with organized sections and improved navigation
  * Enhanced routing system with proper content-type headers for markdown and text files
  * Added configurable path support for LLM directives and metadata enrichment

* **Chores**
  * Updated LLM documentation bundle exclusion rules and optional reference links
  * Refined plugin configuration for improved documentation selection and filtering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->