### PR TITLE
Move markdown content negotiation to routing middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,31 @@
+// Vercel routing middleware: serve markdown when the client asks for it.
+//
+// Agents (Claude Code, Cursor, OpenCode) send `Accept: text/markdown` to
+// request the plain-text version of a page. The build emits a `<page>.md`
+// alongside every documentation page; here we rewrite the request to that
+// file while keeping the canonical URL unchanged.
+//
+// Conditional rewrites in vercel.json don't reliably intercept before the
+// static filesystem on Docusaurus deployments, so we handle the negotiation
+// in middleware where the precedence is well-defined.
+
+export const config = {
+  matcher: ["/docs/:path+", "/blog/:slug"],
+};
+
+export default function middleware(request) {
+  const accept = request.headers.get("accept") || "";
+  if (!/text\/markdown/i.test(accept)) {
+    return;
+  }
+
+  const url = new URL(request.url);
+  const cleanPath = url.pathname.replace(/\/$/, "");
+  const rewriteUrl = new URL(`${cleanPath}.md`, url);
+
+  return new Response(null, {
+    headers: {
+      "x-middleware-rewrite": rewriteUrl.toString(),
+    },
+  });
+}

--- a/middleware.js
+++ b/middleware.js
@@ -21,6 +21,11 @@ export default function middleware(request) {
 
   const url = new URL(request.url);
   const cleanPath = url.pathname.replace(/\/$/, "");
+  // If the client already asked for the .md URL directly, let it through
+  // unchanged — appending another .md would 404.
+  if (cleanPath.endsWith(".md")) {
+    return;
+  }
   const rewriteUrl = new URL(`${cleanPath}.md`, url);
 
   return new Response(null, {


### PR DESCRIPTION
The conditional rewrite in vercel.json (`has: [{ accept: text/markdown }]`) didn't intercept requests on the deployed Docusaurus site — pages with a matching `.md` twin still returned HTML. Replace it with a routing middleware at the project root, which evaluates with well-defined precedence before the static filesystem.

middleware.js handles `Accept: text/markdown` for /docs/<path> and /blog/<slug>, rewriting to the corresponding `.md` file via the x-middleware-rewrite response header. No new runtime dependency.

vercel.json keeps the Content-Type pinning on `.md` and `llms*.txt` responses, and the existing /mcp + blog/tags rewrites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation and blog content can now be served in Markdown format when requested through the appropriate accept header, while maintaining standard web URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->