### PR TITLE
Index per-chain pages in llms.txt for sitemap coverage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -518,10 +518,26 @@ This file is generated from page frontmatter at build time and follows the llmst
               },
               {
                 heading: "Supported Networks",
-                include: [
-                  "docs/HyperIndex/supported-networks/index.{md,mdx}",
-                  "docs/HyperSync/hypersync-supported-networks.{md,mdx}",
-                  "docs/HyperRPC/hyperrpc-supported-networks.{md,mdx}",
+                subsections: [
+                  {
+                    heading: "Overview",
+                    include: [
+                      "docs/HyperIndex/supported-networks/index.{md,mdx}",
+                      "docs/HyperSync/hypersync-supported-networks.{md,mdx}",
+                      "docs/HyperRPC/hyperrpc-supported-networks.{md,mdx}",
+                    ],
+                  },
+                  {
+                    // Per-chain reference pages — listed compactly (no
+                    // description) so 200+ entries don't blow the 50 KB
+                    // llms.txt size threshold.
+                    heading: "HyperIndex Chains",
+                    include: [
+                      "docs/HyperIndex/supported-networks/**/*.{md,mdx}",
+                    ],
+                    exclude: ["**/index.{md,mdx}"],
+                    compact: true,
+                  },
                 ],
               },
               {
@@ -587,12 +603,20 @@ This file is generated from page frontmatter at build time and follows the llmst
                       "docs/HyperIndexV2/Tutorials/**/*.{md,mdx}",
                       "docs/HyperIndexV2/*.{md,mdx}",
                       "docs/HyperIndexV2/fuel/**/*.{md,mdx}",
+                      "docs/HyperIndexV2/solana/**/*.{md,mdx}",
                     ],
                     // Legal/policy pages share a dedicated section.
                     exclude: [
                       "**/privacy-policy.{md,mdx}",
                       "**/terms-of-service.{md,mdx}",
                     ],
+                  },
+                  {
+                    heading: "Chains",
+                    include: [
+                      "docs/HyperIndexV2/supported-networks/**/*.{md,mdx}",
+                    ],
+                    compact: true,
                   },
                 ],
               },

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -282,7 +282,10 @@ function GenerateLLMSPlugin(context, options) {
                 return output;
             }
 
-            function formatDocBullet(doc) {
+            function formatDocBullet(doc, opts = {}) {
+                if (opts.compact) {
+                    return `- [${doc.title}](${doc.pageUrl}.md)`;
+                }
                 const desc =
                     doc.description ||
                     (doc.title.length > 20
@@ -386,7 +389,10 @@ function GenerateLLMSPlugin(context, options) {
                             `[plugin-generate-llms] section "${node.heading}" matched 0 docs`
                         );
                     }
-                    return docs.map(formatDocBullet).join("\n");
+                    const opts = { compact: !!node.compact };
+                    return docs
+                        .map((doc) => formatDocBullet(doc, opts))
+                        .join("\n");
                 };
 
                 for (const sec of sections) {


### PR DESCRIPTION
agentdocsspec's llms-txt-coverage check expects llms.txt to cover ~80% of the sitemap. Before this change, llms.txt indexed 156 of 658 pages (24%) because the auto-generated supported-networks/* pages were omitted from both HyperIndex and the V2 legacy mirror.

Add two new subsections — "Supported Networks > HyperIndex Chains" and "HyperIndex V2 (legacy) > Chains" — that pull in the full chain reference. To keep llms.txt usable for agents, the plugin gains a `compact: true` section flag that renders chain bullets as `- [Title](url.md)` with no description. With it on, ~480 chain entries add only ~25 KB to the file (now ~83 KB / 708 bullets) instead of the ~55 KB they would consume with descriptions.

This trades a warning on llms-txt-size (50 KB threshold) for a pass on llms-txt-coverage. Size is a soft check; coverage previously failed. Also adds docs/HyperIndexV2/solana/** to V2 Tutorials & Examples so the V2 Solana subpages get indexed alongside fuel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized "Supported Networks" documentation with dedicated overview and chain pages
  * Updated "HyperIndex V2 (legacy)" documentation structure with Solana tutorials and chain-specific sections
  * Improved documentation rendering with compact display mode for streamlined presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->