### PR TITLE
Add v2 HyperIndex documentation path to sidebar config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -463,6 +463,7 @@ const config = {
           "/docs/HyperIndex-LLM/**",
           "/docs/HyperSync-LLM/**",
           "/docs/HyperRPC-LLM/**",
+          "/docs/v2/HyperIndex/**",
         ],
       },
     ],


### PR DESCRIPTION
## Summary
Updated the Docusaurus configuration to include the v2 HyperIndex documentation path in the sidebar exclusion list.

## Changes
- Added `/docs/v2/HyperIndex/**` to the sidebar configuration exclusion patterns in `docusaurus.config.js`

## Details
This change ensures that the v2 HyperIndex documentation follows the same sidebar handling as other HyperIndex and HyperSync/HyperRPC LLM documentation paths, maintaining consistent documentation structure and navigation behavior across different documentation versions.

https://claude.ai/code/session_017k3vihnHYBJiDauPACGbcz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server plugin configuration for documentation route handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->