### PR TITLE
Exclude blog routes from sitemap generation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -460,6 +460,7 @@ const config = {
           version: "1.0.0",
         },
         excludeRoutes: [
+          "/blog/**",
           "/docs/HyperIndex-LLM/**",
           "/docs/HyperSync-LLM/**",
           "/docs/HyperRPC-LLM/**",


### PR DESCRIPTION
## Summary
Updated the sitemap configuration to exclude blog routes from being indexed, alongside the existing LLM documentation exclusions.

## Changes
- Added `/blog/**` to the `excludeRoutes` array in `docusaurus.config.js`

## Details
This change prevents blog content from being included in the generated sitemap. The blog routes are now excluded from sitemap generation, consistent with the existing exclusion of HyperIndex-LLM, HyperSync-LLM, and HyperRPC-LLM documentation routes.

https://claude.ai/code/session_013fkeRRMDb8Cgta1uUeyadE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration to exclude blog routes from processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/docs/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->