### PR TITLE
blog: update author title

### DIFF
--- a/blog/2025-04-15-oracle-wars.md
+++ b/blog/2025-04-15-oracle-wars.md
@@ -8,7 +8,7 @@ last_update:
   date: 2026-04-15
 ---
 
-Co-authors: [Jordyn Laurier](https://x.com/j_o_r_d_y_s), Head of Marketing & Operations, and [Jonjon Clark](https://x.com/jonjonclark), Co-Founder at Envio
+Co-authors: [Jordyn Laurier](https://x.com/j_o_r_d_y_s), Head of Marketing, and [Jonjon Clark](https://x.com/jonjonclark), Co-Founder at Envio
 
 <img src="/blog-assets/oracle-wars-1.png" alt="Cover Image Oracle Wars" width="100%"/>
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -9,7 +9,7 @@ nikbhintade:
     linkedin: https://linkedin.com/in/nikbhintade
 j_o_r_d_y_s:
   name: Jordyn Laurier
-  title: Head of Marketing & Ops at Envio
+  title: Head of Marketing at Envio
   url: /blog/author/j_o_r_d_y_s
   image_url: /blog-assets/authors/j_o_r_d_y_s.jpg
   description: "Passionate about building communities and sharing knowledge around blockchain indexing and Web3 infrastructure."


### PR DESCRIPTION
## Summary
- Updates  author title
- `blog/authors.yml` is the central source, so this covers every post using the `authors:` frontmatter.
- Also fixes the one inline co-author line in `blog/2025-04-15-oracle-wars.md`.