### PR TITLE
seo: noindex v2 HyperIndex docs

### DIFF
--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Layout from '@theme-original/DocItem/Layout';
 import { useActivePlugin } from '@docusaurus/plugin-content-docs/client';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import Head from '@docusaurus/Head';
 import Admonition from '@theme/Admonition';
 import Link from '@docusaurus/Link';
 
@@ -16,6 +17,11 @@ export default function LayoutWrapper(props) {
 
   return (
     <>
+      {pluginId === 'HyperIndexV2' && (
+        <Head>
+          <meta name="robots" content="noindex" />
+        </Head>
+      )}
       {isBrowser && pluginId === 'HyperIndexV2' && (
         <Admonition type="warning" title="You're viewing v2 documentation">
           <p>


### PR DESCRIPTION
## Summary
Tell Google to drop v2 HyperIndex docs from search so v3 wins on relevant queries. v2 stays reachable for users on older releases via direct link, sidebar, and the existing v2 banner. The change piggybacks on the existing DocItem/Layout swizzle, so it auto-applies to every current and future v2 page.

## Context
A quick GSC audit before opening this PR showed Google currently indexes only 3 v2 URLs, all niche supported-network pages (zksync, torus-mainnet, neo-x-testnet), and v3 already covers all three. So this is more preventative hygiene than urgent fix, but it locks in the right SEO posture and cleans up the small live footprint.

## Verification
- Built locally with `yarn build`.
- 303 of 304 v2 content pages serve `<meta name="robots" content="noindex">` in the head. The 1 outlier is a pre-existing render issue on a page with parentheses in its URL.
- v3 (313 pages), HyperSync (16 pages), HyperRPC (4 pages), the blog and the homepage all stay clean.
- Curl-tested against a live `yarn serve` to confirm the tag survives gzip and sits inside the head, as Googlebot will see it.
- Side effect, intended: Docusaurus's sitemap plugin auto-excludes noindex pages, so `sitemap.xml` no longer lists v2.

## Follow-up after deploy
- Re-inspect a v2 URL in GSC, confirm `noindex` is detected.
- Request indexing on the 3 known v2 URLs so Google re-crawls and picks up the directive sooner.
- Resubmit `sitemap.xml` in GSC.
- Do NOT add `Disallow: /docs/v2/` to robots.txt, that would block crawl and prevent Google from ever seeing the noindex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine indexing configuration for documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->