### PR TITLE
Add X-Robots-Tag noindex to .md routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -46,6 +46,10 @@
         {
           "key": "Content-Type",
           "value": "text/markdown; charset=utf-8"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
         }
       ]
     },


### PR DESCRIPTION
Adds an X-Robots-Tag noindex response header to .md URLs on docs.envio.dev. The .md twins stay reachable for AI agents and the llms.txt workflow, but Google will drop them from the index, which clears the duplicate content flagged in Search Console and MOZ.