### PR TITLE
Fix benchmark numbers on what-is-hypersync

### DIFF
--- a/blog/2026-04-30-what-is-hypersync.md
+++ b/blog/2026-04-30-what-is-hypersync.md
@@ -48,7 +48,7 @@ The numbers below are pulled from the [HyperSync overview](https://docs.envio.de
 | Scan Arbitrum for sparse log data | Hours to days | 2 seconds | ~2000x faster |
 | Fetch all Uniswap v3 `PoolCreated` events on Ethereum | Hours | Seconds | ~500x faster |
 
-HyperSync is also the data layer powering HyperIndex, the fastest blockchain indexer available. Sentio's independent Uniswap V2 Factory benchmark (May 2025) measured HyperIndex completing the test in 1 minute, 143x faster than The Graph and 15x faster than the nearest competitor (Subsquid).
+HyperSync is also the data layer powering HyperIndex, the fastest blockchain indexer available. Sentio's independent Uniswap V2 Factory benchmark (May 2025) measured HyperIndex completing the test in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor (Subsquid).
 
 In production, that translates into projects like the Polymarket reference indexer, which synced 4 billion events in 6 days and replaced 8 separate subgraphs with a single HyperIndex deployment powered by HyperSync.
 
@@ -226,7 +226,7 @@ HyperSync makes a class of applications practical that traditional RPC cannot re
 
 HyperSync is the data engine underneath a growing set of tools and applications.
 
-**HyperIndex** is Envio's full indexing framework. It uses HyperSync as its primary data source, then layers on schema management, event handlers, multichain support, automatic reorg handling, and a hosted GraphQL API. HyperIndex is the fastest blockchain indexer available, 143x faster than The Graph and 15x faster than Subsquid on the Sentio Uniswap V2 Factory benchmark (May 2025).
+**HyperIndex** is Envio's full indexing framework. It uses HyperSync as its primary data source, then layers on schema management, event handlers, multichain support, automatic reorg handling, and a hosted GraphQL API. HyperIndex is the fastest blockchain indexer available, 142x faster than The Graph and 15x faster than Subsquid on the Sentio Uniswap V2 Factory benchmark (May 2025).
 
 **[ChainDensity.xyz](https://chaindensity.xyz)** uses HyperSync to render transaction and event density across any address on any supported chain. It generates insights in seconds that would take hours over RPC.
 


### PR DESCRIPTION
## Summary

The What is HyperSync post was citing 1 minute as the Envio HyperIndex time for the Sentio Uniswap V2 Factory benchmark (May 2025). That figure is the LBTC case_2 time, not the Uniswap V2 Factory case time (case_6_template). The correct figure per the open-indexer-benchmark repo is 8 seconds.

The 143x multiplier has been corrected to 142x in both prose references to match the same underlying data. The "up to 2000x faster than RPC" lines are HyperSync vs RPC, a different benchmark, and remain untouched. Frontmatter, HyperSyncChainCount component, and all other content are also untouched.

## Test plan

- [x] Source grep confirms zero remaining instances of the old figures
- [x] Local build passes via `yarn build`
- [ ] Spot check the rendered intro section and the related products section on preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)