### PR TITLE
Align stale benchmark and chain-count numbers across older blogs

### DIFF
--- a/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
+++ b/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
@@ -86,7 +86,7 @@ networks:
           - event: Transfer
 ```
 
-HyperSync natively supports 70+ EVM chains, so most multichain setups get full speed across every network without any additional configuration.
+HyperSync natively supports <HyperSyncChainCount /> EVM chains, so most multichain setups get full speed across every network without any additional configuration.
 
 ## Challenge 4: Development and infrastructure overhead
 
@@ -135,7 +135,7 @@ A reorg occurs when the blockchain temporarily forks and resolves to a new canon
 
 ### Can one indexer handle multiple blockchains?
 
-Yes. HyperIndex supports multichain indexing from a single instance. You define all networks in one `config.yaml` file and query all indexed data through one GraphQL endpoint. HyperSync natively supports 70+ EVM chains.
+Yes. HyperIndex supports multichain indexing from a single instance. You define all networks in one `config.yaml` file and query all indexed data through one GraphQL endpoint. HyperSync natively supports <HyperSyncChainCount /> EVM chains.
 
 ### How do I debug a blockchain indexer that is returning incorrect data?
 

--- a/blog/2023-11-15-simplify-data-retrieval-multi-chain-dapps.md
+++ b/blog/2023-11-15-simplify-data-retrieval-multi-chain-dapps.md
@@ -121,7 +121,7 @@ Yes. A single handler function processes matching events from all networks in yo
 
 ### How many chains does Envio support?
 
-HyperSync natively supports 70+ EVM chains. Any supported chain can be added to your `config.yaml`. For chains not yet covered by HyperSync, you can fall back to an RPC endpoint without changing your handler code.
+HyperSync natively supports <HyperSyncChainCount /> EVM chains. Any supported chain can be added to your `config.yaml`. For chains not yet covered by HyperSync, you can fall back to an RPC endpoint without changing your handler code.
 
 ### Where can I see a full multichain indexing example?
 

--- a/blog/2025-06-12-how-to-index-monad-data-using-envio.md
+++ b/blog/2025-06-12-how-to-index-monad-data-using-envio.md
@@ -15,7 +15,7 @@ authors: ["j_o_r_d_y_s"]
 
 :::note TL;DR
 - Monad is a high-performance EVM Layer 1 with 1-second block times, parallel execution, and 10,000+ TPS, purpose-built for data-rich decentralized applications.
-- Envio supports Monad with HyperIndex (full GraphQL indexing), HyperSync (up to 10,000x faster than RPC for historical data), and HyperRPC (drop-in RPC proxy backed by HyperSync).
+- Envio supports Monad with HyperIndex (full GraphQL indexing), HyperSync (up to 2000x faster than RPC for historical data), and HyperRPC (drop-in RPC proxy backed by HyperSync).
 - Compared to The Graph (EVM-only, separate subgraph per chain), Envio's single config covers Monad and all other supported chains through one GraphQL endpoint.
 :::
 
@@ -48,7 +48,7 @@ A full-featured blockchain indexing framework that transforms onchain events int
 
 ### HyperSync
 
-A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 10,000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
+A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 2000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
 
 [Learn more](https://docs.envio.dev/docs/HyperSync/overview)
 
@@ -95,7 +95,7 @@ Yes. Envio HyperSync and HyperIndex support both Monad mainnet and testnet. You 
 
 ### How fast is HyperSync on Monad compared to standard RPC?
 
-HyperSync can deliver up to 10,000x faster historical data retrieval than standard RPC on Monad by bypassing the JSON-RPC layer entirely. This means syncing millions of events that would take hours via RPC completes in minutes.
+HyperSync can deliver up to 2000x faster historical data retrieval than standard RPC on Monad by bypassing the JSON-RPC layer entirely. This means syncing millions of events that would take hours via RPC completes in minutes.
 
 ### Can I use Envio to index multiple chains including Monad in a single indexer?
 

--- a/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
+++ b/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
@@ -15,7 +15,7 @@ authors: ["j_o_r_d_y_s"]
 
 :::note TL;DR
 - MegaETH is a high-performance EVM chain with sub-millisecond block times and 100,000+ TPS, purpose-built for real-time applications that demand scale and speed.
-- Envio supports MegaETH with HyperIndex (full GraphQL indexing), HyperSync (up to 10,000x faster than RPC for historical data), and HyperRPC (standard RPC proxy backed by HyperSync).
+- Envio supports MegaETH with HyperIndex (full GraphQL indexing), HyperSync (up to 2000x faster than RPC for historical data), and HyperRPC (standard RPC proxy backed by HyperSync).
 - Oracle Wars, built in under two hours using Envio HyperIndex on MegaETH, demonstrates how quickly developers can build real-time monitoring tools on high-throughput chains.
 :::
 
@@ -49,7 +49,7 @@ A full-featured blockchain indexing framework that transforms onchain events int
 
 ### HyperSync
 
-A high-performance data retrieval layer that gives developers unprecedented access to data on MegaETH. It directly replaces traditional RPC endpoints for raw block data, delivering up to 10,000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
+A high-performance data retrieval layer that gives developers unprecedented access to data on MegaETH. It directly replaces traditional RPC endpoints for raw block data, delivering up to 2000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
 
 [Learn more](https://docs.envio.dev/docs/HyperSync/overview)
 
@@ -100,7 +100,7 @@ Yes. Envio HyperSync and HyperIndex support both MegaETH mainnet and testnet. Yo
 
 ### How fast is HyperSync on MegaETH compared to standard RPC?
 
-HyperSync can deliver up to 10,000x faster historical data retrieval than standard RPC on MegaETH by bypassing the JSON-RPC layer entirely. This means syncing large datasets that would take hours via RPC completes in minutes.
+HyperSync can deliver up to 2000x faster historical data retrieval than standard RPC on MegaETH by bypassing the JSON-RPC layer entirely. This means syncing large datasets that would take hours via RPC completes in minutes.
 
 ### Can I index MegaETH alongside other chains in a single Envio indexer?
 

--- a/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
+++ b/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
@@ -135,7 +135,7 @@ A full-featured blockchain indexing framework that transforms onchain events int
 
 ### HyperSync
 
-A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 10,000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
+A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 2000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
 
 [Learn more](https://docs.envio.dev/docs/HyperSync/overview)
 

--- a/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
+++ b/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
@@ -15,7 +15,7 @@ authors: ["j_o_r_d_y_s", "nikbhintade"]
 
 :::note TL;DR
 - Alchemy sunset Subgraph support on December 8th, 2025. Teams need a migration path that preserves their existing indexing logic and keeps data live without a full rebuild.
-- Envio's HyperIndex accepts your existing schema and mapping logic, adds 143x faster backfills via HyperSync ([Sentio Uniswap V2 Factory benchmark, May 2025](https://github.com/enviodev/open-indexer-benchmark)), and includes 2 months of free hosting for all Alchemy users.
+- Envio's HyperIndex accepts your existing schema and mapping logic, adds 142x faster backfills via HyperSync ([Sentio Uniswap V2 Factory benchmark, May 2025](https://github.com/enviodev/open-indexer-benchmark)), and includes 2 months of free hosting for all Alchemy users.
 - The migration takes four steps: generate a new HyperIndex project, bring over your schema, move your mapping logic, and use migration cursors to avoid replaying from block zero.
 :::
 
@@ -27,7 +27,7 @@ Envio gives you a clean and fast way to migrate your existing Alchemy Subgraphs 
 
 With Alchemy having sunset its Subgraph support, teams need to move quickly. You still rely on your data, you still need your indexers, and rebuilding the entire stack is not realistic in the given timeframe. With Envio, you get:
 
-- 143x faster backfills via HyperIndex
+- 142x faster backfills via HyperIndex
 - Multichain indexing supported out of the box
 - 2 months free hosting for all Alchemy users
 - White-glove migration support tailored for Alchemy Subgraphs
@@ -113,7 +113,7 @@ Queries will be very similar. HyperIndex uses a GraphQL API structure that is fa
 
 ### How does Envio compare to The Graph as an Alchemy Subgraph replacement?
 
-The Graph is the closest architectural equivalent to Alchemy Subgraphs, but it has the same limitations: separate subgraph per chain, slower historical sync, and no native multichain support. Envio delivers 143x faster backfills via HyperSync, supports multichain indexing from a single config, and includes an active team for migration support.
+The Graph is the closest architectural equivalent to Alchemy Subgraphs, but it has the same limitations: separate subgraph per chain, slower historical sync, and no native multichain support. Envio delivers 142x faster backfills via HyperSync, supports multichain indexing from a single config, and includes an active team for migration support.
 
 ### Is there a free tier on Envio Cloud for migrating teams?
 

--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -166,7 +166,7 @@ Agentic blockchain indexing is the process of using an AI agent to scaffold, con
 The envio-cloud CLI is the command-line interface for Envio Cloud, the managed infrastructure layer that runs HyperIndex indexers in production. It supports login, indexer registration, deployment monitoring, and promotion, all scriptable with JSON output via the `-o json` flag.
 
 ### How fast is Envio HyperIndex for historical sync?
-In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Factory sync in 1 minute, 143x faster than The Graph. In the agentic deployment demo, 400,000 wstETH events on Monad Mainnet were indexed in approximately 20 seconds.
+In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Factory sync in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor (Subsquid). In the agentic deployment demo, 400,000 wstETH events on Monad Mainnet were indexed in approximately 20 seconds.
 
 ### Which chains does Envio support for agentic indexing?
 Envio supports any EVM-compatible chain. HyperSync natively covers <HyperSyncChainCount /> EVM chains for maximum speed, including Ethereum, Base, Arbitrum, Optimism, Polygon, and Monad. Any EVM chain without native HyperSync support can be indexed via standard RPC.

--- a/blog/2026-05-06-revert-hyperindex-case-study.md
+++ b/blog/2026-05-06-revert-hyperindex-case-study.md
@@ -40,7 +40,7 @@ A subgraph stuck at 70% sync for over 2 years is effectively unusable.
 
 Envio HyperIndex is a real-time multichain blockchain indexing framework for any EVM chain. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts and chains simultaneously. It uses HyperSync, Envio's proprietary data engine, which serves filtered event data in bulk directly from a purpose-built data lake, replacing having to poll RPC endpoints block by block. This removes the RPC bottleneck entirely, which is precisely what causes subgraph stalls on BNB Smart Chain.
 
-HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory benchmark run by Sentio in May 2025, HyperIndex synced in 1 minute, 143x faster than The Graph and 15x faster than the nearest competitor. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
+HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory benchmark run by Sentio in May 2025, HyperIndex synced in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
 
 For a full benchmark breakdown see the [complete blockchain indexer comparison](https://docs.envio.dev/docs/HyperIndex/benchmarks).
 

--- a/blog/2026-05-21-migrate-from-ponder-to-envio.md
+++ b/blog/2026-05-21-migrate-from-ponder-to-envio.md
@@ -485,7 +485,7 @@ Yes. A single `config.yaml` declares all chains under a `chains:` array. Multich
 
 ### What is HyperSync?
 
-HyperSync is Envio's data engine. Instead of pulling historical data through standard RPC, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than RPC. 87+ EVM chains have native HyperSync coverage.
+HyperSync is Envio's data engine. Instead of pulling historical data through standard RPC, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than RPC. <HyperSyncChainCount /> EVM chains have native HyperSync coverage.
 
 ### How do I handle reorgs in HyperIndex?
 


### PR DESCRIPTION
## Summary

Aligns older blog posts with the canonical docs and recent benchmark fixes (#941, #942, #944) — Sentio Uniswap V2 Factory results, HyperSync RPC speed claim, and dynamic chain-count component.

## Test plan

- [ ] Skim each affected blog locally to confirm the corrected numbers read naturally in context
- [ ] Spot-check that `<HyperSyncChainCount />` renders correctly in the three `.md` files that now use it

🤖 Generated with [Claude Code](https://claude.com/claude-code)