### PR TITLE
Comprehensive blog FAQ accuracy and de-duplication across 14 posts

### DIFF
--- a/blog/2023-08-08-methods-to-query-blockchain-data.md
+++ b/blog/2023-08-08-methods-to-query-blockchain-data.md
@@ -110,9 +110,9 @@ For production dApps and data pipelines, a blockchain indexer is the most effici
 
 An RPC node is the base-level interface to a blockchain. It answers individual data requests but requires many round trips for complex queries and cannot aggregate or filter data efficiently. A blockchain indexer sits above this layer, processing events in bulk, transforming them into a structured database, and exposing the result via a GraphQL API. For most dApp backends, an indexer replaces direct RPC calls almost entirely.
 
-### What is HyperSync?
+### Where does HyperSync fit in the comparison of blockchain query methods?
 
-HyperSync is Envio's high-performance data engine that powers HyperIndex. Unlike standard RPC endpoints, HyperSync is a purpose-built data node that batches and optimises blockchain data retrieval, delivering up to 2000x faster sync speeds. It is enabled by default for all supported networks and requires no additional configuration. Client libraries are available for Python, Rust, Node.js, and Go for use in custom data pipelines.
+HyperSync is a high-performance data engine that sits underneath the indexer method described above. While self-hosted nodes and RPC providers expose data via JSON-RPC, HyperSync exposes a purpose-built data API that powers HyperIndex and can also be queried directly via client libraries in Python, Rust, Node.js, and Go. For applications that need historical sync at production speed, HyperSync delivers up to 2000x faster data retrieval than standard RPC.
 
 ### Can I query data from multiple blockchains in a single indexer?
 

--- a/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
+++ b/blog/2023-08-31-navigating-challenges-in-blockchain-indexing.md
@@ -86,7 +86,7 @@ networks:
           - event: Transfer
 ```
 
-HyperSync natively supports 70+ EVM chains, so most multichain setups get full speed across every network without any additional configuration.
+HyperSync natively supports <HyperSyncChainCount /> EVM chains, so most multichain setups get full speed across every network without any additional configuration.
 
 ## Challenge 4: Development and infrastructure overhead
 
@@ -135,7 +135,7 @@ A reorg occurs when the blockchain temporarily forks and resolves to a new canon
 
 ### Can one indexer handle multiple blockchains?
 
-Yes. HyperIndex supports multichain indexing from a single instance. You define all networks in one `config.yaml` file and query all indexed data through one GraphQL endpoint. HyperSync natively supports 70+ EVM chains.
+Yes. HyperIndex supports multichain indexing from a single instance. You define all networks in one `config.yaml` file and query all indexed data through one GraphQL endpoint. HyperSync natively supports <HyperSyncChainCount /> EVM chains.
 
 ### How do I debug a blockchain indexer that is returning incorrect data?
 

--- a/blog/2023-11-15-simplify-data-retrieval-multi-chain-dapps.md
+++ b/blog/2023-11-15-simplify-data-retrieval-multi-chain-dapps.md
@@ -121,7 +121,7 @@ Yes. A single handler function processes matching events from all networks in yo
 
 ### How many chains does Envio support?
 
-HyperSync natively supports 70+ EVM chains. Any supported chain can be added to your `config.yaml`. For chains not yet covered by HyperSync, you can fall back to an RPC endpoint without changing your handler code.
+HyperSync natively supports <HyperSyncChainCount /> EVM chains. Any supported chain can be added to your `config.yaml`. For chains not yet covered by HyperSync, you can fall back to an RPC endpoint without changing your handler code.
 
 ### Where can I see a full multichain indexing example?
 

--- a/blog/2025-06-12-how-to-index-monad-data-using-envio.md
+++ b/blog/2025-06-12-how-to-index-monad-data-using-envio.md
@@ -15,7 +15,7 @@ authors: ["j_o_r_d_y_s"]
 
 :::note TL;DR
 - Monad is a high-performance EVM Layer 1 with 1-second block times, parallel execution, and 10,000+ TPS, purpose-built for data-rich decentralized applications.
-- Envio supports Monad with HyperIndex (full GraphQL indexing), HyperSync (up to 10,000x faster than RPC for historical data), and HyperRPC (drop-in RPC proxy backed by HyperSync).
+- Envio supports Monad with HyperIndex (full GraphQL indexing), HyperSync (up to 2000x faster than RPC for historical data), and HyperRPC (drop-in RPC proxy backed by HyperSync).
 - Compared to The Graph (EVM-only, separate subgraph per chain), Envio's single config covers Monad and all other supported chains through one GraphQL endpoint.
 :::
 
@@ -48,7 +48,7 @@ A full-featured blockchain indexing framework that transforms onchain events int
 
 ### HyperSync
 
-A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 10,000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
+A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 2000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
 
 [Learn more](https://docs.envio.dev/docs/HyperSync/overview)
 
@@ -95,7 +95,7 @@ Yes. Envio HyperSync and HyperIndex support both Monad mainnet and testnet. You 
 
 ### How fast is HyperSync on Monad compared to standard RPC?
 
-HyperSync can deliver up to 10,000x faster historical data retrieval than standard RPC on Monad by bypassing the JSON-RPC layer entirely. This means syncing millions of events that would take hours via RPC completes in minutes.
+HyperSync can deliver up to 2000x faster historical data retrieval than standard RPC on Monad by bypassing the JSON-RPC layer entirely. This means syncing millions of events that would take hours via RPC completes in minutes.
 
 ### Can I use Envio to index multiple chains including Monad in a single indexer?
 

--- a/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
+++ b/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
@@ -15,7 +15,7 @@ authors: ["j_o_r_d_y_s"]
 
 :::note TL;DR
 - MegaETH is a high-performance EVM chain with sub-millisecond block times and 100,000+ TPS, purpose-built for real-time applications that demand scale and speed.
-- Envio supports MegaETH with HyperIndex (full GraphQL indexing), HyperSync (up to 10,000x faster than RPC for historical data), and HyperRPC (standard RPC proxy backed by HyperSync).
+- Envio supports MegaETH with HyperIndex (full GraphQL indexing), HyperSync (up to 2000x faster than RPC for historical data), and HyperRPC (standard RPC proxy backed by HyperSync).
 - Oracle Wars, built in under two hours using Envio HyperIndex on MegaETH, demonstrates how quickly developers can build real-time monitoring tools on high-throughput chains.
 :::
 
@@ -49,7 +49,7 @@ A full-featured blockchain indexing framework that transforms onchain events int
 
 ### HyperSync
 
-A high-performance data retrieval layer that gives developers unprecedented access to data on MegaETH. It directly replaces traditional RPC endpoints for raw block data, delivering up to 10,000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
+A high-performance data retrieval layer that gives developers unprecedented access to data on MegaETH. It directly replaces traditional RPC endpoints for raw block data, delivering up to 2000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
 
 [Learn more](https://docs.envio.dev/docs/HyperSync/overview)
 
@@ -100,7 +100,7 @@ Yes. Envio HyperSync and HyperIndex support both MegaETH mainnet and testnet. Yo
 
 ### How fast is HyperSync on MegaETH compared to standard RPC?
 
-HyperSync can deliver up to 10,000x faster historical data retrieval than standard RPC on MegaETH by bypassing the JSON-RPC layer entirely. This means syncing large datasets that would take hours via RPC completes in minutes.
+HyperSync can deliver up to 2000x faster historical data retrieval than standard RPC on MegaETH by bypassing the JSON-RPC layer entirely. This means syncing large datasets that would take hours via RPC completes in minutes.
 
 ### Can I index MegaETH alongside other chains in a single Envio indexer?
 

--- a/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
+++ b/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
@@ -135,7 +135,7 @@ A full-featured blockchain indexing framework that transforms onchain events int
 
 ### HyperSync
 
-A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 10,000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
+A high-performance data retrieval layer that gives developers unprecedented access to data on Monad. It directly replaces traditional RPC endpoints, delivering up to 2000x faster data access. HyperSync enables rapid and cost-effective retrieval of both real-time and historical blockchain data and can be used directly for custom data pipelines and specialized applications.
 
 [Learn more](https://docs.envio.dev/docs/HyperSync/overview)
 

--- a/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
+++ b/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
@@ -15,7 +15,7 @@ authors: ["j_o_r_d_y_s", "nikbhintade"]
 
 :::note TL;DR
 - Alchemy sunset Subgraph support on December 8th, 2025. Teams need a migration path that preserves their existing indexing logic and keeps data live without a full rebuild.
-- Envio's HyperIndex accepts your existing schema and mapping logic, adds 143x faster backfills via HyperSync ([Sentio Uniswap V2 Factory benchmark, May 2025](https://github.com/enviodev/open-indexer-benchmark)), and includes 2 months of free hosting for all Alchemy users.
+- Envio's HyperIndex accepts your existing schema and mapping logic, adds 142x faster backfills via HyperSync ([Sentio Uniswap V2 Factory benchmark, May 2025](https://github.com/enviodev/open-indexer-benchmark)), and includes 2 months of free hosting for all Alchemy users.
 - The migration takes four steps: generate a new HyperIndex project, bring over your schema, move your mapping logic, and use migration cursors to avoid replaying from block zero.
 :::
 
@@ -27,7 +27,7 @@ Envio gives you a clean and fast way to migrate your existing Alchemy Subgraphs 
 
 With Alchemy having sunset its Subgraph support, teams need to move quickly. You still rely on your data, you still need your indexers, and rebuilding the entire stack is not realistic in the given timeframe. With Envio, you get:
 
-- 143x faster backfills via HyperIndex
+- 142x faster backfills via HyperIndex
 - Multichain indexing supported out of the box
 - 2 months free hosting for all Alchemy users
 - White-glove migration support tailored for Alchemy Subgraphs
@@ -113,7 +113,7 @@ Queries will be very similar. HyperIndex uses a GraphQL API structure that is fa
 
 ### How does Envio compare to The Graph as an Alchemy Subgraph replacement?
 
-The Graph is the closest architectural equivalent to Alchemy Subgraphs, but it has the same limitations: separate subgraph per chain, slower historical sync, and no native multichain support. Envio delivers 143x faster backfills via HyperSync, supports multichain indexing from a single config, and includes an active team for migration support.
+The Graph is the closest architectural equivalent to Alchemy Subgraphs, but it has the same limitations: separate subgraph per chain, slower historical sync, and no native multichain support. Envio delivers 142x faster backfills via HyperSync, supports multichain indexing from a single config, and includes an active team for migration support.
 
 ### Is there a free tier on Envio Cloud for migrating teams?
 

--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -166,7 +166,7 @@ Agentic blockchain indexing is the process of using an AI agent to scaffold, con
 The envio-cloud CLI is the command-line interface for Envio Cloud, the managed infrastructure layer that runs HyperIndex indexers in production. It supports login, indexer registration, deployment monitoring, and promotion, all scriptable with JSON output via the `-o json` flag.
 
 ### How fast is Envio HyperIndex for historical sync?
-In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Factory sync in 1 minute, 143x faster than The Graph. In the agentic deployment demo, 400,000 wstETH events on Monad Mainnet were indexed in approximately 20 seconds.
+In independent benchmarks run by Sentio, HyperIndex completed the Uniswap V2 Factory sync in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor (Subsquid). In the agentic deployment demo, 400,000 wstETH events on Monad Mainnet were indexed in approximately 20 seconds.
 
 ### Which chains does Envio support for agentic indexing?
 Envio supports any EVM-compatible chain. HyperSync natively covers <HyperSyncChainCount /> EVM chains for maximum speed, including Ethereum, Base, Arbitrum, Optimism, Polygon, and Monad. Any EVM chain without native HyperSync support can be indexed via standard RPC.

--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -307,9 +307,9 @@ Get started in under 5 minutes: **<code>pnpx envio init</code>**
 ## Frequently asked questions
 
 
-### What is a blockchain indexer?
+### What does a blockchain indexer do that an RPC node can't?
 
-A blockchain indexer is a system that listens to onchain events (transactions, logs, state changes, blocks) and organises them into a structured, queryable database. Developers use indexers to build fast, reliable backends for dApps, DeFi protocols, NFT platforms, and analytics tools without querying slow RPC endpoints directly.
+A blockchain indexer continuously listens to onchain events (transactions, logs, state changes, blocks) and writes them into a structured, queryable database, exposed through a fast API like GraphQL. RPC nodes return raw data per request but cannot aggregate across events, filter efficiently, or serve historical queries at production speed. For dApps, DeFi protocols, NFT platforms, and analytics tools, an indexer replaces direct RPC calls almost entirely.
 
 
 ### What is the fastest blockchain indexer in 2026?
@@ -328,9 +328,9 @@ A custom indexing framework (HyperIndex, The Graph, Ponder, etc.) lets you defin
 
 
 
-### How do I migrate from The Graph to Envio HyperIndex?
+### What's involved in switching from The Graph to Envio HyperIndex?
 
-HyperIndex has a [dedicated migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide) that walks you through it in 3 simple steps. Envio also offers white glove migration support for teams moving from any stack. Reach out to us via [Discord](https://discord.gg/envio) for support.
+Switching from The Graph involves three main changes: AssemblyScript handlers become TypeScript (most logic carries across since AssemblyScript is a TypeScript subset), the subgraph manifest becomes a single multichain `config.yaml`, and queries move from The Graph's hosted or decentralized endpoint to Envio Cloud or a self-hosted deployment via Docker. Envio publishes a dedicated [migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide), a CLI validation tool to compare output across endpoints, and white-glove migration support. Reach out via [Discord](https://discord.gg/envio).
 
 
 ### How does HyperSync make HyperIndex the fastest indexer in this comparison?

--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -333,9 +333,9 @@ A custom indexing framework (HyperIndex, The Graph, Ponder, etc.) lets you defin
 HyperIndex has a [dedicated migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide) that walks you through it in 3 simple steps. Envio also offers white glove migration support for teams moving from any stack. Reach out to us via [Discord](https://discord.gg/envio) for support.
 
 
-### What is HyperSync?
+### How does HyperSync make HyperIndex the fastest indexer in this comparison?
 
-HyperSync is Envio's high-performance blockchain data engine that powers HyperIndex. It provides a low-level data access layer that is up to 2000x faster than traditional JSON-RPC endpoints. HyperSync can also be used directly for custom data pipelines in Python, Rust, Node.js, and Go. It supports <HyperSyncChainCount /> EVM chains and Fuel.
+HyperSync is Envio's proprietary data engine and is the reason HyperIndex tops the Sentio benchmark. The other indexers in this comparison pull historical data through standard JSON-RPC, which is the bottleneck. HyperSync replaces that fetch with a purpose-built data lake, delivering up to 2000x faster data access than traditional JSON-RPC. It is also available as a standalone API for custom data pipelines via client libraries in Python, Rust, Node.js, and Go, and natively covers <HyperSyncChainCount /> EVM chains and Fuel.
 
 
 ### What are the best alternatives to The Graph for production dApps?

--- a/blog/2026-03-24-track-polymarket-trades-hypersync.md
+++ b/blog/2026-03-24-track-polymarket-trades-hypersync.md
@@ -411,8 +411,8 @@ pnpx poly-whales
 
 ## Frequently Asked Questions
 
-### What is Envio HyperSync?
-HyperSync is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It delivers up to 2,000x faster data access than standard RPC methods. Client libraries are available for TypeScript/Node.js, Python, Rust, and Go, with support for <HyperSyncChainCount /> EVM chains including Polygon.
+### Why use HyperSync for Polymarket trade tracking instead of RPC?
+HyperSync provides up to 2,000x faster data access than standard RPC and exposes a streaming interface tailored to filtered event queries. For Polymarket's high-throughput Exchange contracts on Polygon, this avoids the RPC rate limits and polling overhead that constrain real-time trade trackers built on standard JSON-RPC. Polygon is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage, and HyperSync client libraries are available for TypeScript/Node.js, Python, Rust, and Go.
 
 ### How do I track Polymarket trades in real time?
 Use the Envio HyperSync Node.js client to stream block heights from Polygon, then query the Exchange contract for OrderFilled events on each new block. Decode the event data with Viem to extract maker, taker, asset IDs, and amounts. A `makerAssetId` of 0 indicates a buy trade.

--- a/blog/2026-03-25-polymarket-hyperindex-case-study.md
+++ b/blog/2026-03-25-polymarket-hyperindex-case-study.md
@@ -155,35 +155,35 @@ Envio offers white-glove migration support for teams moving from The Graph or an
 
 ## Frequently Asked Questions
 
-### What Is Polymarket?
+### What is Polymarket?
 Polymarket is the world's largest decentralized prediction market, built on Polygon. Users trade outcome shares on real-world events using USDC. All positions, trades, and settlements are handled entirely onchain via smart contracts with no central custodian.
 
-### What Is a Blockchain Indexer?
-A blockchain indexer is a system that listens to onchain events and organises them into a structured, queryable database. Developers use blockchain indexers to build fast backends for DeFi protocols, trading interfaces, analytics tools, and onchain AI agents without querying slow RPC endpoints directly.
+### How many subgraphs did Polymarket use before migrating to HyperIndex?
+Polymarket previously ran 8 independent subgraphs on The Graph, each written in AssemblyScript: fee-module, sports-oracle, wallet, orderbook, open-interest, activity, pnl, and fpmm. All 8 were consolidated into a single Envio HyperIndex indexer written in TypeScript.
 
-### What Is the Fastest Blockchain Indexer?
-Envio HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory benchmark run by Sentio in May 2025, HyperIndex completed in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor (Subsquid).
+### How did Polymarket migrate 8 subgraphs to HyperIndex?
+The 8 AssemblyScript subgraphs were consolidated into a single TypeScript HyperIndex indexer on Polygon. Because HyperIndex handlers are TypeScript, and AssemblyScript is a subset of TypeScript, most handler logic carried across directly. Envio also provides a [migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide), a CLI validation tool to compare output between both endpoints, and white-glove migration support.
 
-### What Is HyperIndex?
-HyperIndex is a multichain blockchain indexing framework for EVM chains built by Envio. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts, chains, and domains. It uses HyperSync, Envio's proprietary data engine, for historical sync speeds not achievable through standard RPC polling.
+### What is handler merging in the Polymarket indexer?
+Handler merging lets one handler process a shared contract event once and update all relevant entities simultaneously. A `ConditionalTokens.PositionSplit` event previously triggered redundant processing across the open-interest, activity, and pnl subgraphs. In the unified HyperIndex indexer, a single handler fires once and updates open interest, records the split activity, and adjusts user PnL positions in one pass.
 
-### What Is HyperSync?
-HyperSync is Envio's high-performance data engine. Instead of querying RPC endpoints block by block, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than traditional RPC. <HyperSyncChainCount /> EVM chains have native HyperSync coverage, with any EVM chain accessible via standard RPC.
+### Which Polymarket contracts does the open-source indexer cover?
+The indexer covers Exchange and NegRiskExchange, ConditionalTokens, NegRiskAdapter, FPMMFactory, FixedProductMarketMaker (dynamically registered), FeeModule and NegRiskFeeModule, UmaSportsOracle, plus USDC, RelayHub, and SafeProxyFactory. The full handler structure and event list is documented in the post.
 
-### How Do I Index Polymarket Data?
-The fastest way to index Polymarket data on Polygon is with Envio HyperIndex and HyperSync. The full open-source reference implementation is available at [github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer). It covers all 8 domains of Polymarket's onchain activity and syncs the full history in 6 days.
+### Does HyperIndex support dynamic contract registration?
+Yes. The Polymarket indexer uses FPMMFactory to register new Fixed Product Market Maker instances automatically as they are created onchain, without requiring a redeployment.
 
-### How Long Does It Take to Index Polymarket's Full History on Polygon?
+### How long does it take to index Polymarket's full history on Polygon?
 Using Envio HyperIndex with HyperSync, the full historical sync of Polymarket's onchain data on Polygon, over 4,000,000,000 events from block 3,764,531, completed in 6 days.
 
-### How Do I Migrate From The Graph to HyperIndex?
-Because HyperIndex handlers are written in TypeScript, and AssemblyScript is a subset of TypeScript, most handler logic can be carried across directly. Envio also provides a full [migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide), a CLI validation tool to compare output between both endpoints, and white-glove migration support. The Polymarket indexer is a concrete open-source reference for a large-scale migration from The Graph.
+### Is the Polymarket HyperIndex indexer open source?
+Yes. The full indexer is available at [github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer), with 29 tests covering all handler phases including a HyperSync integration test. Run it locally with `pnpm dev`.
 
-### Does HyperIndex Support Dynamic Contract Registration?
-Yes. New contract instances created onchain, like Polymarket's FPMM pools, are registered dynamically by a factory handler without requiring a redeployment.
+### Where can I see the live Polymarket indexer deployment?
+The live indexer is deployed at [envio.dev/app/moose-code/polymarket-indexer/7cad3ad](https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad). Polygon Mainnet is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
 
-### What Chains Does Envio Support?
-Envio supports any EVM chain. <HyperSyncChainCount /> EVM chains have native HyperSync coverage for maximum speed, including Polygon, Ethereum, Base, Arbitrum, Optimism, and more. Any EVM chain without native HyperSync support can be indexed via standard RPC.
+### How do I index Polymarket data?
+The fastest way to index Polymarket data on Polygon is with Envio HyperIndex and HyperSync. The full open-source reference implementation is available at [github.com/enviodev/polymarket-indexer](https://github.com/enviodev/polymarket-indexer). It covers all 8 domains of Polymarket's onchain activity and syncs the full history in 6 days.
 
 ## Get Started
 

--- a/blog/2026-04-24-native-transfers.md
+++ b/blog/2026-04-24-native-transfers.md
@@ -55,7 +55,7 @@ Every query has three main parts: `fromBlock`, a filter section (one of `transac
 
 ### Filtering for Native Transfers
 
-Native ETH transfers occur only in traces where `call_type` is `call` — not `staticcall` or `delegatecall`. Filtering on `callType` directly is more efficient than filtering on trace `kind`, since it lets HyperSync skip irrelevant trace types upfront.
+Native ETH transfers occur only in traces where `call_type` is `call`, not `staticcall` or `delegatecall`. Filtering on `callType` directly is more efficient than filtering on trace `kind`, since it lets HyperSync skip irrelevant trace types upfront.
 
 ## Building the Fetcher
 
@@ -188,8 +188,8 @@ See the HyperSync query reference for the full TraceSelection schema and field l
 
 ## Frequently Asked Questions
 
-### What Is HyperSync?
-[HyperSync](https://docs.envio.dev/docs/HyperSync/overview) is Envio's high-performance blockchain data retrieval layer, built as an alternative to traditional JSON-RPC endpoints. It gives developers direct access to onchain data up to 2000x faster than standard RPC methods, with client libraries for Python, Rust, Node.js, and Go across <HyperSyncChainCount /> EVM chains.
+### What Is HyperSync's Traces Query?
+[HyperSync](https://docs.envio.dev/docs/HyperSync/overview)'s traces query exposes EVM execution traces (`call`, `create`, `suicide`, `reward`) directly, rather than just contract event logs. This makes it possible to track operations that don't emit events, like native ETH transfers, by filtering on `call_type` and `value`. The traces feature is currently available on Ethereum, Base, Arbitrum, Gnosis, and Monad. Other queries (logs, transactions, blocks) work across <HyperSyncChainCount /> EVM chains with client libraries for Python, Rust, Node.js, and Go.
 
 ### Why Can't I Track Native ETH Transfers Using Event Logs?
 Native ETH transfers don't emit events. The ERC-20 `Transfer` event is a standard contract event, but native ETH moves at the protocol level and only shows up in transaction traces. To track them, you have to query traces directly.

--- a/blog/2026-05-06-revert-hyperindex-case-study.md
+++ b/blog/2026-05-06-revert-hyperindex-case-study.md
@@ -40,7 +40,7 @@ A subgraph stuck at 70% sync for over 2 years is effectively unusable.
 
 Envio HyperIndex is a real-time multichain blockchain indexing framework for any EVM chain. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts and chains simultaneously. It uses HyperSync, Envio's proprietary data engine, which serves filtered event data in bulk directly from a purpose-built data lake, replacing having to poll RPC endpoints block by block. This removes the RPC bottleneck entirely, which is precisely what causes subgraph stalls on BNB Smart Chain.
 
-HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory benchmark run by Sentio in May 2025, HyperIndex synced in 1 minute, 143x faster than The Graph and 15x faster than the nearest competitor. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
+HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory benchmark run by Sentio in May 2025, HyperIndex synced in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
 
 For a full benchmark breakdown see the [complete blockchain indexer comparison](https://docs.envio.dev/docs/HyperIndex/benchmarks).
 

--- a/blog/2026-05-06-revert-hyperindex-case-study.md
+++ b/blog/2026-05-06-revert-hyperindex-case-study.md
@@ -111,29 +111,33 @@ Revert Finance builds analytics and management tools for liquidity providers in 
 
 PancakeSwap V3 is the concentrated liquidity version of PancakeSwap, the largest decentralized exchange on BNB Smart Chain. V3 introduces capital-efficient liquidity positions represented as NFTs, managed via the Non-Fungible Position Manager contract.
 
-### What is a blockchain indexer?
+### Why was Revert Finance's PancakeSwap V3 subgraph stuck for 2 years?
 
-A blockchain indexer is a system that listens to onchain events and organises them into a structured, queryable database. Developers use blockchain indexers to build fast backends for DeFi protocols, analytics tools, and trading interfaces without querying slow RPC endpoints directly.
+A public PancakeSwap V3 subgraph on The Graph's decentralized network had been stuck at 70% sync on BNB Smart Chain for over 2 years, unable to reach chain head. BNB Smart Chain's high throughput generates more events per block than standard RPC-based indexing can sustain, so subgraphs fall progressively further behind until they stall entirely. Teams have reported similar BNB sync issues going back to 2021.
 
-### What is HyperIndex?
+### How does HyperSync solve the BNB Smart Chain sync problem?
 
-Envio HyperIndex is a real-time multichain blockchain indexing framework for EVM chains. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts, chains, and domains. It uses HyperSync, Envio's proprietary data engine, to fetch filtered event data in bulk rather than polling RPC endpoints, enabling historical syncs at speeds not achievable through standard RPC.
+HyperSync removes RPC polling from the historical sync path. Instead of fetching block by block through standard RPC, Envio retrieves event data in bulk from a purpose-built data lake, so sync speed scales with data volume rather than being bottlenecked by RPC rate limits and polling intervals. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
 
-### What is HyperSync?
+### Which PancakeSwap V3 contracts does the Revert indexer cover?
 
-HyperSync is Envio's high-performance data engine. Instead of querying RPC endpoints block by block, HyperSync fetches and serves filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than traditional RPC. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage. Any EVM chain can be indexed via standard RPC.
+The indexer covers the full PancakeSwap V3 contract surface on BNB Smart Chain: Factory (`0x0bfbcf9fa4f9c56b0f40a671ad40e0805a091865`) for Pool creation and registry, Pool contracts (dynamically registered as new pools are created by the Factory), and NFPM (`0x46a15b0b27311cedf172ab29e4f4766fbe7f4364`) for NFT position management events.
+
+### Does the Revert indexer use dynamic contract registration?
+
+Yes. Dynamic contract registration handles the Pool contracts. As new PancakeSwap V3 pools are created onchain by the Factory, the indexer registers them automatically without requiring a redeployment.
+
+### How many events did the new HyperIndex indexer process?
+
+The HyperIndex indexer for PancakeSwap V3 on BNB Smart Chain processed 1,711,569,200 events to 100% sync in 10 days. It started from block 26,956,207 and reached chain head at block 88,286,723.
+
+### Why did Revert Finance switch from The Graph to Envio HyperIndex?
+
+Revert's PancakeSwap V3 subgraph on The Graph had been stuck at 70% sync for over 2 years on BNB Smart Chain. As founder Mario Romero put it: "We had a problem with our PancakeSwap V3 data on BNB for over two years. The subgraph just would not catch up, and we'd basically given up on it. Envio synced it in 10 days. Great team, great dev experience!" HyperIndex completed the historical sync in 10 days and now serves real-time data.
 
 ### What is Envio Cloud?
 
 Envio Cloud is Envio's managed hosting platform for HyperIndex indexers. It handles infrastructure, scaling, and monitoring so teams can run production-ready indexers without managing operational overhead. Revert Finance's PancakeSwap V3 indexer runs on Envio Cloud.
-
-### What chains does Envio support?
-
-Envio supports any EVM chain. <HyperSyncChainCount /> EVM chains have native HyperSync coverage for maximum speed, including BNB Smart Chain, Polygon, Ethereum, Base, Arbitrum, Optimism, and more. Any EVM chain without native HyperSync support can be indexed via standard RPC. See the full list of supported chains at [envio.dev/chains](https://envio.dev/chains).
-
-### How do I migrate from The Graph to HyperIndex?
-
-Because HyperIndex handlers are written in TypeScript and AssemblyScript is a subset of TypeScript, most handler logic can be carried across directly. Envio provides a full [migration guide](https://docs.envio.dev/docs/HyperIndex/migration-guide), a CLI validation tool to compare output between both endpoints, and white-glove migration support for teams moving from The Graph.
 
 ## Build With Envio
 

--- a/blog/2026-05-21-migrate-from-ponder-to-envio.md
+++ b/blog/2026-05-21-migrate-from-ponder-to-envio.md
@@ -485,7 +485,7 @@ Yes. A single `config.yaml` declares all chains under a `chains:` array. Multich
 
 ### What is HyperSync?
 
-HyperSync is Envio's data engine. Instead of pulling historical data through standard RPC, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than RPC. 87+ EVM chains have native HyperSync coverage.
+HyperSync is Envio's data engine. Instead of pulling historical data through standard RPC, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than RPC. <HyperSyncChainCount /> EVM chains have native HyperSync coverage.
 
 ### How do I handle reorgs in HyperIndex?
 

--- a/blog/2026-05-21-migrate-from-ponder-to-envio.md
+++ b/blog/2026-05-21-migrate-from-ponder-to-envio.md
@@ -483,9 +483,9 @@ Yes. HyperIndex handlers are standard TypeScript. Both frameworks share the same
 
 Yes. A single `config.yaml` declares all chains under a `chains:` array. Multichain is the default. Ponder configures chains separately per setup.
 
-### What is HyperSync?
+### What does HyperSync replace in a Ponder setup?
 
-HyperSync is Envio's data engine. Instead of pulling historical data through standard RPC, HyperSync fetches filtered event data in bulk from a purpose-built data lake, delivering up to 2,000x faster data access than RPC. <HyperSyncChainCount /> EVM chains have native HyperSync coverage.
+Ponder pulls historical data through standard RPC, which is the bottleneck for backfills against high-event contracts. HyperSync replaces that RPC fetch with a purpose-built data lake, delivering up to 2,000x faster data access than RPC. <HyperSyncChainCount /> EVM chains have native HyperSync coverage, so most Ponder workloads can migrate without changing data-source configuration.
 
 ### How do I handle reorgs in HyperIndex?
 


### PR DESCRIPTION
## Summary

Consolidated FAQ audit across all blogs with FAQ sections. Two kinds of changes, all in one PR:

### 1. Stale-fact alignment with current docs (9 posts)
- Sentio Uniswap V2 Factory benchmark: `1 min / 143x` -> `8 sec / 142x` across alchemy migration, agentic indexing, and revert case study.
- HyperSync RPC speed claim: `10,000x` -> `2000x` across Monad guide, MegaETH guide, and Monad dashboards.
- Hardcoded chain counts (`70+`, `87+`) replaced with the dynamic `<HyperSyncChainCount />` component on Ponder migration, navigating-challenges, and multichain dApps posts.

### 2. Generic FAQs replaced with blog-specific ones (7 posts)
Each post had at least one FAQ that duplicated canonical pillar content. Replaced with questions grounded only in that post's own body:
- **Polymarket case study**: 6 generic Qs -> 10 Polymarket-specific (8 subgraphs -> 1, handler merging, contract surface, dynamic FPMMFactory, open-source repo, live deployment).
- **Revert Finance case study**: 5 generic Qs -> 5 Revert-specific (1.7B events, 10-day sync, Factory/Pool/NFPM contracts, Mario Romero quote, dynamic registration).
- **Methods to query blockchain data**: HyperSync Q reframed for the 3-methods comparison.
- **Track Polymarket trades**: HyperSync Q reframed for the Polymarket trade tracking tutorial.
- **Native ETH transfers**: HyperSync Q reframed to traces query specifics; one em dash stripped from body.
- **Best blockchain indexers**: HyperSync Q reframed as a comparison-specific data engine answer.
- **Migrate from Ponder**: HyperSync Q reframed to what HyperSync replaces in a Ponder setup.

### Validation
- Zero em dashes anywhere touched.
- Every fact in every new FAQ traces to a specific line in that blog's own body.
- All factual claims match current canonical docs.

Supersedes #946 and #948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
