### PR TITLE
seo: permanent redirects for retired URLs to current equivalents

### DIFF
--- a/blog/2025-01-21-what-is-a-blockchain-indexer.md
+++ b/blog/2025-01-21-what-is-a-blockchain-indexer.md
@@ -19,7 +19,7 @@ authors: ["j_o_r_d_y_s"]
 - Compared to The Graph (separate subgraph per chain, slower historical sync) and Goldsky, Envio uses a single config for all chains and a single GraphQL endpoint.
 :::
 
-Blockchain data is stored sequentially and is difficult to query directly. Building decentralized apps often involves navigating raw, unstructured blockchain data, which is complex and time-consuming. Blockchain indexers solve this by transforming scattered onchain data into streamlined, structured databases that power fast, efficient apps. This post covers how blockchain indexers work, why they matter, and what to look for when choosing one.
+Blockchain data is stored sequentially and is difficult to query directly. Building decentralized apps often involves navigating raw, unstructured blockchain data, which is complex and time-consuming. A blockchain indexer for dApp development solves this by transforming scattered onchain data into streamlined, structured databases that power fast, efficient apps and give Web3 developers a reliable data retrieval layer. This post covers how blockchain indexers work, why they matter, and what to look for when choosing one.
 
 ## What is a blockchain indexer?
 
@@ -29,7 +29,7 @@ By defining data types and relationships based on your smart contracts, blockcha
 
 Indexers also handle both real-time data retrieval and historical data access. What usually takes days or weeks with traditional methods can be completed in seconds.
 
-## Why are blockchain indexers important?
+## Why dApp developers need a blockchain indexer
 
 ### 1. Simplified data access
 

--- a/vercel.json
+++ b/vercel.json
@@ -47,6 +47,96 @@
       "source": "/blog/what-is-a-blockchain-indexer-for-dapp-development.md",
       "destination": "/blog/what-is-a-blockchain-indexer.md",
       "permanent": true
+    },
+    {
+      "source": "/docs/HyperSync/overview-hyperrpc",
+      "destination": "/docs/HyperRPC/overview-hyperrpc",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperSync/overview-hyperrpc.md",
+      "destination": "/docs/HyperRPC/overview-hyperrpc.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperSync/hyperrpc-supported-networks",
+      "destination": "/docs/HyperRPC/hyperrpc-supported-networks",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperSync/hyperrpc-supported-networks.md",
+      "destination": "/docs/HyperRPC/hyperrpc-supported-networks.md",
+      "permanent": true
+    },
+    {
+      "source": "/blog/blog/:slug",
+      "destination": "/blog/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/v2/:slug",
+      "destination": "/docs/v2/HyperIndex/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/v1/:slug",
+      "destination": "/docs/v2/HyperIndex/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/blog/navigating-common-challenges-in-blockchain-indexing",
+      "destination": "/blog/common-challenges-in-blockchain-indexing",
+      "permanent": true
+    },
+    {
+      "source": "/blog/navigating-common-challenges-in-blockchain-indexing.md",
+      "destination": "/blog/common-challenges-in-blockchain-indexing.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/installation",
+      "destination": "/docs/HyperIndex/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/docs/installation.md",
+      "destination": "/docs/HyperIndex/quickstart.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/installation",
+      "destination": "/docs/HyperIndex/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/installation.md",
+      "destination": "/docs/HyperIndex/quickstart.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/privacy-policy",
+      "destination": "/docs/HyperIndex/privacy-policy",
+      "permanent": true
+    },
+    {
+      "source": "/docs/privacy-policy.md",
+      "destination": "/docs/HyperIndex/privacy-policy.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/terms-of-service",
+      "destination": "/docs/HyperIndex/terms-of-service",
+      "permanent": true
+    },
+    {
+      "source": "/docs/terms-of-service.md",
+      "destination": "/docs/HyperIndex/terms-of-service.md",
+      "permanent": true
+    },
+    {
+      "source": "/blog/page/:n",
+      "destination": "/blog",
+      "permanent": true
     }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,16 @@
       "source": "/blog/tags/:tag*",
       "destination": "/blog/tag/:tag*",
       "permanent": true
+    },
+    {
+      "source": "/blog/what-is-a-blockchain-indexer-for-dapp-development",
+      "destination": "/blog/what-is-a-blockchain-indexer",
+      "permanent": true
+    },
+    {
+      "source": "/blog/what-is-a-blockchain-indexer-for-dapp-development.md",
+      "destination": "/blog/what-is-a-blockchain-indexer.md",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

- Adds permanent (308) redirects in `vercel.json` for a batch of legacy paths that were returning 404, recovering link equity to the current equivalents.
- Covers both HTML and `.md` route variants.
- Uses pattern rules for long-tail buckets so the redirect block stays compact.

## Test plan
- [x] `vercel.json` valid JSON; `yarn build` passes
- [x] Path patterns validated locally with path-to-regexp
- [ ] Vercel preview returns 308 → 200 on a sample across each pattern bucket
- [ ] `.md` variants redirect cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the blockchain indexer blog post with an expanded introduction and clearer focus on developer requirements.

* **Chores**
  * Added URL redirects to maintain accessibility for legacy blog and documentation links pointing to updated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->