### PR TITLE
seo: noindex LLM doc bundles

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -314,6 +314,13 @@ const config = {
           trackingID: "G-J0WZ32ZV5B",
           anonymizeIP: true,
         },
+        sitemap: {
+          ignorePatterns: [
+            "/docs/HyperIndex-LLM/**",
+            "/docs/HyperSync-LLM/**",
+            "/docs/HyperRPC-LLM/**",
+          ],
+        },
       }),
     ],
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -59,6 +59,37 @@
         {
           "key": "Content-Type",
           "value": "text/plain; charset=utf-8"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    },
+    {
+      "source": "/docs/HyperIndex-LLM/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    },
+    {
+      "source": "/docs/HyperSync-LLM/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    },
+    {
+      "source": "/docs/HyperRPC-LLM/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Add `X-Robots-Tag: noindex` headers in `vercel.json` for `/docs/HyperIndex-LLM/*`, `/docs/HyperSync-LLM/*`, `/docs/HyperRPC-LLM/*`, and `/llms*.txt`.
- Exclude the same three route prefixes from the generated sitemap via `presets.classic.sitemap.ignorePatterns`.
- Pages keep returning 200 so LLM/MCP ingestion is unaffected.

## Test plan

- [x] `vercel.json` valid JSON
- [x] `yarn build` clean
- [x] Generated `build/sitemap.xml` contains no `*-LLM` URLs (425 URLs remain)
- [x] Built HTML still exists for all three bundle pages
- [ ] Vercel preview: `curl -I` returns 200 + `X-Robots-Tag: noindex` on all three HTML routes and on `/llms.txt`, `/llms-full.txt`
- [ ] Vercel preview sitemap: `curl -s .../sitemap.xml | grep -E 'HyperIndex-LLM|HyperSync-LLM|HyperRPC-LLM'` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)