### PR TITLE
docs: refresh HyperSync overview metadata and internal links

### DIFF
--- a/blog/2026-05-06-revert-hyperindex-case-study.md
+++ b/blog/2026-05-06-revert-hyperindex-case-study.md
@@ -38,7 +38,7 @@ A subgraph stuck at 70% sync for over 2 years is effectively unusable.
 
 ## The Solution: Envio HyperIndex on BNB Smart Chain
 
-Envio HyperIndex is a real-time multichain blockchain indexing framework for any EVM chain. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts and chains simultaneously. It uses HyperSync, Envio's proprietary data engine, which serves filtered event data in bulk directly from a purpose-built data lake, replacing having to poll RPC endpoints block by block. This removes the RPC bottleneck entirely, which is precisely what causes subgraph stalls on BNB Smart Chain.
+Envio HyperIndex is a real-time multichain blockchain indexing framework for any EVM chain. Developers write event handlers in TypeScript and deploy a single indexer covering multiple contracts and chains simultaneously. It uses [HyperSync](/docs/HyperSync/overview), Envio's proprietary data engine, which serves filtered event data in bulk directly from a purpose-built data lake, replacing having to poll RPC endpoints block by block. This removes the RPC bottleneck entirely, which is precisely what causes subgraph stalls on BNB Smart Chain.
 
 HyperIndex is independently benchmarked as the fastest blockchain indexer available. In the Uniswap V2 Factory benchmark run by Sentio in May 2025, HyperIndex synced in 1 minute, 143x faster than The Graph and 15x faster than the nearest competitor. BNB Smart Chain is one of <HyperSyncChainCount /> EVM chains with native HyperSync coverage.
 

--- a/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
+++ b/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
@@ -215,7 +215,7 @@ For analysts: SQL warehouses are the right tool. For agents acting on the data: 
 
 ### Why do AI agents acting onchain need an indexer at all?
 
-Raw RPC has four problems for an agent: reorgs, no schema, low throughput, and per-chain quirks at multichain scale. An indexer addresses all four. HyperIndex addresses them at the framework level, with reorg-safe storage, structured GraphQL output, HyperSync throughput, and a single multichain config.
+Raw RPC has four problems for an agent: reorgs, no schema, low throughput, and per-chain quirks at multichain scale. An indexer addresses all four. HyperIndex addresses them at the framework level, with reorg-safe storage, structured GraphQL output, [HyperSync](/docs/HyperSync/overview) throughput, and a single multichain config.
 
 ### What is the Envio docs MCP server?
 

--- a/blog/2026-05-14-ai-onchain-app-hyperindex-claude.md
+++ b/blog/2026-05-14-ai-onchain-app-hyperindex-claude.md
@@ -370,7 +370,7 @@ Each layer is a piece you have full control over. None of them require black-box
 
 ### What does an AI-powered onchain app stack look like?
 
-The stack is: Claude Code (or another MCP-aware editor) as the development surface, a HyperIndex project with an auto-discovered `.claude/skills/` directory shipped by v3 rc, the HyperIndex runtime with HyperSync as the data engine, Postgres plus Hasura for GraphQL, and the application or agent on top. Every layer is real and shipping today.
+The stack is: Claude Code (or another MCP-aware editor) as the development surface, a HyperIndex project with an auto-discovered `.claude/skills/` directory shipped by v3 rc, the HyperIndex runtime with [HyperSync](/docs/HyperSync/overview) as the data engine, Postgres plus Hasura for GraphQL, and the application or agent on top. Every layer is real and shipping today.
 
 ### How do I deploy a HyperIndex indexer programmatically?
 

--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -4,6 +4,7 @@ title: "HyperIndex: Fast Multichain Blockchain Indexer"
 sidebar_label: Overview
 slug: /overview
 description: Explore HyperIndex, a blazing-fast multichain indexer for real-time blockchain data.
+image: /docs-assets/og/HyperIndex/overview.png
 ---
 
 <Head>
@@ -19,7 +20,7 @@ description: Explore HyperIndex, a blazing-fast multichain indexer for real-time
 
 **HyperIndex** is Envio's full-featured blockchain indexing framework that transforms on-chain events into structured, queryable databases with GraphQL APIs.
 
-**HyperSync** is the high-performance data engine that powers HyperIndex. It provides the raw blockchain data access layer, delivering up to 2000x faster performance than traditional RPC endpoints.
+[**HyperSync**](/docs/HyperSync/overview) is the high-performance data engine that powers HyperIndex. It provides the raw blockchain data access layer, delivering up to 2000x faster performance than traditional RPC endpoints.
 
 While HyperIndex gives you a complete indexing solution with schema management and event handling, HyperSync can be used directly for custom data pipelines and specialized applications.
 :::

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -1,9 +1,10 @@
 ---
 id: overview
-title: HyperSync
+title: "HyperSync: Ultra-Fast Blockchain Data API"
 sidebar_label: Overview
 slug: /overview
-description: Explore HyperSync for ultra-fast blockchain data access and flexible queries across 87+ networks.
+description: HyperSync is Envio's ultra-fast blockchain data API, a Rust-built alternative to RPC with flexible queries across dozens of EVM chains and Fuel.
+image: /docs-assets/og/HyperSync/overview.png
 ---
 
 # HyperSync: Ultra-Fast & Flexible Data API


### PR DESCRIPTION
## Summary

- Update HyperSync overview frontmatter `title` and `description` for clearer surfacing in search.
- Add four contextual internal links to `/docs/HyperSync/overview` from the HyperIndex overview and three blog posts that already mention HyperSync prominently in body prose.

No content rewrites; copy is taken verbatim from existing on-page wording.

## Test plan

- [x] `yarn build` clean
- [x] Rendered `<title>` confirmed on local build
- [ ] Verify rendered title and links on Vercel preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved navigation between blog posts and documentation by adding direct links to HyperSync overview across multiple articles.
  * Enhanced HyperSync documentation with an updated title and refined description for improved clarity.
  * Added Open Graph image metadata to HyperIndex overview documentation for better content sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->