### PR TITLE
docs: tighten internal links across HyperIndex, HyperSync, and HyperRPC

### DIFF
--- a/blog/2026-04-30-what-is-hypersync.md
+++ b/blog/2026-04-30-what-is-hypersync.md
@@ -215,7 +215,7 @@ For most use cases, the streaming client handles this automatically.
 
 HyperSync makes a class of applications practical that traditional RPC cannot reasonably support.
 
-- **Blockchain indexers** that build high-performance data pipelines with minimal infrastructure.
+- **[Blockchain indexers](/blog/what-is-a-blockchain-indexer)** that build high-performance data pipelines with minimal infrastructure.
 - **Data analytics** that runs complex onchain analysis in seconds instead of days.
 - **Block explorers** that serve responsive UIs with comprehensive historical access.
 - **Monitoring tools** that track blockchain activity with near real-time updates.
@@ -226,7 +226,7 @@ HyperSync makes a class of applications practical that traditional RPC cannot re
 
 HyperSync is the data engine underneath a growing set of tools and applications.
 
-**HyperIndex** is Envio's full indexing framework. It uses HyperSync as its primary data source, then layers on schema management, event handlers, multichain support, automatic reorg handling, and a hosted GraphQL API. HyperIndex is the fastest blockchain indexer available, 142x faster than The Graph and 15x faster than Subsquid on the Sentio Uniswap V2 Factory benchmark (May 2025).
+**[HyperIndex](/docs/HyperIndex/overview)** is Envio's full indexing framework. It uses HyperSync as its primary data source, then layers on schema management, event handlers, multichain support, automatic reorg handling, and a hosted GraphQL API. HyperIndex is the fastest blockchain indexer available, 142x faster than The Graph and 15x faster than Subsquid on the Sentio Uniswap V2 Factory benchmark (May 2025).
 
 **[ChainDensity.xyz](https://chaindensity.xyz)** uses HyperSync to render transaction and event density across any address on any supported chain. It generates insights in seconds that would take hours over RPC.
 
@@ -288,7 +288,7 @@ No. Trace filters are accessed via separate trace-enabled HyperSync endpoints, f
 
 ## Build With Envio
 
-Envio HyperIndex is independently benchmarked as the fastest EVM blockchain indexer available (Sentio benchmark, May 2025). If you are building onchain and need indexing that keeps up with your chain, check out the [docs](https://docs.envio.dev/docs/HyperIndex/overview), run the benchmarks yourself, or come talk to us about your data needs.
+Envio HyperIndex is independently benchmarked as the fastest EVM blockchain indexer available (Sentio benchmark, May 2025). If you are building onchain and need indexing that keeps up with your chain, check out the [HyperIndex documentation](/docs/HyperIndex/overview), run the benchmarks yourself, or come talk to us about your data needs.
 
 Stay tuned for more updates by subscribing to our newsletter, following us on X, or hopping into our Discord.
 

--- a/docs/HyperIndex/Advanced/multichain-indexing.mdx
+++ b/docs/HyperIndex/Advanced/multichain-indexing.mdx
@@ -4,9 +4,12 @@ title: Multichain Indexing
 sidebar_label: Multichain Indexing
 slug: /multichain-indexing
 description: Learn how to index and process events across multiple chains with HyperIndex.
+image: /docs-assets/og/HyperIndex/Advanced/multichain-indexing.png
 ---
 
 # Understanding Multichain Indexing
+
+For a conceptual overview of what multichain indexing is and when to use it, see [What is multichain indexing?](/blog/what-is-multi-chain-indexing). This page covers the HyperIndex configuration and patterns.
 
 Multichain indexing allows you to monitor and process events from contracts deployed across multiple blockchain networks within a single indexer instance. This capability is essential for applications that:
 

--- a/docs/HyperIndex/Advanced/multichain-indexing.mdx
+++ b/docs/HyperIndex/Advanced/multichain-indexing.mdx
@@ -4,7 +4,6 @@ title: Multichain Indexing
 sidebar_label: Multichain Indexing
 slug: /multichain-indexing
 description: Learn how to index and process events across multiple chains with HyperIndex.
-image: /docs-assets/og/HyperIndex/Advanced/multichain-indexing.png
 ---
 
 # Understanding Multichain Indexing

--- a/docs/HyperIndex/Guides/configuration-file.mdx
+++ b/docs/HyperIndex/Guides/configuration-file.mdx
@@ -4,6 +4,7 @@ title: Configuration File (config.yaml)
 sidebar_label: Configuration File (config.yaml)
 slug: /configuration-file
 description: Learn how to configure HyperIndex with contracts, events, networks, and advanced indexing options.
+image: /docs-assets/og/HyperIndex/Guides/configuration-file.png
 ---
 
 The `config.yaml` file defines your indexer's behavior, including which blockchain events to index, contract addresses, which chains to index, and various advanced indexing options. It is a crucial step in configuring your HyperIndex setup.
@@ -145,7 +146,7 @@ Try to use this option sparingly as it can cause redundant Data Source calls and
 
 ## Chains
 
-Everything under the top-level `chains` field configures the networks your indexer connects to — data sources, start/end blocks, reorg behavior, and multichain semantics.
+Everything under the top-level `chains` field configures the networks your indexer connects to — data sources, start/end blocks, reorg behavior, and [multichain indexing](/docs/HyperIndex/multichain-indexing) semantics.
 
 ### RPC
 

--- a/docs/HyperIndex/Guides/configuration-file.mdx
+++ b/docs/HyperIndex/Guides/configuration-file.mdx
@@ -4,7 +4,6 @@ title: Configuration File (config.yaml)
 sidebar_label: Configuration File (config.yaml)
 slug: /configuration-file
 description: Learn how to configure HyperIndex with contracts, events, networks, and advanced indexing options.
-image: /docs-assets/og/HyperIndex/Guides/configuration-file.png
 ---
 
 The `config.yaml` file defines your indexer's behavior, including which blockchain events to index, contract addresses, which chains to index, and various advanced indexing options. It is a crucial step in configuring your HyperIndex setup.

--- a/docs/HyperIndex/benchmarks.md
+++ b/docs/HyperIndex/benchmarks.md
@@ -4,6 +4,7 @@ title: HyperIndex Benchmarks
 sidebar_label: Benchmarks
 slug: /benchmarks
 description: Discover HyperIndex benchmarks and see why it's the fastest blockchain data indexer.
+image: /docs-assets/og/HyperIndex/benchmarks.png
 ---
 
 # HyperIndex Performance Benchmarks
@@ -28,6 +29,8 @@ The most comprehensive and up-to-date benchmarks were conducted by Sentio in Apr
 | Uniswap V2 Factory             | Event handling, Pair and swap analysis      | 8s     | 2m - 15x slower (Subsquid)  | 19m - 142x slower   | 21m - 157x slower    |
 
 The independent benchmark results demonstrate that HyperIndex consistently outperforms all competitors across every tested scenario. This includes the most realistic real-world indexing scenario LBTC Token with RPC calls - where HyperIndex was up to 6x faster than the nearest competitor and over 63x faster than The Graph.
+
+For a wider, benchmark-backed comparison across the rest of the category, see [Best Blockchain Indexers in 2026](/blog/best-blockchain-indexers-2026), which covers Envio, The Graph, Goldsky, SubQuery, Subsquid, Ormi, and Ponder side by side.
 
 ## Historical Benchmarking Results
 

--- a/docs/HyperIndex/benchmarks.md
+++ b/docs/HyperIndex/benchmarks.md
@@ -4,7 +4,6 @@ title: HyperIndex Benchmarks
 sidebar_label: Benchmarks
 slug: /benchmarks
 description: Discover HyperIndex benchmarks and see why it's the fastest blockchain data indexer.
-image: /docs-assets/og/HyperIndex/benchmarks.png
 ---
 
 # HyperIndex Performance Benchmarks

--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -4,6 +4,7 @@ title: Migrate from Alchemy to Envio
 sidebar_label: Migrate from Alchemy
 slug: /migrate-from-alchemy
 description: Easily migrate your existing Alchemy subgraphs to Envio for 143x faster indexing than subgraphs, multichain support, and a better developer experience.
+image: /docs-assets/og/HyperIndex/migrate-from-alchemy.png
 ---
 
 :::note
@@ -14,7 +15,7 @@ For more info on how you can start your free trial or book migration support, vi
 
 Migrating Alchemy subgraphs to Envio’s HyperIndex is a simple and developer-friendly process. Alchemy subgraphs follow The Graph’s model and HyperIndex uses a very similar structure, so most of your existing setup can carry over cleanly.
 
-If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our [Quickstart](/docs/HyperIndex/quickstart) guide before you begin your migration from Alchemy.
+If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our [Quickstart](/docs/HyperIndex/quickstart) guide before you begin your migration from Alchemy. If you are new to the category entirely, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.
 
 ## Why Migrate to Envio’s HyperIndex?
 - **High Speed Performance**: 143x faster than subgraphs

--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -4,7 +4,6 @@ title: Migrate from Alchemy to Envio
 sidebar_label: Migrate from Alchemy
 slug: /migrate-from-alchemy
 description: Easily migrate your existing Alchemy subgraphs to Envio for 143x faster indexing than subgraphs, multichain support, and a better developer experience.
-image: /docs-assets/og/HyperIndex/migrate-from-alchemy.png
 ---
 
 :::note

--- a/docs/HyperIndex/migrate-from-ponder.md
+++ b/docs/HyperIndex/migrate-from-ponder.md
@@ -4,7 +4,6 @@ title: Migrate from Ponder to Envio
 sidebar_label: Migrate from Ponder
 slug: /migrate-from-ponder
 description: Easily migrate your existing subgraph to HyperIndex for up to 100x faster indexing speeds, multichain support, and a better developer experience.
-image: /docs-assets/og/HyperIndex/migrate-from-ponder.png
 ---
 
 # Migrate from Ponder to HyperIndex

--- a/docs/HyperIndex/migrate-from-ponder.md
+++ b/docs/HyperIndex/migrate-from-ponder.md
@@ -4,6 +4,7 @@ title: Migrate from Ponder to Envio
 sidebar_label: Migrate from Ponder
 slug: /migrate-from-ponder
 description: Easily migrate your existing subgraph to HyperIndex for up to 100x faster indexing speeds, multichain support, and a better developer experience.
+image: /docs-assets/og/HyperIndex/migrate-from-ponder.png
 ---
 
 # Migrate from Ponder to HyperIndex
@@ -12,7 +13,7 @@ description: Easily migrate your existing subgraph to HyperIndex for up to 100x 
 
 Migrating from Ponder to HyperIndex is straightforward — both frameworks use TypeScript, index EVM events, and expose a GraphQL API. The key differences are the config format, schema syntax, and entity operation API.
 
-If you are new to HyperIndex, start with the [Quickstart](/docs/HyperIndex/quickstart) guide first.
+If you are new to HyperIndex, start with the [Quickstart](/docs/HyperIndex/quickstart) guide first. If you are new to the category entirely, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.
 
 :::tip Prefer AI-assisted migration?
 For an assistant-led workflow, see [How to Migrate Using AI](./migrate-with-ai), which includes a shared process for Cursor and Claude Code.
@@ -380,5 +381,5 @@ Use the [Indexer Migration Validator](https://github.com/enviodev/indexer-migrat
 ## Getting Help
 
 - **Discord**: [discord.gg/envio](https://discord.gg/envio) — fastest way to get help
-- **Docs**: [docs.envio.dev](/docs/HyperIndex/overview)
+- **Docs**: [the HyperIndex documentation](/docs/HyperIndex/overview)
 - **AI-friendly docs**: [HyperIndex complete reference](/docs/HyperIndex-LLM/hyperindex-complete)

--- a/docs/HyperIndex/migration-guide.md
+++ b/docs/HyperIndex/migration-guide.md
@@ -4,6 +4,7 @@ title: Migrate from The Graph to Envio
 sidebar_label: Migrate from The Graph
 slug: /migration-guide
 description: Easily migrate your existing subgraph to HyperIndex for up to 100x faster indexing speeds, multichain support, and a better developer experience.
+image: /docs-assets/og/HyperIndex/migration-guide.png
 ---
 
 # Migrate from The Graph to Envio
@@ -33,6 +34,8 @@ If you want an assistant-led workflow, see [How to Migrate Using AI](./migrate-w
 - **Better Developer Experience**: Simplified configuration and deployment
 - **Advanced Features**: Access to capabilities not available in other indexing solutions
 - **Seamless Integration**: Easy integration with existing GraphQL APIs and applications
+
+If you are still deciding, our [comparison of the best blockchain indexers in 2026](/blog/best-blockchain-indexers-2026) covers HyperIndex against The Graph, Goldsky, SubQuery, Subsquid, Ormi, and Ponder with side-by-side benchmarks.
 
 ## Subgraph to HyperIndex Migration Overview
 

--- a/docs/HyperIndex/migration-guide.md
+++ b/docs/HyperIndex/migration-guide.md
@@ -4,7 +4,6 @@ title: Migrate from The Graph to Envio
 sidebar_label: Migrate from The Graph
 slug: /migration-guide
 description: Easily migrate your existing subgraph to HyperIndex for up to 100x faster indexing speeds, multichain support, and a better developer experience.
-image: /docs-assets/og/HyperIndex/migration-guide.png
 ---
 
 # Migrate from The Graph to Envio

--- a/docs/HyperRPC/overview-hyperrpc.md
+++ b/docs/HyperRPC/overview-hyperrpc.md
@@ -4,7 +4,6 @@ title: Overview
 sidebar_label: Overview
 slug: /overview-hyperrpc
 description: Explore HyperRPC, fast read-only RPC for data-heavy blockchain queries and analytics.
-image: /docs-assets/og/HyperRPC/overview-hyperrpc.png
 ---
 
 # HyperRPC: Ultra-Fast Read-Only RPC

--- a/docs/HyperRPC/overview-hyperrpc.md
+++ b/docs/HyperRPC/overview-hyperrpc.md
@@ -4,6 +4,7 @@ title: Overview
 sidebar_label: Overview
 slug: /overview-hyperrpc
 description: Explore HyperRPC, fast read-only RPC for data-heavy blockchain queries and analytics.
+image: /docs-assets/og/HyperRPC/overview-hyperrpc.png
 ---
 
 # HyperRPC: Ultra-Fast Read-Only RPC
@@ -13,7 +14,7 @@ HyperRPC is an extremely fast read-only RPC designed specifically for data-inten
 :::info HyperSync vs. HyperRPC
 **For most use cases, we recommend using [HyperSync](/docs/HyperSync/overview) over HyperRPC.**
 
-HyperSync provides significantly faster performance and much greater flexibility in how you query and filter blockchain data. Behind the scenes, HyperRPC actually uses HyperSync to fulfill requests.
+HyperSync provides significantly faster performance and much greater flexibility in how you query and filter blockchain data. Behind the scenes, HyperRPC actually uses HyperSync to fulfill requests. If you want a full indexing framework with schema management, event handlers, and a hosted GraphQL API on top of HyperSync, see [HyperIndex](/docs/HyperIndex/overview).
 
 **When to use HyperRPC:**
 

--- a/docs/HyperSync/hypersync-clients.md
+++ b/docs/HyperSync/hypersync-clients.md
@@ -4,7 +4,6 @@ title: HyperSync Clients
 sidebar_label: Clients
 slug: /hypersync-clients
 description: Explore HyperSync clients for fast blockchain data access in Node.js, Python, Rust, and Go.
-image: /docs-assets/og/HyperSync/hypersync-clients.png
 ---
 
 # HyperSync Client Libraries

--- a/docs/HyperSync/hypersync-clients.md
+++ b/docs/HyperSync/hypersync-clients.md
@@ -4,6 +4,7 @@ title: HyperSync Clients
 sidebar_label: Clients
 slug: /hypersync-clients
 description: Explore HyperSync clients for fast blockchain data access in Node.js, Python, Rust, and Go.
+image: /docs-assets/og/HyperSync/hypersync-clients.png
 ---
 
 # HyperSync Client Libraries
@@ -167,6 +168,7 @@ Choose the client that best fits your use case:
 - [📝 Query Reference](./hypersync-query)
 - [🧪 cURL Examples](./hypersync-curl-examples)
 - [📊 Supported Networks](./hypersync-supported-networks)
+- [🧱 HyperIndex blockchain indexer](/docs/HyperIndex/overview), the full framework with schema, handlers, and a hosted GraphQL API, powered by HyperSync
 
 ## Support
 

--- a/docs/HyperSync/quickstart.md
+++ b/docs/HyperSync/quickstart.md
@@ -4,7 +4,6 @@ title: HyperSync Quickstart
 sidebar_label: Quickstart
 slug: /hypersync-quickstart
 description: Get started quickly with HyperSync to stream and filter blockchain events.
-image: /docs-assets/og/HyperSync/quickstart.png
 ---
 
 :::tip Easiest way to get started: the Query Builder

--- a/docs/HyperSync/quickstart.md
+++ b/docs/HyperSync/quickstart.md
@@ -4,6 +4,7 @@ title: HyperSync Quickstart
 sidebar_label: Quickstart
 slug: /hypersync-quickstart
 description: Get started quickly with HyperSync to stream and filter blockchain events.
+image: /docs-assets/og/HyperSync/quickstart.png
 ---
 
 :::tip Easiest way to get started: the Query Builder
@@ -14,7 +15,7 @@ The **[HyperSync Query Builder](https://builder.hypersync.xyz)** lets you constr
 
 :::
 
-Get up and running with HyperSync in minutes. This guide will help you start accessing blockchain data at unprecedented speeds with minimal setup.
+Get up and running with HyperSync in minutes. This guide will help you start accessing blockchain data at unprecedented speeds with minimal setup. For a conceptual overview before you dive in, see [What is HyperSync?](/blog/what-is-hypersync).
 
 ## Quickest Start: Try LogTUI
 


### PR DESCRIPTION
## Summary

Adds a small set of contextual internal links between the product overviews, the explainer blog posts, and the migration guides so readers can move between related pages more naturally. Twelve link additions plus one anchor-text upgrade on the Ponder migration guide.

## Files touched

- `docs/HyperIndex/Guides/configuration-file.mdx`
- `docs/HyperIndex/Advanced/multichain-indexing.mdx`
- `docs/HyperSync/hypersync-clients.md`
- `docs/HyperRPC/overview-hyperrpc.md`
- `blog/2026-04-30-what-is-hypersync.md`
- `docs/HyperIndex/migrate-from-ponder.md`
- `docs/HyperIndex/migrate-from-alchemy.md`
- `docs/HyperIndex/benchmarks.md`
- `docs/HyperIndex/migration-guide.md`
- `docs/HyperSync/quickstart.md`

## Test plan

- [x] `yarn build` passes locally with no broken-link errors
- [ ] Vercel preview renders the linked sections cleanly
- [ ] Spot-check that each new link resolves to the intended page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation pages with Open Graph images for improved social sharing
  * Added cross-links between related documentation sections for better navigation
  * Updated migration guides with additional resource references and quickstart pointers
  * Improved introductory content with contextual links to foundational concepts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->