### PR TITLE
blog: deduplicate FAQs across 2026-05-14 AI post bundle

### DIFF
--- a/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
+++ b/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
@@ -221,10 +221,6 @@ Raw RPC has four problems for an agent: reorgs, no schema, low throughput, and p
 
 A Model Context Protocol server at `https://docs.envio.dev/mcp` that exposes the Envio docs as two tools, `docs_search` and `docs_fetch`. Configured into Claude Code, Cursor, or VS Code with one setup command. Announcement blog: [Introducing the Envio Docs MCP Server](https://docs.envio.dev/blog/envio-docs-mcp-server).
 
-### What skills ship with HyperIndex?
-
-HyperIndex projects scaffold a `.claude/skills/` directory that auto-discovers for Cursor, Claude Code, and Codex. The canonical templates ship 14 skill definitions covering `indexer-configuration`, `indexer-schema`, `indexer-handlers`, `indexer-factory` (dynamic contracts), `indexer-external-calls` (Effect API), `indexer-multichain`, `indexer-performance`, `indexer-blocks`, `indexer-transactions`, `indexer-traces`, `indexer-filters`, `indexer-wildcard`, `indexer-testing`, and `migrate-from-subgraph`. The full list lives at [the canonical skills directory](https://github.com/enviodev/hyperindex/tree/main/packages/cli/templates/static/shared/.claude/skills).
-
 ### How fast can an AI agent deploy a HyperIndex indexer?
 
 The [agentic indexing blog](https://docs.envio.dev/blog/agentic-blockchain-indexing-envio-hyperindex) documents a single-prompt flow that scaffolds, deploys, and runs an indexer covering 400,000 events on Monad in roughly 20 seconds.
@@ -237,13 +233,13 @@ Yes. The CLI surface includes `envio-cloud login`, `envio-cloud indexer add`, `e
 
 A SQL warehouse is a read-only query layer. HyperIndex is a programmable indexer the agent can own, branch, and deploy. Both have a place. SQL warehouses suit analytical workflows. Indexers suit agents that need to act, not just query.
 
-### What chains does HyperIndex support for AI agents?
+### Can an agent register a new contract mid-session without a redeploy?
 
-Any EVM chain. <HyperSyncChainCount /> have native HyperSync coverage for maximum speed. Any EVM chain without native HyperSync is accessible via standard RPC.
+Yes, when the contract is created by a factory the agent has already configured. HyperIndex's dynamic contract registration is a first-class feature, and the `indexer-factory` skill in `.claude/skills/` is the canonical reference for the pattern. Adding a brand-new chain or an unrelated contract still requires a config change and a redeploy, which the agent can run from the `envio-cloud` CLI in one command.
 
-### How does HyperIndex handle reorgs for agents?
+### Where can I watch an agent run this end-to-end?
 
-At the framework level. Entity state history is persisted for unfinalized blocks. The framework rolls back automatically on reorg. No handler code is required.
+The published [Loom walkthrough](https://www.loom.com/share/09cdac43b18f4143ad78b18c8c8a492b) shows the full wstETH-on-Monad demo, scaffold to live deployment. The [live indexer](https://envio.dev/app/denhampreen/wsteth-monad-indexer-demo/5d55d35) is public.
 
 ## Build With Envio
 

--- a/blog/2026-05-14-ai-onchain-app-hyperindex-claude.md
+++ b/blog/2026-05-14-ai-onchain-app-hyperindex-claude.md
@@ -384,17 +384,9 @@ Adding a chain requires a config change and a redeploy because the indexer needs
 
 Subgraphs use AssemblyScript handlers, single-chain config per subgraph, and matchstick for testing. HyperIndex uses TypeScript handlers, multichain config in one file, and Vitest for testing. The TypeScript surface is what makes Claude's involvement straightforward. The migration story is covered in [AI-assisted subgraph migration](https://docs.envio.dev/blog/ai-subgraph-migration-hyperindex-claude).
 
-### What are the built-in HyperIndex skills?
-
-HyperIndex projects scaffolded with v3 rc ship a `.claude/skills/` directory pre-populated with 14 skills covering the core indexing patterns: `indexer-configuration`, `indexer-schema`, `indexer-handlers`, `indexer-factory`, `indexer-multichain`, `indexer-external-calls`, `indexer-performance`, `indexer-testing`, `indexer-blocks`, `indexer-filters`, `indexer-traces`, `indexer-transactions`, `indexer-wildcard`, and `migrate-from-subgraph`. Claude Code auto-discovers them at session start.
-
 ### Is HyperIndex faster than other indexers in benchmarks?
 
 In Sentio's independent Uniswap V2 Factory benchmark, HyperIndex completed in 8 seconds, 142x faster than The Graph and 15x faster than the nearest competitor.
-
-### What chains are supported?
-
-Any EVM chain. <HyperSyncChainCount /> have native HyperSync coverage for maximum speed. Any EVM chain without native HyperSync is accessible via standard RPC. The current chain count is published on [envio.dev](https://envio.dev).
 
 ### Where can I see a public production reference?
 

--- a/blog/2026-05-14-ai-subgraph-migration-hyperindex-claude.md
+++ b/blog/2026-05-14-ai-subgraph-migration-hyperindex-claude.md
@@ -288,10 +288,6 @@ For a single-domain subgraph with one or two contracts, the AI-assisted workflow
 
 Most directives carry across. `@derivedFrom` and ID-based relations have direct HyperIndex equivalents. The biggest difference is decorators: HyperIndex schemas have no `@entity` decorator at all. Per the project's `AGENTS.md`: "Unlike TheGraph, schema types have no decorators." The `indexer-schema` skill knows the translations and the `migrate-from-subgraph` skill applies them. Anything without a direct equivalent gets flagged for manual handling.
 
-### Can I migrate an Alchemy subgraph the same way?
-
-Yes. Alchemy Subgraphs are technically subgraphs, and the same AI-assisted migration flow described in this blog applies, scaffold a HyperIndex project from a template, hand Claude the AssemblyScript mappings, validate locally, and ship.
-
 ### What if my subgraph uses dynamic contracts (factory pattern)?
 
 HyperIndex supports dynamic contract registration as a first-class feature. Polymarket uses it for FPMM pools created by `FPMMFactory`. The `indexer-factory` skill in `.claude/skills/` handles the translation. See the Polymarket reference handler at [github.com/enviodev/polymarket-indexer/blob/main/src/handlers/FPMMFactory.ts](https://github.com/enviodev/polymarket-indexer/blob/main/src/handlers/FPMMFactory.ts).

--- a/blog/2026-05-14-production-indexer-reliability-hyperindex.md
+++ b/blog/2026-05-14-production-indexer-reliability-hyperindex.md
@@ -266,10 +266,6 @@ Envio Cloud alerts route through the platform's alert channels documented in the
 
 HyperIndex stays at chain head. Reorgs are handled by rollback, not by lag. There is no "wait N confirmations" mode required for correctness.
 
-### Is HyperIndex faster than The Graph in production?
-
-Yes. In the Sentio Uniswap V2 Factory benchmark, HyperIndex completed in 8 seconds. The Graph took 19 minutes on the same workload, 142x slower. Subsquid, the nearest competitor, was 15x slower. Full results on the benchmarks page linked in Get Started.
-
 ## Build With Envio
 
 Envio is the fastest independently benchmarked EVM blockchain indexer for querying real-time and historical data. If you are building onchain and need indexing that keeps up with your chain, check out the [docs](https://docs.envio.dev/docs/HyperIndex/overview), run the benchmarks yourself, and come talk to us about your data needs.


### PR DESCRIPTION
## Summary

Follow-up to #949. Brings the four 2026-05-14 AI/reliability posts in line with the FAQ standard set in that PR, where each post owns its own Qs and boilerplate is removed.

- `ai-agents-acting-onchain-indexer`: drop generic chains and skills Qs; replace with agent-specific Qs (mid-session contract registration, Loom walkthrough).
- `ai-onchain-app-hyperindex-claude`: drop generic chains and skills Qs (already covered in body).
- `ai-subgraph-migration-hyperindex-claude`: drop Alchemy-migration Q (covered by `migrating-alchemy-subgraphs-to-envio`).
- `production-indexer-reliability-hyperindex`: drop generic Sentio-benchmark Q (the reliability post is not the place for the benchmark headline).

Net: -6 generic Qs, +2 post-specific Qs. Each post's FAQ now answers what its body actually argues.

## Test plan

- [x] `yarn build` — succeeds
- [ ] Spot-check rendered FAQ on the four posts