### PR TITLE
seo: redirect Alchemy migration blog to docs migration guide

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -137,6 +137,16 @@
       "source": "/blog/page/:n",
       "destination": "/blog",
       "permanent": true
+    },
+    {
+      "source": "/blog/migrating-alchemy-subgraphs-to-envio",
+      "destination": "/docs/HyperIndex/migrate-from-alchemy",
+      "permanent": true
+    },
+    {
+      "source": "/blog/migrating-alchemy-subgraphs-to-envio.md",
+      "destination": "/docs/HyperIndex/migrate-from-alchemy.md",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

Redirects the orphaned Alchemy migration blog post to the docs migration guide that now owns this content. Blog post was written for the December 2025 Alchemy Subgraph sunset; the permanent home for this content is the docs migration guide, and marketing decided on 4 June 2026 to consolidate the blog into it. The blog URL currently returns 200 and is sitting in Search Console's "Crawled, currently not indexed" bucket, so we redirect rather than leave a duplicate-intent page up.

## Change

Two entries added to the `redirects` array in `vercel.json` (plain + .md variant, matching the existing pattern):

\`\`\`json
{
  "source": "/blog/migrating-alchemy-subgraphs-to-envio",
  "destination": "/docs/HyperIndex/migrate-from-alchemy",
  "permanent": true
},
{
  "source": "/blog/migrating-alchemy-subgraphs-to-envio.md",
  "destination": "/docs/HyperIndex/migrate-from-alchemy.md",
  "permanent": true
}
\`\`\`

The blog source file (`blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md`) is left in place for now — deletion can be a follow-up once the redirect is verified in production.

## Test plan

- [x] Confirmed blog URL currently returns 200 (not already redirecting)
- [x] Confirmed destination `/docs/HyperIndex/migrate-from-alchemy` returns 200
- [x] `vercel.json` parses as valid JSON
- [x] `yarn build` completes cleanly
- [ ] Verify on Vercel preview deployment that the source URL returns a 308 to the destination
- [ ] After merge, verify in production with a cache-busted URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permanent URL redirects to ensure seamless access to migrated documentation pages, maintaining continuity for users with bookmarked or shared links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->