### PR TITLE
seo: fix Moz crawl issues (meta-refresh stubs, descriptions, duplicate titles)

### DIFF
--- a/docs/HyperIndex/supported-networks/any-evm-with-rpc.md
+++ b/docs/HyperIndex/supported-networks/any-evm-with-rpc.md
@@ -3,6 +3,7 @@ id: any-evm-with-rpc
 title: Any EVM with RPC
 sidebar_label: 👉 Any EVM with RPC 👈
 slug: /any-evm-with-rpc
+description: Index any EVM-compatible chain with Envio HyperIndex by pointing at its RPC endpoint. Useful for networks without native HyperSync support.
 ---
 
 # Any EVM with RPC 🐌

--- a/docs/HyperIndex/supported-networks/index.md
+++ b/docs/HyperIndex/supported-networks/index.md
@@ -1,6 +1,6 @@
 ---
 id: index
-title: Supported Networks
+title: HyperIndex Supported Networks
 sidebar_label: Supported Networks
 slug: /supported-networks
 ---

--- a/docs/HyperIndex/supported-networks/local-anvil.md
+++ b/docs/HyperIndex/supported-networks/local-anvil.md
@@ -3,6 +3,7 @@ id: local-anvil
 title: Local network - Anvil
 sidebar_label: 👷 Local network - Anvil 👷
 slug: /local-anvil
+description: Index a local Anvil network (chain ID 31337) with Envio HyperIndex. Includes the config.yaml snippet for pointing at http://localhost:8545.
 ---
 
 # Local network - Anvil

--- a/docs/HyperIndex/supported-networks/local-hardhat.md
+++ b/docs/HyperIndex/supported-networks/local-hardhat.md
@@ -3,6 +3,7 @@ id: local-hardhat
 title: Local network - Hardhat
 sidebar_label: 👷 Local network - Hardhat 👷
 slug: /local-hardhat
+description: Index a local Hardhat network (chain ID 31337) with Envio HyperIndex. Includes the config.yaml snippet for pointing at http://localhost:8545.
 ---
 
 # Local network - Hardhat

--- a/docs/HyperRPC/hyperrpc-supported-networks.md
+++ b/docs/HyperRPC/hyperrpc-supported-networks.md
@@ -1,6 +1,6 @@
 ---
 id: hyperrpc-supported-networks
-title: Supported Networks
+title: HyperRPC Supported Networks
 sidebar_label: Supported Networks
 slug: /hyperrpc-supported-networks
 description: See all networks currently supported by HyperRPC, including their endpoints, network IDs, and trace support. Updated regularly as we add new chains.

--- a/docs/HyperSync/hypersync-supported-networks.md
+++ b/docs/HyperSync/hypersync-supported-networks.md
@@ -1,6 +1,6 @@
 ---
 id: hypersync-supported-networks
-title: Supported Networks
+title: HyperSync Supported Networks
 sidebar_label: Supported Networks
 slug: /hypersync-supported-networks
 description: See all networks currently supported by HyperSync, including reliability notes and the criteria we use when adding new chains.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,14 +24,6 @@ const redirectsList = [
     to: "/docs/HyperIndex/quickstart",
   },
   {
-    from: "/docs/HyperIndex/getting-started",
-    to: "/docs/HyperIndex/quickstart",
-  },
-  {
-    from: "/docs/HyperIndex/contract-import",
-    to: "/docs/HyperIndex/quickstart",
-  },
-  {
     from: "/docs/contract-import",
     to: "/docs/HyperIndex/quickstart",
   },
@@ -84,20 +76,12 @@ const redirectsList = [
     to: "/docs/HyperIndex/fuel",
   },
   {
-    from: "/docs/tutorial-op-bridge-deposits",
-    to: "/docs/HyperIndex/tutorial-op-bridge-deposits",
-  },
-  {
     from: "/docs/tutorial-erc20-token-transfers",
     to: "/docs/HyperIndex/tutorial-erc20-token-transfers",
   },
   {
     from: "/docs/tutorial-indexing-fuel",
     to: "/docs/HyperIndex/tutorial-indexing-fuel",
-  },
-  {
-    from: "/docs/greeter-tutorial",
-    to: "/docs/HyperIndex/greeter-tutorial",
   },
   {
     from: "/docs/linked-entity-loaders",
@@ -108,16 +92,8 @@ const redirectsList = [
     to: "/docs/HyperIndex/overview",
   },
   {
-    from: "/docs/dynamic-contracts",
-    to: "/docs/HyperIndex/dynamic-contracts",
-  },
-  {
     from: "/docs/multichain-indexing",
     to: "/docs/HyperIndex/multichain-indexing",
-  },
-  {
-    from: "/docs/hypersync/",
-    to: "/docs/HyperIndex/hypersync",
   },
   {
     from: "/docs/rpc-sync",
@@ -130,10 +106,6 @@ const redirectsList = [
   {
     from: "/docs/terminology",
     to: "/docs/HyperIndex/terminology",
-  },
-  {
-    from: "/docs/async-mode",
-    to: "/docs/HyperIndex/overview",
   },
   {
     from: "/docs/HyperIndex/async-mode",

--- a/vercel.json
+++ b/vercel.json
@@ -147,6 +147,76 @@
       "source": "/blog/migrating-alchemy-subgraphs-to-envio.md",
       "destination": "/docs/HyperIndex/migrate-from-alchemy.md",
       "permanent": true
+    },
+    {
+      "source": "/docs/hypersync",
+      "destination": "/docs/HyperIndex/hypersync",
+      "permanent": true
+    },
+    {
+      "source": "/docs/hypersync.md",
+      "destination": "/docs/HyperIndex/hypersync.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/getting-started",
+      "destination": "/docs/HyperIndex/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/getting-started.md",
+      "destination": "/docs/HyperIndex/quickstart.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/contract-import",
+      "destination": "/docs/HyperIndex/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/contract-import.md",
+      "destination": "/docs/HyperIndex/quickstart.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/greeter-tutorial",
+      "destination": "/docs/HyperIndex/greeter-tutorial",
+      "permanent": true
+    },
+    {
+      "source": "/docs/greeter-tutorial.md",
+      "destination": "/docs/HyperIndex/greeter-tutorial.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/dynamic-contracts",
+      "destination": "/docs/HyperIndex/dynamic-contracts",
+      "permanent": true
+    },
+    {
+      "source": "/docs/dynamic-contracts.md",
+      "destination": "/docs/HyperIndex/dynamic-contracts.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tutorial-op-bridge-deposits",
+      "destination": "/docs/HyperIndex/tutorial-op-bridge-deposits",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tutorial-op-bridge-deposits.md",
+      "destination": "/docs/HyperIndex/tutorial-op-bridge-deposits.md",
+      "permanent": true
+    },
+    {
+      "source": "/docs/async-mode",
+      "destination": "/docs/HyperIndex/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/async-mode.md",
+      "destination": "/docs/HyperIndex/overview.md",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

Fixes the 2 June 2026 Moz site crawl issues on docs.envio.dev. Scope is sections 1, 5 (3 of 4 pages), 6, and 7 of the punch list.

## What changed

| # | Issue | Fix |
|---|---|---|
| 1 | 7 meta-refresh stub pages (35 Moz issues = 7 × 5) | Moved to vercel.json as 301s (plain + .md variants), removed from Docusaurus client-redirects so stubs stop generating |
| 5 | 3 docs missing descriptions | Added 110-160 char descriptions to `local-hardhat`, `local-anvil`, `any-evm-with-rpc` |
| 6 | Duplicate "Supported Networks" title | Differentiated all three: HyperSync / HyperRPC / HyperIndex Supported Networks |

### Section 1 — redirect map

| Source | Destination |
|---|---|
| `/docs/hypersync` | `/docs/HyperIndex/hypersync` |
| `/docs/HyperIndex/getting-started` | `/docs/HyperIndex/quickstart` |
| `/docs/HyperIndex/contract-import` | `/docs/HyperIndex/quickstart` |
| `/docs/greeter-tutorial` | `/docs/HyperIndex/greeter-tutorial` |
| `/docs/dynamic-contracts` | `/docs/HyperIndex/dynamic-contracts` |
| `/docs/tutorial-op-bridge-deposits` | `/docs/HyperIndex/tutorial-op-bridge-deposits` |
| `/docs/async-mode` | `/docs/HyperIndex/overview` |

Each gets a `.md` companion to match the existing convention.

## No code change needed

- **Section 2 (v2 noindex)**: confirmed intentional — leave as is, mark "Ignore Issue Type" in Moz.
- **Section 7 (http → https 302)**: Vercel now serves a 308 Permanent. `curl -I http://docs.envio.dev` confirmed.

## Intentionally NOT changed

- **Section 4 (blog titles >60 chars)**: leaving the long descriptive titles as-is per Jordy.

## Deferred to follow-up PRs

- **Section 3 (network-page generator)**: needs registry walk, template draft, and 3 sample renders for sign-off before regenerating. Per the spec ("STOP for review before regenerating").
- **Section 5 — `/blog/tag/tutorial` description**: blog tag descriptions need a `blog/tags.yml` change on Docusaurus 3.4. Out of scope here so the doc-pages fix could ship clean.
- **Section 8 (long blog slugs)**: leaving published URLs alone (ranking risk > benefit). New posts to be ≤75 chars per the rule.

## Notes for reviewers

- `scripts/generate-og-images.js` re-injects `image:` frontmatter into ~620 source files on every build (matches the prior commit "drop OG image frontmatter accidentally included from a stashed branch"). Not in scope here — reverted those auto-injections before committing. Worth fixing the generator separately.

## Test plan

- [x] `yarn build` passes, no broken-link warnings
- [x] `vercel.json` parses; no duplicate sources, no source-equals-destination chains
- [x] All 3 doc descriptions 110-160 chars (verified: 141, 139, 139)
- [x] `curl -I http://docs.envio.dev` returns 308 Permanent today
- [ ] After deploy: `curl -I` each of the 7 stub URLs in section 1 — expect 301 with correct `Location`, no chain
- [ ] After deploy: mark Moz issues as "Fixed", mark v2 noindex as "Ignore Issue Type"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive content to supported networks documentation pages for enhanced clarity.
  * Renamed page titles to clearly distinguish between HyperIndex, HyperRPC, and HyperSync supported networks documentation.
  * Configured URL redirects to maintain backward compatibility and ensure legacy documentation links continue to work properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->