### PR TITLE
blog: descriptive alt text on images

### DIFF
--- a/blog/2023-10-24-indexer-benchmarking-results.md
+++ b/blog/2023-10-24-indexer-benchmarking-results.md
@@ -78,7 +78,7 @@ All implementations are publicly available for review and reproduction:
 
 ## Results
 
-<img src="/blog-assets/envio-univ3-benchmark-results.png" alt="Envio benchmark results chart" width="100%"/>
+<img src="/blog-assets/envio-univ3-benchmark-results.png" alt="Bar chart of events indexed per second: Envio v0.0.20 9,299, Subsquid 4,386, Envio v0.0.19 4,282, Ponder 115, theGraph 90, Substreams-powered Subgraph 59" width="100%"/>
 
 Total sync times in minutes, sorted fastest to slowest:
 

--- a/blog/2024-07-18-data-indexing-on-fuel.md
+++ b/blog/2024-07-18-data-indexing-on-fuel.md
@@ -9,7 +9,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/fuel-envio.png" alt="Cover Image Data Querying on Fuel" width="100%"/>
+<img src="/blog-assets/fuel-envio.png" alt="Envio cover banner reading 'Real-time Data Indexing on Fuel' with HyperFuel + HyperIndex and the Fuel logo" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2024-08-13-case-study-sablier.md
+++ b/blog/2024-08-13-case-study-sablier.md
@@ -56,14 +56,14 @@ One of the standout features of Envio's SDK that greatly benefited Sablier was i
 
 Envio's multichain capability provides developers with an efficient way to access fragmented data across multiple chains. Builders can specify their event handler to operate against a common schema. For Sablier, they could collect and transform data from various sources and aggregate it into a single PostgreSQL database. With all cross-chain data consolidated, Sablier could query this data via a unified GraphQL API instead of requesting the same data via multiple endpoints. This streamlined their operations, making it easier to manage and utilize data from multiple blockchain networks.
 
-<img src="/blog-assets/case-study-sablier-2.png" alt="GraphQL Playground for Query Building" width="100%"/>
+<img src="/blog-assets/case-study-sablier-2.png" alt="GraphQL playground showing a Stream query for sender, depositAmount, and chainId with JSON results from multiple chains" width="100%"/>
 
 When indexing multichain, Envio's SDK offers two options:
 
 1. **Default Mode:** This mode preserves ordering across chains and ensures that events from all chains are ingested and processed in sequence. It is essential if you need to maintain the order across chains and are handling the same data from multiple chains.
 2. **Unordered Head Mode:** This mode indexes each chain quickly without preserving order across chains. It is useful if you are indexing at the head and do not want the slow block time of one chain to hinder the optimistic processing of events on other chains.
 
-<img src="/blog-assets/case-study-sablier-3.png" alt="Multichain Indexing Sync Status Progress bars" width="100%"/>
+<img src="/blog-assets/case-study-sablier-3.png" alt="Envio dashboard listing per-chain sync progress for Ethereum, OP, BNB, Gnosis, Polygon, zkSync, Base, Arbitrum, Avalanche, Blast, Scroll, and Sepolia at 100%" width="100%"/>
 
 For more information on Envio's multichain indexing capabilities, view our dev docs [here](https://docs.envio.dev/docs/HyperIndex/multichain-indexing).
 

--- a/blog/2024-08-19-building-chaindensity.md
+++ b/blog/2024-08-19-building-chaindensity.md
@@ -118,7 +118,7 @@ The true prowess of HyperSync becomes evident when dealing with large-scale data
 
 This translates to an impressive processing rate of 7,761,296 blocks per second and 289,107 events per second. This level of performance is achievable "cold" (without caching) for any address across more than 70 different chains. Such speed and efficiency open up new possibilities for all kinds of applications previously impossible due to data retrieval limitations.
 
-<img src="/blog-assets/aave-v3-pool.png" alt="Aave v3: Pool" width="100%"/>
+<img src="/blog-assets/aave-v3-pool.png" alt="ChainDensity event density chart for Aave V3 Pool on Arbitrum with stats: 244,532,390 blocks, 9,108,786 events, 31.51 seconds elapsed" width="100%"/>
 
 ## Visualizing Blockchain Activity
 
@@ -130,7 +130,7 @@ ChainDensity's visualization capabilities bring blockchain data to life. The den
 
 Consider this interesting event density plot for the [Mutant Ape Yacht Club](https://opensea.io/collection/mutant-ape-yacht-club) collection. One can see a massive initial spike in activity (minting) before relatively little activity as users presumably held their NFTs. One can start to see a second spike in activity as users likely started to sell their NFTs. Today activity is minimal as the collection is less popular.
 
-<img src="/blog-assets/mutant-ape-yacht-club.png" alt="Mutant Ape Yacht Club" width="100%"/>
+<img src="/blog-assets/mutant-ape-yacht-club.png" alt="ChainDensity event density chart for the Mutant Ape Yacht Club collection showing a large initial mint spike followed by a smaller secondary spike" width="100%"/>
 
 ## Future Horizons for ChainDensity
 

--- a/blog/2024-09-27-case-study-limitless.md
+++ b/blog/2024-09-27-case-study-limitless.md
@@ -36,7 +36,7 @@ When the event's outcome is determined, the oracle sends the information to the 
 
 ## Overview of Prediction Markets
 
-<img src="/blog-assets/case-study-limitless-3.png" alt="Cover Image Limitless Prediction Markets Case Study" width="100%"/>
+<img src="/blog-assets/case-study-limitless-3.png" alt="Major Category Players chart grouping generalized prediction markets (Polymarket, Hedgehog, Drift, Doxa, Inertia, Euphoria, Omen, Limitless, Contro, Swaye) and sport-focused ones (Azuro, Monaco, SX Network, Overtime)" width="100%"/>
 
 Currently, Polymarket is the world's largest prediction market. Deployed on Polygon, Polymarket has experienced exponential growth, with elections accounting for 85% of its total volume. In July 2024, the platform generated an impressive $137.3 million in weekly trading volume. Data also suggests that non-election prediction markets have been increasing, such as betting on crypto prices, sports results, or social events.
 
@@ -88,7 +88,7 @@ Limitless Exchange is able to query information such as:
 <img src="/blog-assets/case-study-limitless-7.png" alt="Screenshot of app showing markets" width="100%"/>
 *Screenshot of https://limitless.exchange/ markets overview, powered by Envio.*
 
-<img src="/blog-assets/case-study-limitless-9.png" alt="Screenshot of app showing markets" width="100%"/>
+<img src="/blog-assets/case-study-limitless-9.png" alt="Limitless quick buy panel for the market 'Will BRETT be above $0.091 on Tuesday at 6:00am ET?' with Yes/No share pricing" width="100%"/>
 *A screenshot of https://limitless.exchange/ quick bets, powered by Envio.*
 
 The [Limitless Exchange Indexer](https://envio.dev/app/limitless-labs-group/fork-prod) and other indexers can be viewed in the Explorer of Envio Cloud.

--- a/blog/2024-10-02-envio-community-update-sep-2024.md
+++ b/blog/2024-10-02-envio-community-update-sep-2024.md
@@ -89,7 +89,7 @@ A big thank you to all the attendees, sponsors, and event organizers for making 
 
 - [How to Index Data on Fuel In Less Than 5 Minutes](https://www.youtube.com/watch?si=bBKbCvBPYiQzOfKs&v=IEgmHAW0S_A&feature=youtu.be)
 
-<img src="/blog-assets/envio-developer-community-sep-2024-4.png" alt="Cover Image Encode Club Indexing On Fuel" width="100%"/>
+<img src="/blog-assets/envio-developer-community-sep-2024-4.png" alt="Fuel x Encode Club hackathon workshop flyer: How to Index Data on Fuel in Less Than 5 Mins Using Envio with Dmitry Zakharov" width="100%"/>
 
 - [How to Index Dat on Citrea in < 5mins](https://www.youtube.com/watch?v=rPPxS6ORaEc)
 
@@ -101,7 +101,7 @@ For more video tutorials visit our [YouTube](https://www.youtube.com/@envio_inde
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-developer-community-sep-2024-6.png" alt="Dev of the Month September" width="100%"/>
+<img src="/blog-assets/envio-developer-community-sep-2024-6.png" alt="Envio Featured Developer banner for Jordan Lesich with rocket illustration" width="100%"/>
 
 We're pleased to announce our featured developer and community member of the month, Jordan Lesich, a highly experienced builder in the DAO ecosystem. With nearly five years of expertise working on DAO platforms like [DAOhaus](https://daohaus.club/), [Nouns.build](https://nouns.build/), and [DAO Masons](https://www.daomasons.com/), Jord brings a full-stack skill set to the table, engaging in every stage of dApp development - from design and contracts to frontend, backend, and indexers. His dedication to refining the DAO landscape makes him a standout contributor to our community.
 

--- a/blog/2024-10-09-case-study-bridgg-op-superchain.md
+++ b/blog/2024-10-09-case-study-bridgg-op-superchain.md
@@ -28,7 +28,7 @@ Created by [OPLabs](https://www.oplabs.co/), the OP Superchain is a movement tha
 
 OPLabs has recognized that standards and tools will also need to be provided to enable app developers to move assets and messages between interoperable chains to achieve this mission. You can read more about this [here](https://blog.oplabs.co/solving-interoperability-for-the-superchain-and-beyond/).
 
-<img src="/blog-assets/case-study-bridgg-op-superchain-1.png" alt="OP Superchain Chains Explorer" width="100%"/>
+<img src="/blog-assets/case-study-bridgg-op-superchain-1.png" alt="OP Superchain leaderboard ranking Base, OP Mainnet, Mode, Fraxtal, Lisk and others by TVL, projects, and accounts" width="100%"/>
 
 The rise in the number of L2s has produced multiple co-existing chains, most of which solve for Ethereum scalability while balancing trade-offs around decentralization and security. In parallel, these networks have created and fostered diverse communities and ecosystems of applications that provide value and increase adoption.
 
@@ -57,7 +57,7 @@ HyperIndex has allowed Brid.gg to supercharge its data retrieval by using [Hyper
 
 The Brid.gg [Indexer](https://envio.dev/app/bridgg/bridgg-indexer) currently indexes its data across 12 chains with a collection of 11 million events across the chains.
 
-<img src="/blog-assets/case-study-bridgg-op-superchain-3.png" alt="Envio Explorer" width="100%"/>
+<img src="/blog-assets/case-study-bridgg-op-superchain-3.png" alt="Bridgg indexer dashboard showing 11,428,854 events processed across Ethereum, OP Mainnet, Base, Mode, Zora, Fraxtal, Lisk, Redstone and testnets, synced in about 2 hours" width="100%"/>
 
 ## How Envio Powers the OP Superchain
 

--- a/blog/2024-10-15-ethonline24-envio-hackathon-winners.md
+++ b/blog/2024-10-15-ethonline24-envio-hackathon-winners.md
@@ -21,7 +21,7 @@ authors: ["j_o_r_d_y_s"]
 
 By [Ifeanyi Ozanu](https://x.com/iphyman).
 
-<img src="/blog-assets/ethonline-hackathon-winners-1.png" alt="Cover Image Grail Market Project Spotlight" width="100%"/>
+<img src="/blog-assets/ethonline-hackathon-winners-1.png" alt="Grail Market BTC/USD prediction market dashboard showing settled, cancelled, and next round cards with higher/lower options" width="100%"/>
 
 ## Best Use of HyperSync: Know Your Co-Signers
 
@@ -29,7 +29,7 @@ By [Ifeanyi Ozanu](https://x.com/iphyman).
 
 By [Germán Martínez](https://x.com/germago).
 
-<img src="/blog-assets/ethonline-hackathon-winners-2.png" alt="Cover Image EthOnline Know Your Co-Singers Project Spotlight" width="100%"/>
+<img src="/blog-assets/ethonline-hackathon-winners-2.png" alt="Know Your Co-Signers landing page with input field prompting users to type a Safe address from Ethereum Mainnet" width="100%"/>
 
 ## Best Runner-Up for Use of HyperIndex & HyperSync: TornadoTrack
 
@@ -37,7 +37,7 @@ By [Germán Martínez](https://x.com/germago).
 
 By [Martin Lettry](https://x.com/MartinLettry)
 
-<img src="/blog-assets/ethonline-hackathon-winners-3.png" alt="Cover Image EthOnline 2024 TornadoTrack Project Spotlight" width="100%"/>
+<img src="/blog-assets/ethonline-hackathon-winners-3.png" alt="TornadoTrack dashboard showing latest deposits, withdrawals, deposit and withdrawal charts, and an ETH amount pie chart" width="100%"/>
 
 ## Most Creative App of Envio's Features: Hypertui
 
@@ -45,7 +45,7 @@ By [Martin Lettry](https://x.com/MartinLettry)
 
 By [Falco Rodenburg](https://x.com/anestha_).
 
-<img src="/blog-assets/ethonline-hackathon-winners-4.png" alt="Cover Image EthOnline 2024 Hypertui Project Spotlight" width="100%"/>
+<img src="/blog-assets/ethonline-hackathon-winners-4.png" alt="Hypertui terminal UI showing regular transfers, ERC20 transfers, and transaction details with onchain stats" width="100%"/>
 
 ## Best Overall Project: ZkDNS
 
@@ -53,7 +53,7 @@ By [Falco Rodenburg](https://x.com/anestha_).
 
 By [Dhananjay Pa](https://x.com/dhananj10181396).
 
-<img src="/blog-assets/ethonline-hackathon-winners-5.png" alt="Cover Image EthOnline 2024 ZkDNS Project Spotlight" width="100%"/>
+<img src="/blog-assets/ethonline-hackathon-winners-5.png" alt="ZkDNS 'Add ENS Record' form with fields for staking, ENS name, ETH address, and expiry date for vitalik.eth" width="100%"/>
 
 A massive thank you to the EthGlobal team for organizing yet another incredible hackathon! The competition was fierce, with so many outstanding entries. We're grateful for all the hackers who participated and can't wait to see what innovative projects will emerge in the future. Stay tuned for our next hackathon.
 

--- a/blog/2024-10-29-envio-community-update-oct-2024.md
+++ b/blog/2024-10-29-envio-community-update-oct-2024.md
@@ -86,7 +86,7 @@ Read the [full case study](https://docs.envio.dev/blog/case-study-bridgg-op-supe
 
 ## Encode Hackathon Winner: ModuleScan
 
-<img src="/blog-assets/envio-developer-community-oct-2024-4.png" alt="Encode Club Hackathon Winner Module Scan by Timur" width="100%"/>
+<img src="/blog-assets/envio-developer-community-oct-2024-4.png" alt="ModuleScan dashboard showing recent installations and uninstallations tables with chain ID, account, and module columns" width="100%"/>
 
 Congratulations to [ModuleScan](https://modulescan-ui.vercel.app/) for winning multiple prizes at the Encode hackathon! This innovative indexer tracks historical smart account module activity, showcasing:
 
@@ -110,7 +110,7 @@ Kudos to [Timur Badretdinov](https://x.com/DestinerX)!
 
 ## Highlights from Zebu Live & Encode London
 
-<img src="/blog-assets/envio-developer-community-oct-2024-5.png" alt="Zebu Live JonJon CoFounder Speaker Photo" width="100%"/>
+<img src="/blog-assets/envio-developer-community-oct-2024-5.png" alt="Speaker presenting onstage at Zebu Live in front of a sponsor backdrop with Fabric, Eden Block, Bionic, Cherry, Fidesium logos" width="100%"/>
 
 We had a fantastic time at [Zebu Live](https://www.zebulive.xyz/) and the [Encode London](https://www.encode.club/encodelondon-24/#Prizes) Hackathon & Conference! At both events, we hosted data indexing workshops where blockchain developers could explore faster, smarter ways to access their onchain data, demonstrating how alternative indexers like Envio can improve their data retrieval.
 
@@ -126,7 +126,7 @@ For more upcoming events and where to catch us - be sure to check out our upcomi
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-developer-community-oct-2024-6.png" alt="Developer of the Month" width="100%"/>
+<img src="/blog-assets/envio-developer-community-oct-2024-6.png" alt="Envio Featured Developer banner for Ankush Jha with a photo of him beside a coding workstation" width="100%"/>
 
 This month's featured developer and community member of the month is [Ankush Jha](https://www.noveleader.xyz/), a dedicated developer and crypto native with three years in the space. Known for his sharp research skills and innovative approach, Ankush has made significant contributions to our community as a developer and researcher.
 
@@ -142,7 +142,7 @@ For a full list of deployed indexers visit our [explorer](https://envio.dev/expl
 
 [Open Spotify](https://open.spotify.com/playlist/50pryGy4bfJfqAVKZAojNh?si=19a115a6742e4292)
 
-<img src="/blog-assets/envio-developer-community-oct-2024-7.png" alt="Developer of the Month" width="100%"/>
+<img src="/blog-assets/envio-developer-community-oct-2024-7.png" alt="Spotify public playlist cover for 'Relaxing African Music' by Buddha's Lounge" width="100%"/>
 
 ## Envio Freelancer Network
 

--- a/blog/2024-11-08-hosted-service-v2.md
+++ b/blog/2024-11-08-hosted-service-v2.md
@@ -9,7 +9,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/hosted-service-v2.png" alt="Envio Cloud Launch" width="100%"/>
+<img src="/blog-assets/hosted-service-v2.png" alt="Envio Cloud launch banner: Introducing Envio Cloud, 10x Faster Indexer Deployments" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2024-11-13-how-to-cut-aws-cloud-costs.md
+++ b/blog/2024-11-13-how-to-cut-aws-cloud-costs.md
@@ -9,7 +9,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/cut-aws-cloud-costs1.png" alt="Envio Cover Photo" width="100%"/>
+<img src="/blog-assets/cut-aws-cloud-costs1.png" alt="Envio cover banner reading Optimizing Indexers on AWS: How To Cut AWS Cloud Costs" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2024-11-26-indexing-and-reorgs.md
+++ b/blog/2024-11-26-indexing-and-reorgs.md
@@ -11,7 +11,7 @@ last_update:
 Author: [Denham Preen](https://x.com/DenhamPreen), Co-Founder at Envio
 
 
-<img src="/blog-assets/indexing-and-reorgs.png" alt="Envio Cover Photo" width="100%"/>
+<img src="/blog-assets/indexing-and-reorgs.png" alt="Diagram showing a chain reorg with canonical blocks 2 to 5 and orphaned blocks 3 and 4, with the indexer's event handlers writing entities to a DB and orphaned data marked in red" width="100%"/>
 
 <!--truncate-->
 
@@ -79,29 +79,29 @@ In order to understand reorgs, let's break down the fundamental concepts and bui
 
 A container that stores transactions.
 
-<img src="/blog-assets/indexing-and-reorgs-1.png" alt="Indexing & Reorgs" width="100%"/>
+<img src="/blog-assets/indexing-and-reorgs-1.png" alt="Sketch of Block 1 listing example transactions: transfer ETH, swap USDC to USDT on Uniswap, vote on Compound governance" width="100%"/>
 
 ### Chain
 
 A series of sequential blocks.
 
-<img src="/blog-assets/indexing-and-reorgs-2.png" alt="Indexing & Reorgs" width="100%"/>
+<img src="/blog-assets/indexing-and-reorgs-2.png" alt="Diagram of a chain as four sequential blocks linked by arrows from Block 1 to Block 4" width="100%"/>
 
 ### Miners
 
 Actors that try to submit the next valid block.
 
-<img src="/blog-assets/indexing-and-reorgs-3.png" alt="Indexing & Reorgs" width="100%"/>
+<img src="/blog-assets/indexing-and-reorgs-3.png" alt="Diagram of miners Alice, Bob, Charlie, and Den, with blocks 1 to 4 labelled as mined by Alice, Bob, Alice, and Charlie" width="100%"/>
 
 ### Chain fork
 
-<img src="/blog-assets/indexing-and-reorgs-4.png" alt="Indexing & Reorgs" width="100%"/>
+<img src="/blog-assets/indexing-and-reorgs-4.png" alt="Diagram of a chain fork after Block 1, splitting into two parallel branches of Block 2 and Block 3 mined by different miners" width="100%"/>
 
 A chain fork occurs when more than one miner submits a valid block at the same time, causing a split where two valid chains exist simultaneously.
 
 ### Orphaned chain and canonical chain
 
-<img src="/blog-assets/indexing-and-reorgs-5.png" alt="Indexing & Reorgs" width="100%"/>
+<img src="/blog-assets/indexing-and-reorgs-5.png" alt="Diagram showing an orphaned chain branch greyed out above the canonical chain that continues through Block 5" width="100%"/>
 
 When a chain forks, eventually one chain becomes accepted as the valid chain, known as the canonical chain. The forked chain that is not accepted becomes the orphaned chain. Orphaned blocks cease to exist, and transactions that occurred in those blocks cease to exist as well.
 

--- a/blog/2024-11-28-envio-community-update-november-2024.md
+++ b/blog/2024-11-28-envio-community-update-november-2024.md
@@ -62,7 +62,7 @@ If you love what we're building as much as we do and want to stay updated on our
 
 ## Our V2 Hosted Service is Here!
 
-<img src="/blog-assets/envio-developer-community-november-2024-1.png" alt="V2 Hosted Service" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-1.png" alt="Envio V2 Hosted Service banner with tagline Fast Is For Everyone" width="100%"/>
 
 Our V2 Hosted Service has arrived! It's a significant upgrade that brings you faster build times, enhanced features, and an overall smoother experience.
 
@@ -80,7 +80,7 @@ For more details, check out our [FAQs](https://envio-dev.notion.site/V2-Hosted-S
 
 ## Exciting De-Fi Integration with Swaylend
 
-<img src="/blog-assets/envio-developer-community-november-2024-2.png" alt="Envio Swaylend Integration" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-2.png" alt="Swaylend x Envio partnership announcement banner" width="100%"/>
 
 Envio's efficient indexing solution has been integrated with Swaylend, a lightning-fast & low-cost lending platform. We're pleased to integrate and power real-time insights for the smoothest crypto lending experience on the Fuel Network.
 
@@ -89,7 +89,7 @@ This integration elevates Swaylend's functionality by delivering efficient acces
 
 ## Lightning-Fast Data Retrieval Now Supported on Tangle & More!
 
-<img src="/blog-assets/envio-developer-community-november-2024-3.png" alt="HyperSync Supported Networks" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-3.png" alt="Tangle x Envio partnership banner with planets and rings background" width="100%"/>
 
 Build, deploy, and monetize decentralized services effortlessly with Tangle - your gateway to the next era of restaking cloud infrastructure. HyperSync enables applications and data analysts to retrieve data through standard RPC or unlock up to 1000x faster performance with its advanced capabilities. Together, this integration drives innovation, simplifies development, and delivers unmatched performance for users.
 
@@ -108,7 +108,7 @@ View all current HyperSync-supported networks in our [docs](https://docs.envio.d
 
 ## Optimizing AWS for Indexer Performance: Strategies to Lower Cloud Costs
 
-<img src="/blog-assets/envio-developer-community-november-2024-4.png" alt="AWS Cost Optimization" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-4.png" alt="Envio blog cover with headline How to Cut AWS Cloud Costs over a circuit board" width="100%"/>
 
 
 Reducing AWS costs doesn't have to come at the expense of performance. By optimizing your network and fine-tuning infrastructure, you can maintain smooth indexer operations while staying within budget.
@@ -118,7 +118,7 @@ Explore our tips for smarter, more efficient AWS spending in our latest [blog](h
 
 ## Dev Tutorial: Building Decentralized Applications on Fuel
 
-<img src="/blog-assets/envio-developer-community-november-2024-5.png" alt="Envio Fuel Tutorial" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-5.png" alt="Video tutorial screenshot showing the Introducing Fuel Ignition page with a presenter in the corner" width="100%"/>
 
 In our new Fuel tutorial, we guide you through the process of building and deploying a smart contract on a testnet, starting with the fundamentals of Fuel. We then dive into Fuel's internals and show you how to use Envio to set up a backend indexer, making your app production-ready.
 
@@ -127,7 +127,7 @@ This tutorial is perfect for devs looking to leverage Fuel and Envio to create s
 
 ## Highlights from DevCon & ZuThailand
 
-<img src="/blog-assets/envio-developer-community-november-2024-6.png" alt="Envio DevCon & ZuThailand" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-6.png" alt="Crowd of attendees gathered at the Data and Chill Cafe side event in Bangkok" width="100%"/>
 
 We had an incredible time at [Devcon](https://devcon.org/en/) 2024 in Bangkok! Envio had the pleasure of co-hosting the [Data & Chill Café](https://lu.ma/w84y3q08) side event, bringing together top builders from around the world spanning data, analytics, indexing, block explorers, and more.
 
@@ -145,7 +145,7 @@ To stay updated on our upcoming events and where to find us next, check out the 
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-developer-community-november-2024-7.png" alt="Envio Featured Developer" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-7.png" alt="Envio Featured Developer banner for Chris Koo with avatar over a glowing jar" width="100%"/>
 
 This month's featured developer and community member is Chris Koo, a talented developer and crypto enthusiast known for his contributions to the DeFi space. Chris created the [Salt Dex Indexer](https://v2.envio.dev/app/hashscape/salt-dex-indexer-prod), which indexes Uniswap V2 and V3 across all EVM chains, enabling users to easily access decentralized trading through [Salt](https://saltapp.xyz/) - an all-in-one trading service that connects over 30 chains and all major DEXs, allowing you to trade newly created tokens quickly and securely.
 
@@ -156,7 +156,7 @@ Explore the full list of deployed indexers in our [explorer](https://v2.envio.de
 
 ## Playlist of the Month
 
-<img src="/blog-assets/envio-developer-community-november-2024-8.png" alt="Envio Playlist" width="100%"/>
+<img src="/blog-assets/envio-developer-community-november-2024-8.png" alt="Spotify playlist cover titled 5 by Jordy Baby, 20 songs, 1 hr 26 min, with a duct-taped banana artwork" width="100%"/>
 
 
 [Open Spotify](https://open.spotify.com/playlist/0AWh4ltYv86dIgdw44tCip?si=b2f8de47dba14ca8)

--- a/blog/2024-12-09-tokenizing-real-world-assets.md
+++ b/blog/2024-12-09-tokenizing-real-world-assets.md
@@ -38,7 +38,7 @@ This process allows investors to buy, sell, and trade ownership stakes in real e
 
 At the heart of Blocksquare is [Oceanpoint](https://oceanpoint.fi/), a DeFi platform where users can stake real estate-backed tokens, earn rewards, and participate in a growing ecosystem of tokenized properties. Powered by the BST utility token, Oceanpoint makes property investment more accessible, transparent, and efficient.
 
-<img src="/blog-assets/tokenizing-rwa-1.png" alt="Oceanpoint" width="100%"/>
+<img src="/blog-assets/tokenizing-rwa-1.png" alt="Oceanpoint real estate marketplace listing tokenized properties in Ljubljana, Dubai, and Techpark with APY, valuation, and token holder counts" width="100%"/>
 
 *Screenshot of [Oceanpoint's Real Estate Marketplace](https://marketplace.oceanpoint.fi/oceanpoint/marketplace)*
 
@@ -61,7 +61,7 @@ By leveraging Envio's indexing infrastructure, Blocksquare benefits from real-ti
 
 Envio optimizes performance significantly, enabling the indexing of over 400,000 Ethereum Mainnet events in under 20 minutes, a task that previously took hours with The Graph. This gives web3 developers significantly faster access to onchain data, speeding up development and testing cycles and ensuring scalable data access as applications grow.
 
-<img src="/blog-assets/tokenizing-rwa-2.png" alt="Oceanpoint Marketplace" width="100%"/>
+<img src="/blog-assets/tokenizing-rwa-2.png" alt="Envio CLI terminal showing 400,564 events processed on Chain ID 1 synced to 100% in 16 minutes" width="100%"/>
 
 Envio's integration allows Blocksquare to power its DeFi platform and marketplace with a performant backend that stores important data points such as available liquidity and asset pools, token investment listings, APY calculations, token holders, transaction history, supply information, and any other data points of interest.
 

--- a/blog/2024-12-18-case-study-zkpass.md
+++ b/blog/2024-12-18-case-study-zkpass.md
@@ -11,7 +11,7 @@ authors: ["j_o_r_d_y_s"]
 ---
 
 
-<img src="/blog-assets/zkpass-casestudy.png" alt="Cover Image How ZKPs help User Privacy" width="100%"/>
+<img src="/blog-assets/zkpass-casestudy.png" alt="Envio case study cover: Redefining User Privacy with ZKPs, Case Study zkPass" width="100%"/>
 
 <!--truncate-->
 
@@ -69,9 +69,9 @@ At zkPass, user empowerment is at the forefront. Web3 users can manage their cre
 
 By offering a versatile solution for proving identity and qualifications, zkPass is leading the charge toward a more secure and privacy-centric future in digital identity management.
 
-<img src="/blog-assets/zkpass-casestudy-1.png" alt="Screenshot of zkPass App" width="100%"/>
+<img src="/blog-assets/zkpass-casestudy-1.png" alt="zkPass Portal Schema Market showing Uber-based ZKP attestations like Rider Account Owner and Trips greater than 1, 10, and 20" width="100%"/>
 
-<img src="/blog-assets/zkpass-casestudy-2.png" alt="Screenshot of zkPass App" width="100%"/>
+<img src="/blog-assets/zkpass-casestudy-2.png" alt="zkPass Portal home with Schema Market, Farming the Internet, and Transgate-JS-SDK product panels" width="100%"/>
 
 ## How Envio Powers zkPass's Privacy Solutions
 
@@ -97,7 +97,7 @@ Envio's multichain architecture consolidates data from multiple blockchains into
 Moreover, by using HyperSync as the data source for HyperIndex (instead of traditional RPC methods), the zkPass engineering team benefits from exceptionally fast indexing performance and reliable data access. This empowers the zkPass team to accelerate their development lifecycle, test product features more rapidly, and drive innovation at a faster pace.
 
 
-<img src="/blog-assets/zkpass-casestudy-4.png" alt="Indexer Hosted Service" width="100%"/>
+<img src="/blog-assets/zkpass-casestudy-4.png" alt="Envio hosted service dashboard showing zkPass indexer synced across OP Mainnet, BNB Smart Chain, X Layer, zkSync, Base, Arbitrum One, Linea, and Scroll" width="100%"/>
 
 ## Conclusion
 

--- a/blog/2024-12-24-envio-community-update-december.md
+++ b/blog/2024-12-24-envio-community-update-december.md
@@ -24,7 +24,7 @@ Happy holidays from all of us at Envio!
 
 ## HyperSync Milestone
 
-<img src="/blog-assets/envio-developer-community-december-2024-1.png" alt="HyperSync Milestone #2" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-1.png" alt="HyperSync milestone graphic showing 79,514,671,665 all time total requests" width="100%"/>
 
 With nearly 80 billion requests served, [HyperSync](https://docs.envio.dev/docs/HyperSync/overview) is rapidly becoming a top choice as a data source for faster data retrieval than standard RPC. Envio's indexer, HyperIndex, supports both RPC and HyperSync as sources for ingesting blockchain data.
 
@@ -62,7 +62,7 @@ If you love what we're building as much as we do and want to stay updated on our
 
 ## Exciting De-Fi Integration with Blocksquare
 
-<img src="/blog-assets/envio-developer-community-december-2024-2.png" alt="Blocksqaure Integration" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-2.png" alt="Blocksquare x Envio New Partnership Announcement banner with handshake illustration" width="100%"/>
 
 [Blocksquare](https://blocksquare.io/) has integrated Envio's advanced indexing technology! This integration boosts Blocksquare's RWA platform, providing faster, more efficient access to onchain data.
 
@@ -73,7 +73,7 @@ This collaboration powers [Oceanpoint](https://oceanpoint.fi/) and Blocksquare's
 
 ## Indexing & Reorgs
 
-<img src="/blog-assets/envio-developer-community-december-2024-3.png" alt="Indexing & Reorgs" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-3.png" alt="Diagram showing a canonical chain branching from an orphaned chain with event handlers writing entities to a database" width="100%"/>
 
 Check out our new article on the impact of chain reorgs on data consumption and aggregation and the challenges of navigating a multichain environment.
 
@@ -84,7 +84,7 @@ Explore the full [blog](https://docs.envio.dev/blog/indexing-and-reorgs).
 
 ## Tokenizing RWAs: How Blockchain is Redefining Real Estate Investment
 
-<img src="/blog-assets/envio-developer-community-december-2024-4.png" alt="Tokenizing RWAs" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-4.png" alt="Envio and Blocksquare Tokenizing RWAs Revolutionizing Real Estate banner" width="100%"/>
 
 What if you could own real estate without the high costs? Blocksquare's tokenized real-world assets (RWAs) are unlocking new investment opportunities. No barriers - just seamless, borderless access to property markets. Welcome to the future of real estate.
 
@@ -93,7 +93,7 @@ Read the [full case study](https://docs.envio.dev/blog/tokenizing-real-world-ass
 
 ## Dev Tutorial: Indexing Data on Rootstock
 
-<img src="/blog-assets/envio-developer-community-december-2024-5.png" alt="Indexing Data on Rootstock" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-5.png" alt="Rootstock Educate workshop banner powered by Encode Club" width="100%"/>
 
 Check out our latest Rootstock Educate workshop with Encode Club. Master smart contract indexing on [Rootstock](https://rootstock.io/) in under 5 minutes with live coding and hands-on examples. Learn how to identify key transactions using Envio's powerful blockchain indexing solution to handle millions of events in seconds.
 
@@ -102,7 +102,7 @@ For more developer tutorials check out our [YouTube](https://www.youtube.com/@en
 
 ## Can ZKPs Redefine User Privacy? How zkPass is Shaping the Future of Data Security
 
-<img src="/blog-assets/envio-developer-community-december-2024-6.png" alt="Redefining Privacy with ZKPs" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-6.png" alt="Envio and zkPass banner reading Redefining User Privacy with ZKPs" width="100%"/>
 
 Can zero-knowledge proofs (ZKPs) redefine user privacy? [zkPass](https://zkpass.org/) is revolutionizing privacy by verifying information without exposing sensitive data. With privacy breaches becoming all too common, the question isn't if your data is exposed, it's when. Can we protect personal information while still verifying key details?
 
@@ -111,7 +111,7 @@ Read the full [blog](https://docs.envio.dev/blog/zkpass-shaping-future-of-data-p
 
 ## Envio Powers BakoID's Handles with Efficient Data Indexing
 
-<img src="/blog-assets/envio-developer-community-december-2024-7.png" alt="Envio Powers Bako" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-7.png" alt="Bako logo and Envio logo with an X between them on a dark gradient background" width="100%"/>
 
 We're partnering with Bako, the native naming system for the Fuel ecosystem. Envio powers Bako with faster and more reliable data to power their users' handles.
 
@@ -122,7 +122,7 @@ Check it out at app.bako.id
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-developer-community-december-2024-8.png" alt="December Featured Dev" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-8.png" alt="Envio Featured Developer banner for Simon Kruse with portrait photo" width="100%"/>
 
 This month's Featured Community Member is [Simon Kruse](https://github.com/Simon0x), Head of Web3 Development at Blocksquare. Since 2017, Simon has been active in crypto, specializing in real estate tokenization and DeFi, focusing on borrowing and lending solutions.
 
@@ -135,7 +135,7 @@ Check out Blocksquare on [X](https://x.com/blocksquare_io) for updates and explo
 
 ## Playlist of the Month
 
-<img src="/blog-assets/envio-developer-community-december-2024-9.png" alt="December Playlist" width="100%"/>
+<img src="/blog-assets/envio-developer-community-december-2024-9.png" alt="Spotify Christmas Playlist 2024 cover under Holiday Vibes with 28,788 saves and 121 songs" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/7awVFZ11ewVYCk0KyMYCka?si=c198409b4f9d43c1)
 

--- a/blog/2025-01-21-what-is-a-blockchain-indexer.md
+++ b/blog/2025-01-21-what-is-a-blockchain-indexer.md
@@ -9,7 +9,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/blockchain-indexer.png" alt="future of blockchain indexing" width="100%"/>
+<img src="/blog-assets/blockchain-indexer.png" alt="Envio blog cover, What is a Blockchain Indexer? An Introduction" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2025-01-30-envio-developer-update-january.md
+++ b/blog/2025-01-30-envio-developer-update-january.md
@@ -24,7 +24,7 @@ Learn more about our latest release and new features to make your indexing exper
 Please note: The latest release is V2.12.1.
 
 
-<img src="/blog-assets/envio-developer-community-january-2025-1.png" alt="Version 2.12.0" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-1.png" alt="GitHub release card for HyperIndex v2.12.0 noting RPC source feature-parity with HyperSync" width="100%"/>
 
 
 
@@ -47,7 +47,7 @@ If you love what we're building as much as we do and want to stay updated on our
 
 ## Indexing Contract Events with Envio HyperSync
 
-<img src="/blog-assets/envio-developer-community-january-2025-2.png" alt="Indexing Conract Events" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-2.png" alt="Stylised illustration of a Rust crab connected to database servers, representing indexing contract events with HyperSync" width="100%"/>
 
 
 Intuition recently shared their experience using Envio HyperSync to index contract events efficiently with Rust. They highlighted how HyperSync's real-time data extraction, multichain support, and extreme speed - scanning 200M blocks in 10 seconds - enhanced their infrastructure.
@@ -79,7 +79,7 @@ Learn more in our latest [guide](https://docs.envio.dev/docs/HyperIndex/price-da
 
 ## Falcon Gun Integrates Envio to Streamline its Data Retrieval for Enhanced Trading
 
-<img src="/blog-assets/envio-developer-community-january-2025-3.png" alt="Falcon Gun Integrates Envio" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-3.png" alt="Integration announcement banner showing Falcon Gun and Envio logos side by side" width="100%"/>
 
 
 We're pleased to announce our integration with [Falcon Gun](https://falcongun.com/). Their lightning-fast trading bot terminal now leverages Envio's indexing solution to streamline data retrieval for faster, more reliable trades.
@@ -90,7 +90,7 @@ Learn more [here](https://x.com/FalconGunBot/status/1879860589704745030).
 ## What is a Blockchain Indexer?
 
 
-<img src="/blog-assets/envio-developer-community-january-2025-4.png" alt="What is an indexer" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-4.png" alt="Envio blog cover titled What is a blockchain indexer? An introduction to indexing, over a blue chain link image" width="100%"/>
 
 
 New to indexing or need a refresher? Check out our latest blog where we explain how blockchain indexers transform complex onchain data into easy-to-query, actionable insights. Learn how Envio's tools like HyperSync and multichain support make data retrieval faster and help you build decentralized apps more efficiently.
@@ -100,7 +100,7 @@ Read the full [blog](https://docs.envio.dev/blog/what-is-a-blockchain-indexer).
 
 ## Envio & ChainDensity: Featured Sponsors in Primo Data's Blockchain Tools Directory
 
-<img src="/blog-assets/envio-developer-community-january-2025-5.png" alt="Envio & ChainDensity Sponsor Primo Data" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-5.png" alt="Primo Data directory listing showing Envio and ChainDensity entries with supported chains, products, and descriptions" width="100%"/>
 
 
 Envio & [ChainDensity](https://chaindensity.xyz/) are proud to sponsor and be featured alongside 300+ leading tools in Primo Data's [directory](https://www.primodata.org/blockchain-data). Explore the most comprehensive blockchain data resources and discover cutting-edge companies and open-source projects building tools to query, analyze, and visualize blockchain data.
@@ -108,7 +108,7 @@ Envio & [ChainDensity](https://chaindensity.xyz/) are proud to sponsor and be fe
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-developer-community-january-2025-6.png" alt="Jan 2025 Dev of the month" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-6.png" alt="Envio Featured Developer banner for Luis Eduardo Boiko with his photo" width="100%"/>
 
 
 This month's featured developer and community member of the month is Luis Eduardo Boiko Ferreira!
@@ -125,7 +125,7 @@ Follow Luis on [X](https://x.com/lockpickingtux) for more updates and check them
 
 ## Playlist of the Month
 
-<img src="/blog-assets/envio-developer-community-january-2025-7.png" alt="Jan playlist of the month" width="100%"/>
+<img src="/blog-assets/envio-developer-community-january-2025-7.png" alt="Spotify public playlist by Jordy Baby with 19 songs and 1 hr 17 min runtime" width="100%"/>
 
 
 [Open Spotify](https://open.spotify.com/playlist/6RrIwtSy6PiKOmUHuPtBFc?si=194fb56ca8da4282)

--- a/blog/2025-02-27-envio-dev-update-feb.md
+++ b/blog/2025-02-27-envio-dev-update-feb.md
@@ -19,7 +19,7 @@ Welcome to the Envio monthly developer update. Here is what shipped in February 
 
 ## HyperSync Milestone
 
-<img src="/blog-assets/envio-dev-update-feb-2025-1.png" alt="HyperSync Milestone" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-1.png" alt="HyperSync stat showing 115,004,865,332 all time total requests" width="100%"/>
 
 
 Over 115 billion HyperSync requests served across multiple networks. It's becoming the go-to choice for faster data retrieval over standard RPC.
@@ -29,7 +29,7 @@ Huge thanks to all the devs building with Envio.
 
 ## HyperIndex Version 2.13.0 is now available
 
-<img src="/blog-assets/envio-dev-update-feb-2025-2.png" alt="Version 2.13.0" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-2.png" alt="GitHub release card for HyperIndex v2.13.0 noting ENVIO_PG_PUBLIC_SCHEMA support" width="100%"/>
 
 
 A major milestone for HyperIndex: the first pull request from an external contributor has been merged.
@@ -45,9 +45,9 @@ If you love what we're building as much as we do and want to stay updated on our
 
 ## V4: Get Real-time Analytics for Uniswap V4 Swaps Across Multiple Networks 
 
-<img src="/blog-assets/envio-dev-update-feb-2025-3.png" alt="V4" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-3.png" alt="V4 Uniswap dashboard showing total swaps and pool counts broken down by network" width="100%"/>
 
-<img src="/blog-assets/envio-dev-update-feb-2025-4.png" alt="V4 Hooks" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-4.png" alt="Uniswap v4 Leaderboard Hook Information tab listing lending hook projects like Tenor Finance, Solvent network, and Collar" width="100%"/>
 
 
 Check out [V4](https://uniswap-v4-analytics.vercel.app/) - powered by HyperIndex - a hub for Uniswap data and hooks that tracks top swaps, pools, and trends in real-time, all displayed in a unified dashboard.
@@ -57,7 +57,7 @@ In collaboration with [Silvio Busonero](https://x.com/SilvioBusonero) from [Boos
 
 ## Oracle Wars: Visualize Onchain Oracle Performance
 
-<img src="/blog-assets/envio-dev-update-feb-2025-5.png" alt="Oracle Wars" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-5.png" alt="Oracle Wars chart comparing ETH/USD price feeds from Redstone and Chainlink on Ethereum" width="100%"/>
 
 
 Introducing [Oracle Wars](https://www.oraclewars.xyz/) - powered by HyperIndex - a live feed showcasing onchain oracle data from multiple providers, including ETH/USD feeds from [RedStone](https://www.redstone.finance/) and [Chainlink](https://chain.link/). This tool helps developers gain insights into how oracles operate in real-world scenarios, especially during periods of market volatility.
@@ -67,7 +67,7 @@ By visualizing real-time updates, Oracle Wars empowers developers to make more i
 
 ## Exciting DeFi Integration With Haha Wallet
 
-<img src="/blog-assets/envio-dev-update-feb-2025-6.png" alt="Haha Wallet" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-6.png" alt="Tweet from Keone Hon thanking Envio with a Rohan Kuru reply showing the Haha Wallet indexed in-house at 10k TPS" width="100%"/>
 
 
 Envio's efficient indexing solution has been integrated with [Haha Wallet](https://www.haha.me/) - an innovative smart wallet delivering the best user experience on Monad.
@@ -79,7 +79,7 @@ See it in action on [X](https://x.com/0xtrojan_/status/1891503860713173456).
 
 ## EthDenver: Encode Club Modular DeFi Hackathon & Research Day
 
-<img src="/blog-assets/envio-dev-update-feb-2025-7.png" alt="Encode Hack" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-7.png" alt="Jonjon presenting at the Encode Club Modular DeFi Hackathon with the Envio Uniswap v4 indexer running on a screen behind him" width="100%"/>
 
 
 This month, our team attended [EthDenver](https://www.ethdenver.com/), where we hosted a developer workshop led by our Co-founder [Jonjon](https://x.com/jonjonclark), who built a Uniswap V4 dashboard from scratch in under 15 minutes. We also offered several bounties with a total prize pool of $5k for Encode Club's Modular DeFi Hackathon & Research Day.
@@ -89,7 +89,7 @@ A huge thank you to the [Encode](https://www.encode.club/) team for hosting us a
 
 ## EthDenver: Monad Evm/Accathon
 
-<img src="/blog-assets/envio-dev-update-feb-2025-8.png" alt="Monad Hack" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-8.png" alt="Monad evm/accathon ETH Denver event banner with the tagline Accelerate the EVM" width="100%"/>
 
 
 This month, we hosted the Envio Bounty Challenge during the first-ever Monad hackathon, the EVM/Accathon, inviting participants to create live analytics dashboards to track Monad's onchain activity using Envio's HyperIndex & HyperSync. The challenge featured a prize of $2,000 USD!
@@ -108,7 +108,7 @@ Check out the recorded version of the discussion below.
 
 ## Envio Supports Developers Building on Monad
 
-<img src="/blog-assets/envio-dev-update-feb-2025-9.png" alt="Monad Support" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-9.png" alt="Envio and Monad co-branded banner with both logos on a deep purple background" width="100%"/>
 
 
 Monad's testnet is live and a high-speed chain deserves a high-performance solution.
@@ -121,7 +121,7 @@ Learn more in our [thread](https://x.com/envio_indexer/status/189223005671957319
 
 ## Envio's Open Indexing Framework Supports Devs Building on Berachain
 
-<img src="/blog-assets/envio-dev-update-feb-2025-10.png" alt="Berachain Support" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-10.png" alt="Envio and Berachain co-branded banner with the Berachain bear mascot perched in a pine forest" width="100%"/>
 
 
 Envio's open indexing framework supports devs building on Berachain Mainnet with efficient access to real-time & historical data. Developers can utilize Envio's HyperSync to sync millions of events 1000x faster than RPC. Easy, fast, and fully customizable!
@@ -132,7 +132,7 @@ View all current HyperSync-supported networks in our [docs](https://docs.envio.d
 
 ## New Feature Alert: Search Bar Now Live
 
-<img src="/blog-assets/envio-dev-update-feb-2025-11.png" alt="Search Bar" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-11.png" alt="Envio Explorer with a new search bar above a grid of indexer cards showing block counts and deploy times" width="100%"/>
 
 
 The much-anticipated search bar is here, allowing you to easily navigate the 100+ indexers deployed on Envio. Stay tuned for upcoming features, and don't hesitate to share your feedback or suggestions in our Discord!
@@ -148,7 +148,7 @@ Test it out yourself in our [Explorer](https://envio.dev/explorer).
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-dev-update-feb-2025-12.png" alt="Search Bar" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-12.png" alt="Envio Featured Developer banner for Sergey Potekhin with his portrait beside the title" width="100%"/>
 
 
 This month's featured developer and community member is [Sergey Potekhin](https://www.linkedin.com/in/sergey-potekhin/)!
@@ -160,7 +160,7 @@ Follow Sergey on [GitHub](https://github.com/pavlovdog/) for updates on his late
 
 ## Playlist of the Month
 
-<img src="/blog-assets/envio-dev-update-feb-2025-13.png" alt="Feb Playlist 2025" width="100%"/>
+<img src="/blog-assets/envio-dev-update-feb-2025-13.png" alt="Spotify Feb 25 public playlist by Jordy Baby with 25 songs and 1 hr 38 min runtime" width="100%"/>
 
 
 [Open Spotify](https://open.spotify.com/playlist/0yOOvvkHFIDsi2VRHDIrH0?si=7ad749d44b464830)

--- a/blog/2025-03-26-envio-supports-70-networks.md
+++ b/blog/2025-03-26-envio-supports-70-networks.md
@@ -9,7 +9,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/envio-supports-70-networks.png" alt="Cover Image Envio Developer Community Update February 2025" width="100%"/>
+<img src="/blog-assets/envio-supports-70-networks.png" alt="Envio cover banner reading Powering 70+ Blockchains, HyperSync Support, surrounded by chain logos" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2025-03-31-envio-dev-update-march-2025.md
+++ b/blog/2025-03-31-envio-dev-update-march-2025.md
@@ -134,7 +134,7 @@ If you love what we're building as much as we do and want to stay updated on our
 ## Introducing LogTui: Scan Entire Chains for Logs in Seconds
 
 
-<img src="/blog-assets/envio-dev-update-march-2-2025.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-2-2025.png" alt="Terminal UI streaming Uniswap V3 events from Ethereum Mainnet via HyperSync, with scanning progress, stats, and an event distribution chart" width="100%"/>
 
 [LogTui](https://www.npmjs.com/package/logtui) is a free CLI tool that lets you scan entire chains for onchain events with a single command. It supports 70+ networks and comes with presets for major protocols like ERC-20, ERC-721, Aave, and Chainlink. Designed for speed, it can process millions of events in minutes, powered by HyperSync's efficient filtering to keep data transfer minimal.
 
@@ -145,7 +145,7 @@ For more details check out this [post](https://x.com/jonjonclark/status/19016043
 ## Exciting DeFi Integration V12
 
 
-<img src="/blog-assets/envio-dev-update-march-3-2025.png" alt="v12" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-3-2025.png" alt="V12 x Envio partnership banner with both logos on a dark background" width="100%"/>
 
 
 Envio's open-indexing framework has been integrated with V12 - an onchain order book that provides high-speed and precise trading.
@@ -156,7 +156,7 @@ With this integration, V12 can seamlessly track key trading metrics, including d
 ## Envio's Blockchain Indexing Framework Supports Developers Building on the XDC Network
 
 
-<img src="/blog-assets/envio-dev-update-march-4-2025.png" alt="xdc" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-4-2025.png" alt="Envio and XDC Network partnership banner with both logos over a blue particle background" width="100%"/>
 
 
 Envio's open indexing framework supports developers building on the [XDC Network](https://xdc.org/) - an EVM-compatible L1 for secure, scalable global trade with efficient and reliable access to real-time & historical data.
@@ -165,7 +165,7 @@ Envio's open indexing framework supports developers building on the [XDC Network
 ## Envio Powers a Growing Ecosystem on Monad
 
 
-<img src="/blog-assets/envio-dev-update-march-5-2025.png" alt="monad ecosystem" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-5-2025.png" alt="Envio and Monad partnership banner with both logos over a purple grid background" width="100%"/>
 
 
 Envio is fueling a thriving ecosystem on [Monad](https://www.monad.xyz/), empowering projects with real-time data retrieval and optimized UX as they prepare for mainnet. From [Kuru Exchange](https://www.kuru.io/markets?marketType=trending&timeInterval=5m) and [HaHa Wallet](https://www.haha.me/) to [Nadradar](https://nadradar.com/), [Nad.fun](https://testnet.nad.fun/), [Monorail](https://testnet-preview.monorail.xyz/), [Revoke Cash](https://revoke.cash/), and more - Envio is at the heart of the next wave of high-performance applications.
@@ -177,7 +177,7 @@ Check out this [thread](https://x.com/envio_indexer/status/1900493623784808598) 
 
 
 
-<img src="/blog-assets/envio-dev-update-march-6-2025.png" alt="Envio x Chiliz" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-6-2025.png" alt="Chiliz x Envio partnership banner with both logos over a purple space background" width="100%"/>
 
 
 Envio's open-indexing framework now supports developers building on [Chiliz](https://www.chiliz.com/), the leading sports-focused blockchain. With seamless access to real-time and historical data, devs can create high-performance applications that bring fan engagement, sports analytics, and Web3 experiences to the next level.
@@ -189,7 +189,7 @@ Envio's open-indexing framework now supports developers building on [Chiliz](htt
 ### Monad Tutorial
 
 
-<img src="/blog-assets/envio-dev-update-march-7-2025.png" alt="monad tutorial" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-7-2025.png" alt="Telegram message showing a wMonad whale alert for a 20000 wMonad transfer, with a Monad Explorer link preview" width="100%"/>
 
 
 Build a Telegram bot that tracks $WMON token transfers in real-time on the Monad Testnet using Envio's open-indexing framework. This tutorial walks you through setting up an indexer, handling live events, and sending instant notifications - all powered by HyperIndex.
@@ -200,7 +200,7 @@ Learn more by visiting Monad's [documentation](https://docs.monad.xyz/guides/tg-
 ### Chiliz Tutorial
 
 
-<img src="/blog-assets/envio-dev-update-march-8-2025.png" alt="chiliz tutorial" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-8-2025.png" alt="ERC20 Transfer handler code that sends an FC Barcelona whale alert to Telegram when a transfer exceeds a threshold" width="100%"/>
 
 
 Track major Fan Token transfers with a Telegram bot in just minutes. Our latest Chiliz indexing tutorial shows you how to monitor high-value moves and stay ahead in the sports-focused blockchain ecosystem.
@@ -219,7 +219,7 @@ Watch our hands-on Rootstock indexing tutorial and learn how to seamlessly retri
 ## Powering the next-gen Apps on Fuel
 
 
-<img src="/blog-assets/envio-dev-update-march-9-2025.png" alt="powering apps on fuel" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-9-2025.png" alt="Envio and Fuel partnership banner with both logos over a green data particle background" width="100%"/>
 
 
 
@@ -230,7 +230,7 @@ For more on the projects we're powering, check out this [thread](https://x.com/e
 
 ## Visualize Any Address Instantly with Chain Density
 
-<img src="/blog-assets/envio-dev-update-march-10-2025.png" alt="chaindensity update" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-10-2025.png" alt="ChainDensity landing page headline 'Visualize Blockchain Activity Density', powered by HyperSync, with feature pills for spot trends, indexing efforts, contracts, and patterns" width="100%"/>
 
 
 Block explorers show raw data - ChainDensity makes it visual. Instantly track onchain activity for any address and spot trends without complex queries.
@@ -255,7 +255,7 @@ For more details about our winners and prizes, check out this [thread](https://x
 
 ## What is Multichain Indexing?
 
-<img src="/blog-assets/envio-dev-update-march-12-2025.png" alt="what is multichain indexing" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-12-2025.png" alt="Envio 'Multi-Chain Indexing: Powering Web3 Data Access' banner with floating chain logos on a black background" width="100%"/>
 
 Multichain indexing is the ability to read, organise, and query data from many chains through one unified system so developers can work with onchain activity without managing separate setups for each network.
 
@@ -273,7 +273,7 @@ Web3 is inherently multichain, but navigating networks can be challenging. Learn
 
 ## Featured Developer
 
-<img src="/blog-assets/envio-dev-update-march-13-2025.png" alt="dev of the month march 2025" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-13-2025.png" alt="Envio Featured Developer banner for Gabriel Stoica with his headshot on a blue network background" width="100%"/>
 
 
 This month, we're excited to feature Gabriel Stoica, a passionate developer focused on decentralization, privacy, and bridging the gap between Web2 and Web3. With years of experience crafting smart contracts and building end-to-end dApps, Gabriel has dedicated his work to making Web3 more accessible for all.
@@ -291,7 +291,7 @@ Make sure to check out Gabriel's [GitHub](https://github.com/gabrielstoica) and 
 
 ## Playlist of the Month
 
-<img src="/blog-assets/envio-dev-update-march-14-2025.png" alt="playlist march 2025" width="100%"/>
+<img src="/blog-assets/envio-dev-update-march-14-2025.png" alt="Spotify public playlist card titled 'Mar 25' by Jordy Baby, 25 songs, 1 hr 36 min" width="100%"/>
 
 
 [Open Spotify](https://open.spotify.com/playlist/0KuEG8cv3T7oNV0rtLKaEP?si=e00c3fc7a6f244ca)

--- a/blog/2025-04-15-oracle-wars.md
+++ b/blog/2025-04-15-oracle-wars.md
@@ -10,7 +10,7 @@ last_update:
 
 Co-authors: [Jordyn Laurier](https://x.com/j_o_r_d_y_s), Head of Marketing, and [Jonjon Clark](https://x.com/jonjonclark), Co-Founder at Envio
 
-<img src="/blog-assets/oracle-wars-1.png" alt="Cover Image Oracle Wars" width="100%"/>
+<img src="/blog-assets/oracle-wars-1.png" alt="Oracle Wars dashboard showing ETH/USD price chart comparing Redstone and Chainlink oracle feeds over 24 hours" width="100%"/>
 
 <!--truncate-->
 
@@ -47,7 +47,7 @@ Wonder what happens in live conditions during periods of high volatility? That i
 
 You will notice that updates are not always evenly spaced. That is the deviation threshold kicking in: when markets get volatile, updates come in fast. When things are calm, fewer updates appear. This is a valuable pattern to observe if you are designing a protocol that depends on accurate and real-time data.
 
-<img src="/blog-assets/oracle-wars-2.png" alt="Oracle Wars 2" width="100%"/>
+<img src="/blog-assets/oracle-wars-2.png" alt="Oracle Wars price chart showing a sharp ETH/USD drop to around $2,200 with clustered Redstone and Chainlink updates during high volatility" width="100%"/>
 
 ## Understanding the limitations of deviation thresholds in push oracles
 
@@ -69,7 +69,7 @@ With the advent of high-speed chains like MegaETH and Monad, we are starting to 
 
 On Oracle Wars, you can observe how these super-fast push oracles behave in real time, with feeds like the ETH/USD price on MegaETH. The data is continuously updated, providing a new level of insight into how push oracles might evolve to rival the responsiveness of pull models.
 
-<img src="/blog-assets/oracle-wars-3.png" alt="Oracle Wars 2" width="100%"/>
+<img src="/blog-assets/oracle-wars-3.png" alt="Oracle Wars showing Redstone ETH/USD feed on MegaETH with current price $1,641.78 and per-block step updates" width="100%"/>
 
 One aspect that remains intriguing is the frequent occurrence of multiple price updates at the same timestamp. This raises questions about whether these oracles are pushing multiple updates within the same block and the rationale behind this granularity.
 

--- a/blog/2025-04-25-developer-update-april-2025.md
+++ b/blog/2025-04-25-developer-update-april-2025.md
@@ -65,7 +65,7 @@ UserContract.Transfer.handler(async ({ event, context }) => {
 V2.17.0 also went live, allowing you to track indexer progress, access the GraphQL Playground, and level up your local dev experience, with plenty more features on the way!
 
 
-<img src="/blog-assets/dev-update-april-2025-1.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-1.png" alt="Envio Development Console showing indexer info and per-chain sync progress across Ethereum, Optimism, LUKSO, Gnosis, Polygon, Fantom, and zkSync" width="100%"/>
 
 
 ### Logger improvements
@@ -92,7 +92,7 @@ If you love what we're building as much as we do and want to stay updated on our
 
 ## Envio Delivers Modular, Real-Time Indexing for Monad Builders
 
-<img src="/blog-assets/dev-update-april-2025-2.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-2.png" alt="Envio and Monad partnership banner with both logos side by side on a stylised cliff backdrop" width="100%"/>
 
 Envio's open indexing framework now supports developers building on Monad. [Monad](https://www.monad.xyz/) is pushing the boundaries of performance at the execution layer, and Envio ensures your data pipeline keeps up seamlessly. Instantly index real-time and historical data on Monad using Envio, fast, reliable, and fully customizable. Track complex state changes, power prediction markets, or build whatever you're working on with full control over how your data flows.
 
@@ -101,7 +101,7 @@ We're proud to support Monad developers with the fastest blockchain indexing sol
 
 ## Introducing Snubb: A Multichain Token Approval Scanner for Your Terminal
 
-<img src="/blog-assets/dev-update-april-2025-3.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-3.png" alt="Snubb terminal UI showing multichain token approval scan progress, per-chain summary, and a list of outstanding unlimited approvals" width="100%"/>
 
 Inspired by [Revoke](https://revoke.cash/), Snubb is an incredibly fast and efficient CLI tool to scan for outstanding token approvals for your address across as many as 70 chains simultaneously.
 
@@ -131,7 +131,7 @@ If you're curious, feel free to check out the original background [post](https:/
 
 ## Introducing Loggregate: A Terminal-Native Tool for Real-Time EVM Event Data Aggregation
 
-<img src="/blog-assets/dev-update-april-2025-4.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-4.png" alt="Loggregate terminal UI aggregating live Transfer events with stats showing 127,744,424 total events and an average value of 111,727" width="100%"/>
 
 Introducing [Loggregate](https://www.npmjs.com/package/loggregate), inspired by [LogTUI](https://www.npmjs.com/package/logtui). It's a terminal-native tool that lets developers aggregate and analyze EVM event data in real-time. Whether it's token transfers, swaps, or deposits, Loggregate makes it easy to pull meaningful data from Ethereum and other networks.
 
@@ -154,7 +154,7 @@ Feel free to check out the original background [post](https://x.com/DenhamPreen/
 
 ## Oracle Wars: Exploring Real-Time Oracle Behavior and Push-Based Feeds
 
-<img src="/blog-assets/dev-update-april-2025-5.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-5.png" alt="Oracle Wars dashboard charting the ETH/USD Redstone feed on MegaETH with a current price of $1,796.53" width="100%"/>
 
 Powered by HyperIndex, [Oracle Wars](https://www.oraclewars.xyz/) visualizes how oracle feeds behave onchain, highlighting deviations and helping you design more reliable smart contracts.
 
@@ -163,7 +163,7 @@ Learn more about it in our latest [blog](https://docs.envio.dev/blog/oracle-wars
 
 ## Envio's HyperSync Powers Trading Strategy with Multichain Data Collection
 
-<img src="/blog-assets/dev-update-april-2025-6.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-6.png" alt="Trading Strategy line chart of 1-month rolling returns by USDC vault from Dec 2024 to Apr 2025, excluding market-making vaults" width="100%"/>
 
 Check out how [Trading Strategy](https://tradingstrategy.ai/) leveraged Envio to collect onchain data across multiple chains and dive into their epic data & research notebook analyzing the performance of 7,000 ERC-4626 vaults across 10 blockchains!
 
@@ -172,7 +172,7 @@ Learn more in this [post](https://x.com/TradingProtocol/status/19103194808879759
 
 ## HyperSync Now Supports 70+ EVM Networks, Enhancing Real-time Data Access Across Web3
 
-<img src="/blog-assets/dev-update-april-2025-7.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-7.png" alt="Envio HyperSync banner reading '70+ SUPPORTED NETWORKS' surrounded by floating EVM chain logos" width="100%"/>
 
 HyperSync now supports 70+ EVM networks, with many more on the way! Developers and analysts can now access real-time and historical data across various EVM networks with ease. Whether you're tracking activity, analyzing trends, or powering apps, HyperSync makes querying fast, reliable, and effortless.
 
@@ -198,7 +198,7 @@ Missed our XDC Developer Workshop? We got you. Check out this step-by-step walkt
 
 ## Featured Developer
 
-<img src="/blog-assets/dev-update-april-2025-8.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-8.png" alt="Envio Featured Developer banner for Manu Soman with his profile photo on a circuit-board background" width="100%"/>
 
 This month, we're excited to feature Manu Soman, a talented developer who transitioned from UX design to mastering backend programming in Rust and JavaScript. Manu's work primarily revolves around systems programming and crypto, with a special focus on Solana. Recently, he's been expanding his skill set by exploring Go.
 
@@ -215,7 +215,7 @@ Be sure to follow Manu and his work on [X](https://x.com/manu_221b) for the late
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-april-2025-9.png" alt="logtui" width="100%"/>
+<img src="/blog-assets/dev-update-april-2025-9.png" alt="Spotify 'Apr 25' public playlist card by Jordy Baby with 22 songs and 1 hr 33 min runtime" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/5ICzfWy4hkVDOEe0NSOuZy?si=762121a2d366461b)
 

--- a/blog/2025-05-16-monad-hackathon-winners-2025.md
+++ b/blog/2025-05-16-monad-hackathon-winners-2025.md
@@ -10,7 +10,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/monad-hackathon-winners-2025.png" alt="Cover Image Monad Hackathon Winners" width="100%"/>
+<img src="/blog-assets/monad-hackathon-winners-2025.png" alt="Envio cover banner reading Monad Hackathon Winners, EVM/Accathon 2025" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2025-05-29-developer-update-may-2025.md
+++ b/blog/2025-05-29-developer-update-may-2025.md
@@ -94,11 +94,11 @@ Big shoutout to one of our leading devs, [Dmitry Zakharov](https://x.com/dzakh_d
 
 Here's a look at the local dev console, a useful way to track indexing speed and progress in real time. In this example, it's tearing through Uniswap V3 data.
 
-<img src="/blog-assets/dev-update-may-2025-1.png" alt="contract indexing" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-1.png" alt="HyperIndex performance dashboard showing 26,338 events per second while indexing Uniswap V3" width="100%"/>
 
 ## Envio Sponsors DappCon 2025
 
-<img src="/blog-assets/dev-update-may-2025-2.png" alt="dappcon 2025" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-2.png" alt="DappCon Berliner Mauer banner featuring Envio as a sponsor" width="100%"/>
 
 Envio is one of the proud sponsors of [DappCon](https://dappcon.io/) 2025, joining an incredible lineup of projects pushing Web3 forward.
 
@@ -109,7 +109,7 @@ See you in Berlin!
 
 ## Exciting DeFi Integration With Nad.fun
 
-<img src="/blog-assets/dev-update-may-2025-3.png" alt="nad dot fun" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-3.png" alt="World heatmap visualising HyperSync request traffic across regions for Nad.fun" width="100%"/>
 
 Envio has been integrated with [Nad.fun](https://testnet.nad.fun/), an onchain trading game built on Monad. We recently developed geographic request visualizations as we began serving HyperSync requests from multiple regions. Check out the awesome graphs showcasing where traffic is coming from.
 
@@ -118,7 +118,7 @@ Learn more in this [post](https://x.com/naddotfun/status/1920483968417177768) on
 
 ## Envio Powers Real-Time Analytics on Monorail
 
-<img src="/blog-assets/dev-update-may-2025-4.png" alt="monorail" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-4.png" alt="Monorail Analytics Overview dashboard powered by Envio showing total trades, fees, and exchange volumes on Monad" width="100%"/>
 
 [Monorail](https://testnet-preview.monorail.xyz/) is now serving up real-time blockchain analytics, powered by our indexing infrastructure on Monad.
 
@@ -129,7 +129,7 @@ Learn more in this [post](https://x.com/envio_indexer/status/1923323564117156011
 
 ## Sonic Summit Keynote
 
-<img src="/blog-assets/dev-update-may-2025-5.png" alt="sonic summit" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-5.png" alt="Sonic Summit speaker card for Envio co-founder Denham Preen, talk titled Indexing Millions of Events in Seconds" width="100%"/>
 
 Learn how to index millions of events on Sonic - in seconds.
 
@@ -140,7 +140,7 @@ Watch on [YouTube](https://www.youtube.com/watch?v=DYvzHIRinQQ).
 
 ## Integration Spotlight: Forever Moments
 
-<img src="/blog-assets/dev-update-may-2025-6.png" alt="forever moments" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-6.png" alt="Forever Moments app interface showing a Top Moments grid of onchain media collections" width="100%"/>
 
 [Forever Moments](https://www.forevermoments.life/) just rolled out a robust new indexing setup using Envio. The result? Faster performance, cleaner data feeds, and expanded features. Even better, they'll be open-sourcing their version soon so others can build on it too.
 
@@ -151,7 +151,7 @@ Learn more in this [post](https://x.com/momentsonchain/status/192727896665978505
 
 ## Monad Evm/Accathon Winners
 
-<img src="/blog-assets/dev-update-may-2025-7.png" alt="monad hackathon" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-7.png" alt="Envio and Monad banner congratulating winners of the Evm/accathon 2025 hackathon" width="100%"/>
 
 Congratulations to the winners of the first-ever Monad hackathon (evm/accathon). It brought some serious builder energy, and we were proud to support teams with the fastest and most performant data indexing on Monad.
 
@@ -168,7 +168,7 @@ Learn more about the winning projects in our [blog](https://docs.envio.dev/blog/
 
 ## Featured Developer
 
-<img src="/blog-assets/dev-update-may-2025-8.png" alt="dev of the month paul" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-8.png" alt="Envio Featured Developer banner for Paul Berg, co-founder and CEO of Sablier Labs" width="100%"/>
 
 This month, we're proud to spotlight Paul Berg, co-founder and CEO of Sablier Labs, and a long-time contributor to the open-source Ethereum ecosystem. Known for building tools like [Sablier](https://sablier.com/) and [PRBMath](https://github.com/paulrberg/prb-math), Paul continues to push the space forward with thoughtful, developer-first projects.
 
@@ -180,7 +180,7 @@ We highly recommend exploring Paul's contributions and projects in the space. He
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-may-2025-9.png" alt="playlist may 2025" width="100%"/>
+<img src="/blog-assets/dev-update-may-2025-9.png" alt="Spotify public playlist titled May 25 by Jordy Baby, 23 songs, 1 hr 27 min" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/5qpi10IrOQcNv8ixqWPkFB?si=876ddf7528534b2f)
 

--- a/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
+++ b/blog/2025-06-17-how-to-index-megaeth-data-using-envio.md
@@ -76,7 +76,7 @@ Envio offers a range of advanced capabilities that make it easy to build rich, f
 
 ### Oracle Wars
 
-<img src="/blog-assets/megaeth-oracle-wars.png" alt="orcale wars megaeth" width="100%"/>
+<img src="/blog-assets/megaeth-oracle-wars.png" alt="Oracle Wars dashboard showing live ETH/USD price chart from Redstone on MegaETH, powered by HyperIndex" width="100%"/>
 
 [Oracle Wars](https://www.oraclewars.xyz/) is an experimental dashboard built with Envio's HyperIndex that visualizes real-time oracle behavior on MegaETH. It showcases how push-based oracles like [RedStone Bolt](https://blog.redstone.finance/2025/04/08/introducing-redstone-bolt-the-fastest-blockchain-oracle-to-date/) behave under live market conditions by tracking heartbeat intervals, deviation thresholds, and latency patterns. The project helps developers understand how oracles operate in volatile environments and the potential risks of delayed or unexpected updates. Built in under two hours, Oracle Wars demonstrates how Envio enables rapid development of real-time monitoring tools on high-throughput chains like MegaETH.
 

--- a/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
+++ b/blog/2025-06-24-building-visualizers-and-dashboards-on-monad.md
@@ -27,7 +27,7 @@ Monad's rapid growth has created a strong need for scalable, real-time data infr
 
 By [@monadicoo](https://x.com/monadicoo)
 
-<img src="/blog-assets/monad-visualizer.gif" alt="monad visualizer" width="100%"/>
+<img src="/blog-assets/monad-visualizer.gif" alt="Monad Super-Visualizer dashboard with live data stream of transactions, current block 22,878,361 and live TPS 112.0" width="100%"/>
 
 This immersive dashboard allows users to explore live activity across the entire Monad chain, with deep visibility into data from specific protocols, contracts, or addresses. Envio powers two core functionalities: streaming live, chain-wide activity to the homepage, and offering a filtered data feed for targeted protocol analysis.
 
@@ -37,7 +37,7 @@ Check it out [here](https://monadviewer.vercel.app/)
 
 By [@sifu_lam](https://x.com/sifu_lam)
 
-<img src="/blog-assets/monad-genki.gif" alt="monad genki" width="100%"/>
+<img src="/blog-assets/monad-genki.gif" alt="Monad Genki Dama Dragon Ball Z themed visualizer with Monanimals charging a purple energy ball and a block data panel" width="100%"/>
 
 A Dragon Ball Z-inspired visual experience that depicts each Monad testnet block as energy contributing to a Genki Dama. Monanimals generate power balls representing transaction types, visually charging the Monad mainnet. Envio's HyperSync ensures real-time accuracy and high throughput with minimal latency.
 
@@ -47,7 +47,7 @@ Check it out [here](https://monad-genki-dama.vercel.app/)
 
 By [@bossonormal1](https://x.com/bossonormal1)
 
-<img src="/blog-assets/lendhub.png" alt="lendhub" width="100%"/>
+<img src="/blog-assets/lendhub.png" alt="LendHub Platform Stats page showing Total Completed (wMON) 192.74, 21 Completed Loans, 6 Active Loans, 4 Pending Loans, and an activity feed" width="100%"/>
 
 LendHub's dashboard presents real-time analytics for a peer-to-peer NFT lending protocol. It tracks metrics such as loans listed, funded, repaid, claimed, and withdrawn. Custom-built with Envio's config.yaml, schema.graphql, and event handlers, this tool uses a GraphQL endpoint to update dynamically based on key smart contract events.
 
@@ -57,7 +57,7 @@ Check it out [here](https://www.lendhub.xyz/stats)
 
 By [@velkan_gst](https://x.com/velkan_gst)
 
-<img src="/blog-assets/miris.gif" alt="miris" width="100%"/>
+<img src="/blog-assets/miris.gif" alt="Miris real-time visualizer Chain tab with 100.0 TPS, 1.9 BPS, 0.52s block time, 63% epoch progress, live block stream and network status" width="100%"/>
 
 Miris is a fully featured chain visualizer offering insights into blocks, transactions, and overall network health. Envio handles the indexing of core protocols like Wormhole and Apr Labs, and the Explorer page uncovers activity from additional Monad projects. Built using Apollo Client and Next.js.
 
@@ -67,7 +67,7 @@ Check it out [here](https://miris.vercel.app/)
 
 By [@WagmiArc](https://x.com/WagmiArc)
 
-<img src="/blog-assets/monad-frens.gif" alt="monad frens" width="100%"/>
+<img src="/blog-assets/monad-frens.gif" alt="Monad Frens Testnet Dashboard with 1.8B total transactions, current TPS 55.0, 7-day activity chart and Monad Pizza Madness visual" width="100%"/>
 
 Monad Frens delivers real-time and historical chain insights in a visually engaging format, including a pizza-themed chain status display. Envio's HyperSync feeds accurate block and transaction data, while a custom API calculates cumulative transactions since Block 0. The dashboard filters transactions by timestamp, ensuring comprehensive tracking.
 
@@ -87,7 +87,7 @@ Check it out [here](https://monlake.vercel.app/)
 
 By [@Samruddhi_Krnr](https://x.com/Samruddhi_Krnr)
 
-<img src="/blog-assets/animonad.gif" alt="animonad" width="100%"/>
+<img src="/blog-assets/animonad.gif" alt="Animonad dashboard with TPS vs Categories bar chart, Most Used dApps list led by Curvance and Aprior, and Latest TXs feed" width="100%"/>
 
 Animonad tracks live transactions per second across Monad-based dApps like Magma, PancakeSwap, and Narwhal Finance. Each transaction is categorized by address and function signature. Envio's HyperSync facilitates rapid data retrieval to update the UI every second, powering dynamic graphs and protocol rankings.
 
@@ -97,7 +97,7 @@ Check it out [here](https://animonad.vercel.app/)
 
 By [@yomax75](https://x.com/yomax75)
 
-<img src="/blog-assets/nadmetrics.gif" alt="nadmetrics" width="100%"/>
+<img src="/blog-assets/nadmetrics.gif" alt="NadMetrics Live Statistics with latest block #22,925,334, 602 transactions, 2.24K MON volume, average TPS 120.40, and live TPS chart" width="100%"/>
 
 Built with React, TypeScript, Node.js, and WebSockets, NadMetrics is a robust analytics platform offering real-time and historical data for Monad. The dashboard is ideal for developers and analysts monitoring chain volume, transaction flow, and usage trends. Envio serves as the foundation for its high-speed data ingestion.
 
@@ -107,7 +107,7 @@ Check it out [here](https://nadmetrics.com/live)
 
 By [@gabriell_santi](https://x.com/gabriell_santi)
 
-<img src="/blog-assets/monalytics.gif" alt="monalytics" width="100%"/>
+<img src="/blog-assets/monalytics.gif" alt="Monalytics Network Realtime Analytics on Monad Testnet showing block number, block size, TPS 114, block gas usage 8.64%, and block entropy chart" width="100%"/>
 
 An interactive dashboard for real-time visualization of activity on the Monad testnet. It leverages Envio for continuous onchain event streaming and HyperRPC for fast, low-latency data access. The platform delivers both a global view of the network, including metrics like TPS, gas usage, and block entropy, and protocol-specific panels for apps like MonTools, Castora, Ambient, and more.
 
@@ -117,7 +117,7 @@ Check it out [here](https://analytics.montools.xyz/chain)
 
 By [@Pradeeppilot2k5](https://x.com/Pradeeppilot2k5) and [@vidit_0](https://x.com/vidit_0)
 
-<img src="/blog-assets/monanimals-blast.gif" alt="monanimals blast" width="100%"/>
+<img src="/blog-assets/monanimals-blast.gif" alt="Monanimals Blast Mayhem game with Monanimals labelled with block numbers, a Score of 6, and a Monad Testnet Stats sidebar" width="100%"/>
 
 A gamified dashboard transforming real-time blockchain stats into interactive graphics. Monanimals symbolize block numbers, and animated graphs display key metrics such as gas usage, TPS, and block peers. Envio's HyperRPC ensures seamless data delivery for a high-performance user experience.
 

--- a/blog/2025-06-24-dev-update-june-2025.md
+++ b/blog/2025-06-24-dev-update-june-2025.md
@@ -102,7 +102,7 @@ If you love what we're building as much as we do and want to stay updated on our
 
 ## Mission 4: Building Visualizers & Dashboards on Monad
 
-<img src="/blog-assets/visualizers-and-dash-monad.png" alt="mission 4" width="100%"/>
+<img src="/blog-assets/visualizers-and-dash-monad.png" alt="Envio x Monad Mission 4 banner: Building Visualizers and Dashboards on Monad" width="100%"/>
 
 As part of Mission 4 with the Monad Developer community, we invited builders to push the limits of real-time dashboards and visualizers on Monad, powered by Envio. The outcome? A wave of standout projects that combined sharp design with serious indexing performance.
 
@@ -111,7 +111,7 @@ Catch the highlights in our [blog](https://docs.envio.dev/blog/how-to-build-visu
 
 ## Exploring Cross-Chain Arbitrage on Uniswap V4
 
-<img src="/blog-assets/arbitrage-v4.png" alt="v4 arbitrage" width="100%"/>
+<img src="/blog-assets/arbitrage-v4.png" alt="V4.xyz Multi-Chain ETH/USDC Price Arbitrage dashboard comparing prices across Ethereum, Unichain, Arbitrum, Base, and Optimism" width="100%"/>
 
 Curious how much prices diverge across the same Uniswap V4 pools deployed on different chains? One builder tracked ETH/USDC across Ethereum, Base, Arbitrum, and Unichain, building a real-time dashboard that surfaces price discrepancies, trade sizes, and cross-chain spread opportunities as they appear.
 
@@ -129,7 +129,7 @@ Take a look at what we shipped by reading this [thread](https://x.com/envio_inde
 
 ## How to Index Data on MegaEth Using Envio
 
-<img src="/blog-assets/megaeth.png" alt="index megaeth data" width="100%"/>
+<img src="/blog-assets/megaeth.png" alt="Envio cover graphic: How to Index Real-Time Data on MegaETH" width="100%"/>
 
 Envio proudly supports developers and data analysts building on MegaEth with the most performant real-time indexing stack designed for high-throughput environments. Get fast, reliable access to both real-time and historical data without the usual bottlenecks. 
 
@@ -138,7 +138,7 @@ Learn more about how to efficiently index data on MegaEth in our [blog](https://
 
 ## Join Us at Pragma Cannes
 
-<img src="/blog-assets/pragma-jonjon.png" alt="pragma jonjon" width="100%"/>
+<img src="/blog-assets/pragma-jonjon.png" alt="Pragma Cannes speaker banner for JonJon Clark, Co-founder of envio.dev, Thu, Jul 3, 2025" width="100%"/>
 
 We're heading to EthGlobal's Pragma in Cannes and running a hands-on workshop built for developers. Learn how to easily access, index, and query multichain data with Envio.
 
@@ -147,7 +147,7 @@ Still need a ticket? Grab $70 off with our [referral link]( https://ethglobal.co
 
 ## Analyzing Safe Data in Real-time Using HyperIndex
 
-<img src="/blog-assets/analyzing-safe-data.png" alt="safe data" width="100%"/>
+<img src="/blog-assets/analyzing-safe-data.png" alt="Envio x Safe workshop banner: Analyzing Safe Data in Real-time, Execution Layer Workshop Room, 17th June 2pm GMT+2" width="100%"/>
 
 
 Missed our speaking slot at DappCon? Check out this session. Learn how Envio's HyperIndex unlocks instant visibility into [Safe](https://safe.global/) transactions, from multisig behavior to governance and fund flows in our [developer workshop](https://www.youtube.com/live/3_5__fpQjKM?t=18381s).
@@ -156,7 +156,7 @@ Missed our speaking slot at DappCon? Check out this session. Learn how Envio's H
 
 ## How to Index Data on Monad Using Envio
 
-<img src="/blog-assets/index-data-on-monad.png" alt="indexing monad" width="100%"/>
+<img src="/blog-assets/index-data-on-monad.png" alt="Envio cover graphic: How to Index Data on Monad Quickstart Guide" width="100%"/>
 
 Envio is proud to support developers and data analysts building on [Monad](https://www.monad.xyz/) by providing the most efficient and reliable access to real-time and historical data on the Monad network through our modular indexing stack.
 
@@ -172,7 +172,7 @@ Learn more about how to efficiently index data on Monad in our [blog](https://do
 
 ## Featured Developer
 
-<img src="/blog-assets/dev-of-the-month-june-2025.png" alt="DOTM June" width="100%"/>
+<img src="/blog-assets/dev-of-the-month-june-2025.png" alt="Envio Featured Developer banner for Thalles Passos" width="100%"/>
 
 This month's featured developer is Thalles Passos. He's a full-stack developer from Brazil who started building professionally at just 17. Thalles began his journey with [Notus Labs](https://notus.team/) and is now working on [Notus API](https://docs.notus.team/docs/guides), where the team is creating a complete suite for account abstraction.
 
@@ -189,7 +189,7 @@ Be sure to follow Thalles on [X](https://x.com/thallescomumh) and check out his 
 
 ## Playlist of the Month
 
-<img src="/blog-assets/june-playlist.png" alt="june playlist" width="100%"/>
+<img src="/blog-assets/june-playlist.png" alt="Spotify public playlist cover titled June 25 by Jordy Baby, 17 songs, 1 hr 8 min" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/0YkXxUDzOrUSh2h0eznxu6?si=192e7f80b18e478a)
 

--- a/blog/2025-07-30-dev-update-july-2025.md
+++ b/blog/2025-07-30-dev-update-july-2025.md
@@ -73,7 +73,7 @@ Try it out now by visiting our landing [page](https://envio.dev/).
 
 ## Envio Supports Base with Lightning Fast Data Retrieval
 
-<img src="/blog-assets/base-support.png" alt="base support" width="100%"/>
+<img src="/blog-assets/base-support.png" alt="Base and Envio logos side by side on a dark background" width="100%"/>
 
 [Base](https://www.base.org/) is booming. Envio's HyperSync supports Base with the most advanced indexing on the market. Sync historical data in minutes, access it up to 2000x faster than RPC, and query structured logs, traces, events, and functions.
 
@@ -81,7 +81,7 @@ Learn how to index millions of events in seconds on Base using Envio in this [th
 
 ## Internal Hackathon July 2025
 
-<img src="/blog-assets/internal-hack-turkey.png" alt="internal hack turkey" width="100%"/>
+<img src="/blog-assets/internal-hack-turkey.png" alt="Envio team building during the internal hackathon at the team offsite in Turkey" width="100%"/>
 
 We wrapped up another successful internal hackathon during our team offsite this month. The goal? Build tools that push Envio forward. Some are already live.
 
@@ -91,7 +91,7 @@ Check out this [thread](https://x.com/envio_indexer/status/1950145932516880605) 
 
 ## Supercharge Your Ethereum Data With Envio's HyperSync
 
-<img src="/blog-assets/eth-support.png" alt="eth support" width="100%"/>
+<img src="/blog-assets/eth-support.png" alt="Ethereum and Envio logos side by side on a purple background" width="100%"/>
 
 [Ethereum](https://ethereum.org/en/) is on fire. ETF inflows are climbing, regulatory clarity is coming, and price action is picking up. The network's heating up, but can your infrastructure keep up? Envio's HyperSync lets you index millions of events on Ethereum in seconds. No delays. Just fast, structured access to the data that matters.
 
@@ -99,7 +99,7 @@ Learn how in this [thread](https://x.com/envio_indexer/status/194584907774632763
 
 ## EthCC & Pragma Cannes 2025 Recap
 
-<img src="/blog-assets/ethcc-pragma.png" alt="ethcc & pragma" width="100%"/>
+<img src="/blog-assets/ethcc-pragma.png" alt="Envio speaker on stage presenting at Pragma Cannes" width="100%"/>
 
 Big shoutout to the [EthCC](https://ethcc.io/) team for an incredible event, and to [ETHGlobal](https://ethglobal.com/) for hosting a packed Pragma. Non-stop energy, great convos, and a stacked builder crowd.
 
@@ -115,7 +115,7 @@ Missed our workshop on lightning-fast multichain indexing? Catch the replay on [
 
 ## Featured Developer
 
-<img src="/blog-assets/dev-of-the-month-july-2025.png" alt="july 2025 DOTM" width="100%"/>
+<img src="/blog-assets/dev-of-the-month-july-2025.png" alt="Envio Featured Developer banner for Nikhil" width="100%"/>
 
 This month's featured developer is Nikhil, a software developer and technical content creator who's been sharing practical insights with Web3 devs for years. He's worked with teams like Figment, Celo, and Bitquery, crafting developer-facing content. Nikhil has also contributed as a Solidity developer on smaller DeFi projects and is now focusing on personal projects while exploring new opportunities.
 
@@ -130,7 +130,7 @@ Be sure to follow Nikhil on [X](https://x.com/nikbhintade) and check out their w
 
 ## Playlist of the Month
 
-<img src="/blog-assets/july-2025-playlist.png" alt="july 2025 playlist" width="100%"/>
+<img src="/blog-assets/july-2025-playlist.png" alt="Spotify public playlist titled 'July 25' by Jordy Baby, 20 songs, 1 hr 19 min" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/1vyctkfc1CrmnVv2dMCrUo?si=84f39e6a4b1d436e)
 

--- a/blog/2025-08-29-dev-update-august-2025.md
+++ b/blog/2025-08-29-dev-update-august-2025.md
@@ -97,7 +97,7 @@ Our new [YouTube series](https://www.youtube.com/@envio_indexer/playlists) cover
 
 ## Introducing Chain Pulse
 
-<img src="/blog-assets/chain-pulse.png" alt="chain pulse" width="100%"/>
+<img src="/blog-assets/chain-pulse.png" alt="Chain Pulse terminal dashboard showing live throughput, blocks, logs, and transaction metrics across multiple chains" width="100%"/>
 
 A simple yet powerful tool to quickly check the pulse of multiple blockchains in real time.
 
@@ -123,7 +123,7 @@ Check out the original post on [X](https://x.com/jonjonclark/status/195849712129
 
 ## Envio Powers Zup Protocol 
 
-<img src="/blog-assets/zup-integration.png" alt="zup" width="100%"/>
+<img src="/blog-assets/zup-integration.png" alt="Zup Protocol graphic showing HyperEVM and Base now live, surrounded by DEX and protocol logos" width="100%"/>
 
 
 Easily search millions of pools across multiple DEXs and chains for the best yield per pair.
@@ -137,14 +137,14 @@ Check out Zup Protocol: [app.zupprotocol.xyz](https://app.zupprotocol.xyz)
 
 ## HyperSync is now Globally Distributed
 
-<img src="/blog-assets/k8gb.png" alt="k8gb" width="100%"/>
+<img src="/blog-assets/k8gb.png" alt="K8GB Adopters page highlighting envio.dev as a new entry providing cross region availability of Envio's data engine" width="100%"/>
 
 We've joined the official list of [K8GB adopters](https://k8gb.io/ADOPTERS/). HyperSync is now served from multiple regions, giving builders faster and more reliable access wherever they are.
 
 
 ## Mobil3 Hackathon - Mexico City 
 
-<img src="/blog-assets/mobil3-hackathon.png" alt="mobil3 hackathon" width="100%"/>
+<img src="/blog-assets/mobil3-hackathon.png" alt="Selfie of Denham Preen with hackers at the Mobil3 hackathon in Mexico City" width="100%"/>
 
 
 We had a great time at the [Mobil3](https://mobil3.xyz/) Hackathon in CDMX!
@@ -158,7 +158,7 @@ Big thanks to the Mobil3 organizers, the Monaa Foundation, and all the builders 
 
 ## $943M Frozen 
 
-<img src="/blog-assets/banned-list.png" alt="banned list" width="100%"/>
+<img src="/blog-assets/banned-list.png" alt="Terminal output listing top USDT and USDC blacklisted wallet balances on Ethereum mainnet" width="100%"/>
 
 Say hello to the only list you don't want to be on → [The Banned List](https://thebannedlist.xyz)
 
@@ -171,7 +171,7 @@ Check out the original post on [X](https://x.com/DenhamPreen/status/195603785392
 
 ## Introducing Liquidator
 
-<img src="/blog-assets/liquidator.png" alt="liquidator" width="100%"/>
+<img src="/blog-assets/liquidator.png" alt="Liquidator terminal UI showing live liquidation stats and per-chain activity bars across Scroll, Avalanche, Base, Arbitrum, and more" width="100%"/>
 
 Say hello to Liquidator, a new tool that lets you watch liquidation events unfold live in your terminal.
 
@@ -201,7 +201,7 @@ Check it out on [GitHub](https://github.com/enviodev/telegram-to-notiondb)
 
 ## Featured Developer
 
-<img src="/blog-assets/aug-2025-DOTM.png" alt="Aug 2025 DOTM" width="100%"/>
+<img src="/blog-assets/aug-2025-DOTM.png" alt="Envio Featured Developer banner for Mikko Ohtamaa with portrait photo" width="100%"/>
 
 This month's featured developer is Mikko Ohtamaa, CEO and Co-Founder of [Trading Strategy](https://tradingstrategy.ai/), a Web3 algorithmic trading protocol. Over the past decade, Mikko has served as CTO at leading blockchain companies like LocalBitcoins (one of the first Bitcoin exchanges) and TokenMarket (one of the first ICO platforms), where he helped build infrastructure for more than $1B in digital assets. He's also an active voice in digital rights and open-source communities.
 
@@ -215,7 +215,7 @@ Be sure to follow them on [X](https://x.com/moo9000) and check out their work on
 
 ## Playlist of the Month
 
-<img src="/blog-assets/aug-playlist-2025.png" alt="Aug 2025 Playlist" width="100%"/>
+<img src="/blog-assets/aug-playlist-2025.png" alt="Spotify playlist cover titled 'Aug 25' by Jordy Baby, 20 songs, 1 hr 20 min" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/3n3qReuChMo6SEgl0Bso3Z?si=23e45edbfde34be1)
 

--- a/blog/2025-09-30-dev-update-september-2025.md
+++ b/blog/2025-09-30-dev-update-september-2025.md
@@ -53,7 +53,7 @@ We've refactored internal tables to focus on a single public entry point: `_meta
 
 If this impacts your setup, reach out, and we'll help you migrate smoothly.
 
-<img src="/blog-assets/sep-update-2025-1.png" alt="query" width="100%"/>
+<img src="/blog-assets/sep-update-2025-1.png" alt="HyperIndex _meta GraphQL query with annotated fields like chainId, progressBlock, eventsProcessed alongside JSON response data" width="100%"/>
 
 ### V2.29.0
 
@@ -102,7 +102,7 @@ Star us on [GitHub](https://github.com/enviodev/hyperindex)
 
 ## Liqo Brings Real-Time Liquidation Insights Across Major DeFi Protocols
 
-<img src="/blog-assets/sep-update-2025-2.png" alt="liqo" width="100%"/>
+<img src="/blog-assets/sep-update-2025-2.png" alt="Liqo dashboard headlined Hub for all onchain liquidations with totals for Aave, Euler, Morpho and a recent liquidations table" width="100%"/>
 
 Track major real-time liquidations in style with [Liqo](https://www.liqo.xyz/), a powerful liquidation leaderboard tool powered by Envio. The new leaderboard gives you a clear view of the most active liquidators across top protocols like [Aave](https://aave.com/), [Morpho](https://morpho.org/), and [Euler](https://euler.finance/), with support for [Twyne](https://twyne.xyz/) coming soon.
 
@@ -115,7 +115,7 @@ Check out the original post on [X](https://x.com/jonjonclark/status/197016444648
 
 ## MetaMask Smart Accounts Hackathon with Monad and Envio
 
-<img src="/blog-assets/sep-update-2025-3.png" alt="metamask hackathon" width="100%"/>
+<img src="/blog-assets/sep-update-2025-3.png" alt="MetaMask Smart Accounts x Monad Dev Cook-Off hackathon banner with a $15,000 prize pool in partnership with Monad and Envio" width="100%"/>
 
 The MetaMask Smart Accounts Hackathon, in collaboration with Monad and Envio, is now live and will run from September 19 to October 20. Builders are invited to create next-level applications on Monad with a focus on account abstraction and user experience.
 
@@ -134,7 +134,7 @@ Missed our kickoff call and want to learn more? Check out the broadcast on [X](h
 
 ## Envio at Pragma and ETHGlobal New Delhi
 
-<img src="/blog-assets/sep-update-2025-4.png" alt="ethglobal new dehli" width="100%"/>
+<img src="/blog-assets/sep-update-2025-4.png" alt="Envio speaker on stage at Pragma in New Delhi with a Pragma logo and frontend slide projected behind" width="100%"/>
 
 The team was in New Delhi for Pragma and ETHGlobal, spending the week with builders, founders, and partners across the ecosystem. Every dapp relies on indexing, but most existing solutions are slow, siloed, and unreliable.
 
@@ -145,7 +145,7 @@ Big thanks to ETHGlobal, the organisers, partners, and everyone who stopped by t
 
 ## Envio Supports MegaETH Builders with Lightning-Fast Onchain Data Access
 
-<img src="/blog-assets/sep-update-2025-5.png" alt="megaeth support" width="100%"/>
+<img src="/blog-assets/sep-update-2025-5.png" alt="Envio and MegaETH co-branded artwork with a hooded figure facing a glowing skyline and lightning sky" width="100%"/>
 
 100k+ TPS, 10+ ggas p/s & less than 10ms blocks? Envio is built for it. Our indexing framework supports developers building on MegaETH with efficient access to both real-time and historical data.
 
@@ -154,7 +154,7 @@ With Envio, you can sync millions of events up to 2000x faster than RPC, making 
 
 ## The State of AI in Blockchain Data: Neon x Envio
 
-<img src="/blog-assets/sep-update-2025-6.png" alt="neonevm ama" width="100%"/>
+<img src="/blog-assets/sep-update-2025-6.png" alt="Neon AMA banner The State of AI in Blockchain Data, Live on X, Thursday 18th September 15:00 CET with speakers @jonjonclark and @0xbeary" width="100%"/>
 
 Blockchain generates endless streams of data, and powerful indexers like Envio make it usable. But what happens when AI steps into the picture?
 
@@ -165,7 +165,7 @@ Missed it live? Catch the full recording of the broadcast on [X](https://x.com/i
 
 ## Join Envio at Encode London This October
 
-<img src="/blog-assets/sep-update-2025-7.png" alt="encode london 2025" width="100%"/>
+<img src="/blog-assets/sep-update-2025-7.png" alt="Encode London 2025 banner with Encode Club and Envio logos and a Partner Sponsor label" width="100%"/>
 
 We're excited to be partners at the Encode London Hackathon and Conference, taking place from 24–26 October at the [Encode Hub](https://hub.encode.club/) in Shoreditch, London. This three-day event brings together builders, researchers, and industry leaders for hands-on hacking, talks, and workshops focused on AI and Web3. Our team will be on the ground all weekend supporting builders, so keep an eye out for us throughout the event.
 
@@ -199,7 +199,7 @@ to follow along and catch every session.
 
 ## Featured Developer
 
-<img src="/blog-assets/sep-update-2025-8.png" alt="DOTM Sep 2025" width="100%"/>
+<img src="/blog-assets/sep-update-2025-8.png" alt="Envio Featured Developer banner for Ryan Holanda with his portrait on a purple particle background" width="100%"/>
 
 This month's featured developer is [Ryan Holanda](https://www.linkedin.com/in/ryan-holanda/), Co-founder and CTO of [Zup Protocol](https://zupprotocol.xyz/). A software engineer since the age of 16, Ryan brings advanced expertise across front-end, mobile, blockchain, and design. Driven by a deep passion for DeFi and the Web3 ecosystem, he has dedicated his career to building innovative solutions that empower users and promote financial freedom.
 
@@ -212,7 +212,7 @@ Be sure to follow them on [X](https://x.com/moo9000) and check out their work on
 
 ## Playlist of the Month
 
-<img src="/blog-assets/sep-update-2025-9.png" alt="PLOTM Sep 2025" width="100%"/>
+<img src="/blog-assets/sep-update-2025-9.png" alt="Spotify public playlist Sept 25 by Jordy Baby, 20 songs, 1 hr 18 min, with a grid of album covers" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/2lOYVNjlopciZGOUGdPED1?si=34ee9820a0db4494)
 

--- a/blog/2025-10-28-dev-update-october-2025.md
+++ b/blog/2025-10-28-dev-update-october-2025.md
@@ -87,7 +87,7 @@ Star us on [GitHub](https://github.com/enviodev/hyperindex)
 
 ## The Uniswap Alert System That Uncovered a MEV Bot Making Millions
 
-<img src="/blog-assets/dev-update-oct-25-1.png" alt="mev bot" width="100%"/>
+<img src="/blog-assets/dev-update-oct-25-1.png" alt="Transactions table highlighting a $1.09M Add and Remove pair, evidence of an MEV sandwich attack on a Uniswap pool" width="100%"/>
 
 While testing a Uniswap alert system, the team accidentally uncovered an active MEV bot that has been making millions every week on mainnet! 
 
@@ -122,7 +122,7 @@ Our bounties can double as a bonus on top of whatever you're already building, s
 
 ## Understanding Stablecoin Flows in Real-time
 
-<img src="/blog-assets/dev-update-oct-25-2.gif" alt="stablecoin flows" width="100%"/>
+<img src="/blog-assets/dev-update-oct-25-2.gif" alt="Stable Volume dashboard powered by Envio showing 14,757 real-time stablecoin transfers per minute across chains" width="100%"/>
 
 Stablecoins move faster than ever, and understanding that flow in real-time opens up new layers of insight, from transaction velocity to how close we are to Visa or Mastercard throughput.
 
@@ -143,7 +143,7 @@ Co-Founder [Denham Preen](https://x.com/DenhamPreen) led a workshop at ETHGlobal
 
 ## Envio Showcase
 
-<img src="/blog-assets/dev-update-oct-25-3.gif" alt="showcase" width="100%"/>
+<img src="/blog-assets/dev-update-oct-25-3.gif" alt="Envio Showcase page featuring live demos built with HyperIndex and HyperSync, including v4.xyz, Stable Volume, and Oracle Wars" width="100%"/>
 
 We launched a new showcase page highlighting live demos built with HyperIndex and HyperSync. From real-time dashboards to onchain visualizations, it's a growing collection of projects built by the community and team to show what's possible with Envio.
 
@@ -152,7 +152,7 @@ Explore the [Showcase](https://docs.envio.dev/showcase) in our documentation.
 
 ## Empowering Builders with Real-Time Indexing | Encode London 2025
 
-<img src="/blog-assets/dev-update-oct-25-4.png" alt="encode london 2025" width="100%"/>
+<img src="/blog-assets/dev-update-oct-25-4.png" alt="Encode London 2025 partner banner announcing Envio's $3,000 bounty" width="100%"/>
 
 Envio joined [Encode London](https://luma.com/Encode-London-25) 2025 as a partner, offering $3K in bounties to support builders throughout the weekend hackathon.
 
@@ -172,7 +172,7 @@ Well done to all the builders and a big shoutout to the Encode team and organize
 
 ## Featured Developer
 
-<img src="/blog-assets/dev-update-oct-25-5.png" alt="DOTM 2025" width="100%"/>
+<img src="/blog-assets/dev-update-oct-25-5.png" alt="Envio Featured Developer banner for Enguerrand with a headshot on a purple circuit board background" width="100%"/>
 
 This month's featured developer is Enguerrand, a builder with a strong focus on low level tech and decentralized solutions to real world problems.
 
@@ -191,7 +191,7 @@ Be sure to follow them on [X](https://x.com/enguerrandpp) and check out their wo
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-oct-25-6.png" alt="PLOTM Oct 2025" width="100%"/>
+<img src="/blog-assets/dev-update-oct-25-6.png" alt="Spotify public playlist cover for 'Oct 25' by Jordy Baby, 21 songs, 1 hr 19 min" width="100%"/>
 
 
 [Open Spotify](https://open.spotify.com/playlist/01eyMwoIMDEmcDjuFJsuhm?si=0319312d9a2d4499)

--- a/blog/2025-11-12-encode-london-2025.md
+++ b/blog/2025-11-12-encode-london-2025.md
@@ -21,7 +21,7 @@ The results spoke for themselves.
 
 ## Best use of HyperIndex ($1,000): VeriLoan
 
-<img src="/blog-assets/encode-london-2025-1.png" alt="VeriLoan - Best use of HyperIndex" width="100%"/>
+<img src="/blog-assets/encode-london-2025-1.png" alt="GitHub repo card for LuLuKar05/VeriLoan: trustworthy borrower profiles for DeFi" width="100%"/>
 
 **Team:** Myo Myat
 
@@ -34,7 +34,7 @@ VeriLoan solves one of DeFi's biggest problems: trust. It connects [Concordium](
 
 ## Best use of HyperSync ($1,000): Sniffer
 
-<img src="/blog-assets/encode-london-2025-2.png" alt="Sniffer - Best use of HyperSync" width="100%"/>
+<img src="/blog-assets/encode-london-2025-2.png" alt="GitHub repo card for Junaid2005/encode-hack-nov: Sniff out blockchain fraud, leveraging Envio HyperSync and AI" width="100%"/>
 
 **Team:** Abdul Aaqib Ali
 
@@ -47,7 +47,7 @@ Sniffer uses Envio HyperSync and GPT 5 to make blockchain forensics conversation
 
 ## Best use of HyperIndex Runner Up ($500): TradeTrackr
 
-<img src="/blog-assets/encode-london-2025-3.png" alt="TradeTrackr - Best use of HyperIndex Runner Up" width="100%"/>
+<img src="/blog-assets/encode-london-2025-3.png" alt="GitHub repo card for Cozkou/portfi, the TradeTrackr social trading project" width="100%"/>
 
 **Team:** Xferno GT
 

--- a/blog/2025-11-13-metamask-smart-accounts-hackathon-winners.md
+++ b/blog/2025-11-13-metamask-smart-accounts-hackathon-winners.md
@@ -10,7 +10,7 @@ last_update:
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/metamask-hackathon-2025.png" alt="Metamask Dev-cook off 2025 Hackathon Winners" width="100%"/>
+<img src="/blog-assets/metamask-hackathon-2025.png" alt="Envio cover banner: Smart Accounts Hackathon Winners, $15,000 prize pool" width="100%"/>
 
 <!--truncate-->
 
@@ -22,7 +22,7 @@ The projects below stood out across innovation, execution quality, and use of En
 
 ## Best use of Envio ($2,000): Last Monad
 
-<img src="/blog-assets/metamask-hackathon-2025-1.png" alt="Last monad" width="100%"/>
+<img src="/blog-assets/metamask-hackathon-2025-1.png" alt="GitHub repo card for jerrymusaga/last-monad, an on-chain multiplayer elimination game on Monad" width="100%"/>
 
 Last Monad built a live network dashboard that showcases activity across Monad in real-time. Using Envio to index contract events with high speed and accuracy, the team delivered an always up to date view of the chain.
 
@@ -30,7 +30,7 @@ The project shows how real-time blockchain indexers like Envio unlock transparen
 
 ## Best Onchain Automation ($1,000): TradeClub
 
-<img src="/blog-assets/metamask-hackathon-2025-2.png" alt="tradeclub" width="100%"/>
+<img src="/blog-assets/metamask-hackathon-2025-2.png" alt="GitHub repo card for DxcMint868/trade-club-liquidator, a social trading degen engine for EVM blockchains" width="100%"/>
 
 TradeClub introduced automated onchain execution powered by smart accounts. The project used Envio to index their data to power intent based triggers and automated flows, allowing users to run actions without managing complex backend logic.
 
@@ -38,7 +38,7 @@ It highlights how real-time data from Envio's blockchain indexing solution can s
 
 ## Best AI Agent ($1,000): ShieldAI
 
-<img src="/blog-assets/metamask-hackathon-2025-3.png" alt="ShieldAi" width="100%"/>
+<img src="/blog-assets/metamask-hackathon-2025-3.png" alt="GitHub repo card for officialcmg/shieldai-monad, an AI-powered autonomous wallet guardian" width="100%"/>
 
 ShieldAI built an onchain monitoring agent that reacts to blockchain events on Monad in real-time. With Envio providing reliable, indexed data, the agent could track contract interactions, detect anomalies, and surface insights efficiently.
 
@@ -46,7 +46,7 @@ It shows how AI agents become significantly more powerful when they can rely on 
 
 ## Best Consumer App ($1,000): Smart Account Explorer
 
-<img src="/blog-assets/metamask-hackathon-2025-4.png" alt="Smart account explorer" width="100%"/>
+<img src="/blog-assets/metamask-hackathon-2025-4.png" alt="GitHub repo card for prevostc/soa-delegation-tracker, the Smart Account Explorer project" width="100%"/>
 
 Smart Account Explorer created a clear interface for viewing and understanding smart account activity. With Envio's real-time blockchain indexing layer handling the heavy lifting, the app delivered fast lookups of permissions, transactions, and account behaviour without any lag. It made smart accounts feel accessible and transparent for everyday users.
 

--- a/blog/2025-11-26-dev-update-november-2025.md
+++ b/blog/2025-11-26-dev-update-november-2025.md
@@ -76,7 +76,7 @@ export const getMetadata = createEffect(
 
 The Development Console now shows detailed performance metrics for every Effect API execution. You can see execution time, rate limits, and caching behaviour at a glance, making it much easier to debug and fine tune performance. A simple way to get more visibility and improve your indexer.
 
-<img src="/blog-assets/dev-update-nov-25-1.png" alt="Dev console" width="100%"/>
+<img src="/blog-assets/dev-update-nov-25-1.png" alt="HyperIndex Development Console showing Effects and Storage Reads performance metrics with call counts, batched percentages and execution times" width="100%"/>
 
 
 ### New getWhere.lt Query
@@ -114,7 +114,7 @@ For a full walkthrough on how to migrate, read our guide on [How to Migrate Alch
 
 ## MetaMask x Envio Advanced Permissions Hackathon is Live 
 
-<img src="/blog-assets/dev-update-nov-25-4.png" alt="MetaMask x Envio hackathon" width="100%"/>
+<img src="/blog-assets/dev-update-nov-25-4.png" alt="MetaMask Advanced Permissions Edition hackathon banner with $10,000 prize pool in partnership with Envio" width="100%"/>
 
 We have partnered with MetaMask for the Advanced Permissions Dev Cook-Off hackathon, inviting developers to build with ERC-7715 and ship new agent and automation ideas. The hack is now live with $10,000 in total prizes available.
 
@@ -132,7 +132,7 @@ Check the original post on [X](https://x.com/DenhamPreen/status/1988980819629863
 
 ## How to Monetize HyperSync Queries using x402
 
-<img src="/blog-assets/dev-update-nov-25-6.png" alt="Monetize HyperSync Queries using x402" width="100%"/>
+<img src="/blog-assets/dev-update-nov-25-6.png" alt="GitHub repo card for nikbhintade/x402-hypersync with the description monetize your hypersync queries with x402" width="100%"/>
 
 A new demo went live this month showing how analysts and builders can monetize their HyperSync queries using [x402](https://www.x402.org). The project combines HyperSync's fast querying and filtering across multiple networks with x402's pay per request model to create simple monetizable blockchain APIs. The example lets users fetch token transfer history for any address across all HyperSync supported networks, with optional filtering by token.
 
@@ -141,7 +141,7 @@ Explore the demo or try it yourself on [GitHub](https://github.com/nikbhintade/x
 
 ## Devconnect and Edge City | Argentina 
 
-<img src="/blog-assets/dev-update-nov-25-7.png" alt="Envio at Devconnect & Edge City" width="100%"/>
+<img src="/blog-assets/dev-update-nov-25-7.png" alt="Empty Devconnect Buenos Aires main hall with rows of chairs facing the lit stage and Devconnect signage" width="100%"/>
 
 The team recently attended [Edge City](https://www.edgecity.live/patagonia) in Patagonia, spending time with builders and getting a closer look at what teams are working on across the ecosystem. It was a good mix of conversations, working sessions and meeting new faces.
 
@@ -152,7 +152,7 @@ We wrapped up the month at Devconnect Buenos Aires, taking part in the sessions 
 
 ## Encode Hackathon: Envio's Winners 
 
-<img src="/blog-assets/dev-update-nov-25-8.png" alt="Encode x Envio hackathon" width="100%"/>
+<img src="/blog-assets/dev-update-nov-25-8.png" alt="Envio Hackathon Winners banner for Encode London 2025 with Encode Club logo" width="100%"/>
 
 Envio partnered with Encode Club at Encode London 2025 and awarded $3,000 in bounties for builders using HyperIndex and HyperSync. The winners included:
 
@@ -169,7 +169,7 @@ Congratulations to all the builders who took part and big thanks to the Encode t
 
 ## High Performance Indexing on Sonic with HyperSync
 
-<img src="/blog-assets/dev-update-nov-25-9.png" alt="ComparNodes HyperSync Sonic benchmark" width="100%"/> 
+<img src="/blog-assets/dev-update-nov-25-9.png" alt="Compare Nodes benchmark dashboard for Envio HyperSync on Sonic showing 5.25K req/s peak, 2.67 million total successes and 100% success rate" width="100%"/> 
 
 Building on Sonic? Envio keeps up.
 
@@ -191,7 +191,7 @@ See Rootstock's original post on [X](https://x.com/rootstock_io/status/199144621
 
 ## MetaMask Smart Accounts x Monad x Envio Hackathon Winners
 
-<img src="/blog-assets/dev-update-nov-25-10.png" alt="MetaMask x Envio hack winners #1" width="100%"/>
+<img src="/blog-assets/dev-update-nov-25-10.png" alt="MetaMask Smart Accounts Hackathon Winners banner with $15,000 prize pool in partnership with MetaMask and Monad" width="100%"/>
 
 We partnered with [MetaMask](https://metamask.io/en-GB/developer) and [Monad](https://www.monad.xyz/brand-and-media-kit) for the Smart Accounts hackathon, which featured a total prize pool of $15,000. This hackathon focused on the next generation of wallet and smart account experiences. Builders explored account abstraction, modular execution, AI driven automation and real-time blockchain indexing using Envio.
 
@@ -223,7 +223,7 @@ Be sure to follow them on [X](https://x.com/Slutsky___) and check out their work
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-nov-25-12.png" alt="PLOTM Nov 2025" width="100%"/> 
+<img src="/blog-assets/dev-update-nov-25-12.png" alt="Spotify public playlist Nov 25 by Jordy Baby with 27 songs and 1 hr 39 min runtime" width="100%"/> 
 
 [Open Spotify](https://open.spotify.com/playlist/5soTYYQq62La4bssYRdwzH?si=d1e1faa2d3bf44bd)
 

--- a/blog/2025-12-16-dev-update-december-2025.md
+++ b/blog/2025-12-16-dev-update-december-2025.md
@@ -178,7 +178,7 @@ If you need support reindexing or redeploying after the re-genesis, feel free to
 
 ## Envio at Solana Breakpoint 2025 in Abu Dhabi
 
-<img src="/blog-assets/dev-update-dec-25-2.png" alt="Solana Breakpoint 2025" width="100%"/>
+<img src="/blog-assets/dev-update-dec-25-2.png" alt="Exterior of Etihad Arena in Abu Dhabi, venue for Solana Breakpoint 2025" width="100%"/>
 
 The Envio team attended [Solana Breakpoint](https://solana.com/breakpoint) in Abu Dhabi this month, spending time with teams across the Solana ecosystem and learning more about their data needs and how they're building on Solana.
 
@@ -191,7 +191,7 @@ Big thanks to everyone we met and spoke with at Solana Breakpoint. We're looking
 
 ## Envio Developer Workshops: Decypted Bytes Is Back
 
-<img src="/blog-assets/dev-update-dec-25-3.png" alt="Decrypt Bytes" width="100%"/>
+<img src="/blog-assets/dev-update-dec-25-3.png" alt="YouTube thumbnail grid of Decypted Bytes streams covering the Base-Solana Bridge Indexer, USDT0 Indexer with HyperIndex, and DuckDB Sink for HyperSync" width="100%"/>
 
 Decypted Bytes streams are back and now running daily at 3:00pm UTC, focused on hands-on developer workflows using Envio.
 
@@ -220,7 +220,7 @@ To get started and learn how to index data on Tempo, check out the [setup guide]
 
 ## How to Index Cross-Chain USDT0 Transfers with Envio
 
-<img src="/blog-assets/dev-update-dec-25-5.png" alt="Index USDT0 with Envio" width="100%"/>
+<img src="/blog-assets/dev-update-dec-25-5.png" alt="GitHub repo card for enviodev/usdt0-indexer: Index cross-chain USDT transfers done with USDT0" width="100%"/>
 
 Learn how to build a [USDT0](https://usdt0.to) Indexer using Envio by exploring this example repository, which demonstrates how to track USDT0 transfers across multiple chains.
 
@@ -231,7 +231,7 @@ You can explore the full example, code, and setup instructions in the [GitHub re
 
 ## Envio Powers Slab.cash with Efficient Data Indexing
 
-<img src="/blog-assets/dev-update-dec-25-6.png" alt="Slab Cash" width="100%"/>
+<img src="/blog-assets/dev-update-dec-25-6.png" alt="Metallic Slab.cash logo emblem lit with red and blue neon" width="100%"/>
 
 [Slab.cash](https://slab.cash) recently went live, bringing onchain collectibles to users.
 
@@ -268,7 +268,7 @@ The MetaMask Advanced Permissions Hackathon is live and runs until December 31, 
 
 ## Featured Developer: Port
 
-<img src="/blog-assets/dev-update-dec-25-7.png" alt="DOTM Dec 2025" width="100%"/>
+<img src="/blog-assets/dev-update-dec-25-7.png" alt="Envio Featured Developer banner for Port, with their avatar over a desk setup with multiple monitors" width="100%"/>
 
 This month's featured developer is Port, a builder who loves experimenting with ideas and shipping fast. His journey into development started a few years ago after a health scare, which pushed him to rethink how he wanted to spend his time. Coming from a non-technical background, he began learning web development through The Odin Project and quickly found his way into Web3.
 
@@ -292,7 +292,7 @@ We're wishing many of you a fantastic time over the festive season. The Envio te
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-dec-25-9.png" alt="PLOTM Dec 2025" width="100%"/>
+<img src="/blog-assets/dev-update-dec-25-9.png" alt="Spotify public playlist 'Dec 25' by Jordy Baby, 21 songs, 1 hr 21 min" width="100%"/>
 
 [Open Spotify](https://open.spotify.com/playlist/757HncfHabgU6rpMv9748b?si=94a19e83ccdc4f0d)
 

--- a/blog/2026-01-28-dev-update-january-2026.md
+++ b/blog/2026-01-28-dev-update-january-2026.md
@@ -116,7 +116,7 @@ The ERC20 template has been updated to be multichain and includes the new testin
 
 The improved init flow can include additional setup options from upcoming releases, such as configured GitHub CI and an [AGENTS.md](http://agents.md/) file to support LLM-based development.
 
-<img src="/blog-assets/dev-update-jan-26-1.png" alt="Envio init improvements" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-1.png" alt="Terminal output from envio init showing prompts for folder name, blockchain ecosystem, initialization option, and ABI source" width="100%"/>
 
 
 ### Expose Indexer Config & State
@@ -129,7 +129,7 @@ New official types are also introduced:
 
 **<code>Indexer</code>**, **<code>EvmChainId</code>**, **<code>FuelChainId</code>**, **<code>SvmChainId</code>**.
 
-<img src="/blog-assets/dev-update-jan-26-2.png" alt="Expose Indexer Config & State" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-2.png" alt="Code snippet importing the indexer object from generated and accessing chainIds, chains, startBlock, isLive, and PoolManager contract data" width="100%"/>
 
 ### Automatic Contract Configuration
 
@@ -137,7 +137,7 @@ V3 automatically configures all globally defined contracts.
 
 Globally defined contracts are handled automatically, even when they aren’t linked to a specific chain or address.
 
-<img src="/blog-assets/dev-update-jan-26-3.png" alt="Automatic Contract Configuration" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-3.png" alt="YAML config diff showing UniswapV3Pool entries removed from per-chain contracts because global contracts are now auto-configured" width="100%"/>
 
 
 ### Conditional Event Handlers
@@ -146,7 +146,7 @@ V3 allows event handlers to be enabled or disabled conditionally.
 
 You can now return a boolean value from the eventFilters function to control whether a handler runs.
 
-<img src="/blog-assets/dev-update-jan-26-4.png" alt="Conditional Event Handlers" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-4.png" alt="ERC20.Transfer handler code using eventFilters with chainId to skip Polygon, track all on Ethereum Mainnet, and whitelist addresses on other chains" width="100%"/>
 
 ### TUI Love
 
@@ -154,7 +154,7 @@ V3 brings updates to the TUI, making it even more beautiful & compact.
 
 It uses fewer resources, shares a link to the Hasura playground, and adjusts dynamically to the terminal width.
 
-<img src="/blog-assets/dev-update-jan-26-5.png" alt="TUI" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-5.png" alt="Envio TUI showing pixel art ENVIO logo with per-chain progress bars for chains 1, 143 and 8453, total events and GraphQL and Dev Console links" width="100%"/>
 
 ### Envio API Token Required
 
@@ -177,7 +177,7 @@ For a deeper dive into everything included so far, be sure to check out the full
 
 ## Indexing Data on Injective
 
-<img src="/blog-assets/dev-update-jan-26-6.png" alt="Indexing Data on Injective" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-6.png" alt="Envio and Injective co-branded banner with both logos on a purple background" width="100%"/>
 
 Envio proudly supports developers and analysts building on [Injective](https://injective.com) by providing efficient access to real-time and historical onchain data to help teams build robust apps on Injective.
 
@@ -186,7 +186,7 @@ With Envio, teams can sync and query Injective data and define fully customizabl
 
 ## Migrating Production Subgraphs: Polymarket Indexer
 
-<img src="/blog-assets/dev-update-jan-26-7.png" alt="Polymarket indexer" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-7.png" alt="GitHub repo card for enviodev/polymarket-indexer with the tagline Index Polymarket events with HyperIndex" width="100%"/>
 
 A common question we hear is what migrating a real production subgraph setup actually looks like in practice.
 
@@ -201,7 +201,7 @@ The full implementation is available here:
 
 ## Blockchain Indexer For Application Backends
 
-<img src="/blog-assets/blockchain-indexer-backends.png" alt="Blockchain Indexer asset" width="100%"/>
+<img src="/blog-assets/blockchain-indexer-backends.png" alt="Envio cover graphic titled Blockchain Indexer For Application Backends with subtitle A Practical Overview" width="100%"/>
 
 Indexers are a core part of most application backends, sitting between the blockchain and the app. By transforming raw onchain data into structured, queryable state, indexing removes a lot of complexity from backend logic and makes applications easier to build and scale as they grow. Envio fits into this workflow by providing a consistent indexing layer teams can use from local development through production, without changing how their backend logic is defined.
 
@@ -210,7 +210,7 @@ For more details, read the full [blog](https://docs.envio.dev/blog/blockchain-in
 
 ## Envio Powers Funnel with Efficient Data Indexing
 
-<img src="/blog-assets/dev-update-jan-26-9.png" alt="Envio & Funnel" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-9.png" alt="Envio and Funnel co-branded banner with both logos on a dark blue background" width="100%"/>
 
 [Funnel](https://funnel.markets/) is back after completing a successful backend migration to Envio, which has improved the performance and reliability of the onchain data powering their application heading into 2026.
 
@@ -230,7 +230,7 @@ See this post on [X](https://x.com/funnel_markets/status/2009670839940329711) fo
 
 ## Featured Developer: Zod
 
-<img src="/blog-assets/dev-update-jan-26-10.png" alt="DOTM Jan 2026" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-10.png" alt="Envio Featured Developer banner for Zod with a portrait photo over a purple developer workstation backdrop" width="100%"/>
 
 This month’s featured developer is Zod. They’ve been building for a few decades and working onchain since 2019. Over the past year, they’ve been actively using tools like Cursor and exploring in-the-loop agentic development.
 
@@ -245,7 +245,7 @@ Well done, Zod. Be sure to check out Scale and follow the team on [X](https://x.
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-jan-26-11.png" alt="PLOTM Jan 2026" width="100%"/>
+<img src="/blog-assets/dev-update-jan-26-11.png" alt="Spotify public playlist card titled Jan 26 by Jordy Baby with 21 songs and 1 hr 27 min runtime" width="100%"/>
 
 ▶ [Open Spotify](https://open.spotify.com/playlist/3LismooWdej6nDxwY9486d?si=00ab83ef26874d81)
 

--- a/blog/2026-02-25-dev-update-february-2026.md
+++ b/blog/2026-02-25-dev-update-february-2026.md
@@ -165,7 +165,7 @@ For information, be sure to check out the full release notes. More updates comin
 
 ## Indexing Data on MegaEth Mainnet
 
-<img src="/blog-assets/dev-update-feb-26-1.gif" alt="MegaEth Mainnet" width="100%"/>
+<img src="/blog-assets/dev-update-feb-26-1.gif" alt="MegaETH mainnet website with animated radar showing live TPS and total transactions counter" width="100%"/>
 
 [MegaETH](https://rabbithole.megaeth.com) launched its public Mainnet on February 9, 2026, marking the transition from testnet experimentation to a live production network. As a performance focused Ethereum Layer 2, MegaETH is built to support high throughput and low latency execution for onchain applications.
 
@@ -189,7 +189,7 @@ Be sure to check out the series on [YouTube](https://www.youtube.com/@decryptedb
 
 ## Tyde Terminal Tide Visualiser
 
-<img src="/blog-assets/dev-update-feb-26-3.gif" alt="Tyde" width="100%"/>
+<img src="/blog-assets/dev-update-feb-26-3.gif" alt="Tyde terminal app rendering an animated ASCII tide scene with a 24-hour tide chart for Cape Town" width="100%"/>
 
 
 Tyde is an open source terminal based tool that visualises real world tide levels directly in the command line. It renders an animated tide scene with waves, sand, and foam, alongside a 24-hour tide chart showing the current position in the cycle. Sunrise and sunset times are also displayed, with support for a day and night cycle.
@@ -219,7 +219,7 @@ For more information, see the original [post](https://x.com/envio_indexer/status
 
 ## Envio Alerts: Uniswap v4 Alert Bots
 
-<img src="/blog-assets/dev-update-feb-26-5.png" alt="Envio alert bots" width="100%"/>
+<img src="/blog-assets/dev-update-feb-26-5.png" alt="Telegram feeds for the Uniswap v4 MEV Alerts and Liquid Token Alerts bots posting $1M TVL pool alerts" width="100%"/>
 
 
 Get automated alerts when a Uniswap v4 pool crosses 1m in TVL, including when an MEV bot trade causes the threshold to be hit.
@@ -244,7 +244,7 @@ Be sure to join the bot groups on Telegram to receive alerts in real-time and st
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-feb-26-7.png" alt="PLOTM Feb 2026" width="100%"/>
+<img src="/blog-assets/dev-update-feb-26-7.png" alt="Spotify public playlist titled 'Feb 26' by Jordy Baby with 22 songs spanning 1 hr 23 min" width="100%"/>
 
 ▶ [Open Spotify](https://open.spotify.com/playlist/0CNf2YeAWBGUii76h6xilv?si=575e6a3e76c844b5)
 

--- a/blog/2026-03-20-agentic-blockchain-indexing.md
+++ b/blog/2026-03-20-agentic-blockchain-indexing.md
@@ -127,7 +127,7 @@ Check the live deployment from this demo here:
 
 **400,000 events indexed. ~20 seconds**
 
-<img src="/blog-assets/agentic-blockchain-indexing-1.png" alt="Cover Image Agentic Blockchain Indexing" width="100%"/>
+<img src="/blog-assets/agentic-blockchain-indexing-1.png" alt="Envio Cloud deployment dashboard showing the wstETH Monad indexer live, 463,275 events processed and 100% synced in 1 minute" width="100%"/>
 
 See the full walkthrough on [Loom](https://www.loom.com/share/09cdac43b18f4143ad78b18c8c8a492b), covering the complete agent driven workflow from scaffold to deployment.
 

--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -9,7 +9,7 @@ last_update:
   author: Jords
 ---
 
-<img src="/blog-assets/best-blockchain-indexers.png" alt="Cover Image Best Blockchain Indexers" width="100%"/>
+<img src="/blog-assets/best-blockchain-indexers.png" alt="Envio cover graphic with a podium and the title Best Blockchain Indexers, Real Benchmark Comparison" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2026-03-23-dev-update-march-2026.md
+++ b/blog/2026-03-23-dev-update-march-2026.md
@@ -110,7 +110,7 @@ Learn more in our blog and test it yourself here: [https://docs.envio.dev/blog/a
 
 ## Host your subgraphs on Envio
 
-<img src="/blog-assets/dev-update-march-2026-2.png" alt="Host your subgraphs on Envio" width="100%"/>
+<img src="/blog-assets/dev-update-march-2026-2.png" alt="Envio subgraph hosting page headlined 143x Faster Subgraph Deployments with How it works and What you get checklists" width="100%"/>
 
 Deploy and host your subgraphs with HyperIndex, with a fully subgraph-compatible GraphQL endpoint and no client changes required.
 
@@ -123,7 +123,7 @@ Get started on Discord - open a support ticket: [https://discord.gg/envio](https
 
 ## Heatbook: Polymarket Orderbooks as Heatmaps
 
-<img src="/blog-assets/dev-update-march-2026-3.png" alt="Heatbook" width="100%"/>
+<img src="/blog-assets/dev-update-march-2026-3.png" alt="Heatbook orderbook heatmap for the Polymarket market Will Donald Trump win the 2024 US Presidential Election" width="100%"/>
 
 An interface for visualising Polymarket orderbooks using historical heatmaps. Orderbook heatmaps for prediction markets, with 115M+ fills visualised. View any market and explore activity over time.
 
@@ -134,7 +134,7 @@ See original post: [https://x.com/jonjonclark/status/2031016707309949042?s=20](h
 
 ## EthCC[9]: Sapphire Sponsor
 
-<img src="/blog-assets/dev-update-march-2026-4.png" alt="EthCC sponsorship" width="100%"/>
+<img src="/blog-assets/dev-update-march-2026-4.png" alt="Envio Sapphire Sponsor banner for EthCC[9] at Palais des Festivals Cannes, March 30 to April 2, 2026" width="100%"/>
 
 Envio is a Sapphire sponsor of [EthCC[9]](https://ethcc.io), taking place at Palais des Festivals in Cannes from March 30 to April 2, 2026.
 
@@ -146,7 +146,7 @@ P.S. be sure to get your hands on one of our snazzy Envio caps and stickers.
 
 ## Developer contributions: Uniswap CCA indexer
 
-<img src="/blog-assets/dev-update-march-2026-5.png" alt="Uniswap CCA indexer" width="100%"/>
+<img src="/blog-assets/dev-update-march-2026-5.png" alt="GitHub repo card for dzmbs/uniswap-cca-indexer, an Envio HyperIndex indexer for Uniswap Continuous Clearing Auction contracts" width="100%"/>
 
 Check out this Uniswap CCA indexer built with HyperIndex to index continuous clearing auction contracts across Ethereum, Base, Arbitrum, and Unichain. It tracks auctions, bids, ticks, steps, and checkpoints, using HyperSync for logs and selective RPC reads for derived onchain state.
 
@@ -168,7 +168,7 @@ We're reopening it to benchmark new use cases and warmly welcome all contributio
 
 ## Wonderland CTF
 
-<img src="/blog-assets/dev-update-march-2026-6.png" alt="Wonderland CTF" width="100%"/>
+<img src="/blog-assets/dev-update-march-2026-6.png" alt="Wonderland CTF 2026 sponsor banner listing Grego AI, Envio, runtime verification, and Pashov Audit Group" width="100%"/>
 
 Envio is a proud sponsor of the Wonderland CTF. The event takes place on April 1, 2026, in person at EthCC[9] in Cannes.
 
@@ -223,7 +223,7 @@ Well done, Praveen. Be sure to follow the team on [X](https://x.com/hpmszk) and 
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-march-2026-10.png" alt="Playlist of the month" width="100%"/>
+<img src="/blog-assets/dev-update-march-2026-10.png" alt="Spotify public playlist Mar 26 by Jordy Baby, 19 songs, 1 hr 14 min" width="100%"/>
 
 ▶ [Open Spotify](https://open.spotify.com/playlist/240pHTCbwvf6kBMdfWGmw9?si=bb40d616e82a49f3)
 

--- a/blog/2026-03-24-track-polymarket-trades-hypersync.md
+++ b/blog/2026-03-24-track-polymarket-trades-hypersync.md
@@ -79,7 +79,7 @@ If you’re new to HyperSync clients, please start by going through these exampl
 
 Let’s discuss how we are going to structure our script. Instead of streaming events directly, we are going to stream height. When we get a new height, we query HyperSync to fetch the data we need. Here is a visual representation of that:
 
-![Visual representation of the script's data flow](/blog-assets/polymarket-data-flow.png)
+![Sequence diagram showing index.ts streaming new block heights from HyperSync and querying OrderFilled events on each new height](/blog-assets/polymarket-data-flow.png)
 
 ## Stream Height
 
@@ -407,7 +407,7 @@ Run the following command in your terminal:
 pnpx poly-whales
 ```
 
-![poly-whales TUI screenshot](/blog-assets/poly-whales-tui.png)
+![Terminal UI titled "Polymarket Whale Tracker" with a $500 threshold panel, watch addresses panel, and a live trades list of BUY orders with USD amounts, maker addresses, and timestamps](/blog-assets/poly-whales-tui.png)
 
 ## Frequently Asked Questions
 

--- a/blog/2026-03-25-polymarket-hyperindex-case-study.md
+++ b/blog/2026-03-25-polymarket-hyperindex-case-study.md
@@ -133,7 +133,7 @@ The indexer synced Polymarket's full onchain history on Polygon from block 3,764
 
 Run it locally with `pnpm dev` and compare the data with data from Polymarket subgraphs.
 
-<img src="/blog-assets/polymarket-hyperindex-case-study-1.png" alt="Polymarket indexer sync results" width="100%"/>
+<img src="/blog-assets/polymarket-hyperindex-case-study-1.png" alt="Envio dashboard for the Polymarket indexer showing 4,119,162,600 events processed, 6 days historical sync time, and Polygon Mainnet 100% synced" width="100%"/>
 
 Live deployment: [https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad](https://envio.dev/app/moose-code/polymarket-indexer/7cad3ad)
 

--- a/blog/2026-04-24-native-transfers.md
+++ b/blog/2026-04-24-native-transfers.md
@@ -11,7 +11,7 @@ last_update:
   author: Nikhil Bhintade
 ---
 
-![Cover image for the blog with title](/blog-assets/tracking-native-eth-transfers-hypersync.png)
+![Envio blog cover with title "Tracking Native ETH Transfers Using HyperSync" and a network of linked Ethereum nodes](/blog-assets/tracking-native-eth-transfers-hypersync.png)
 :::info TL;DR
 
 - Tracking native ETH transfers onchain requires parsing traces rather than event logs, which is slow over standard RPC.
@@ -178,7 +178,7 @@ Run it with:
 bun run index.ts
 ```
 
-![Output table showing native transfers](/blog-assets/native-transfers-cli-output.png)
+![Terminal output from `bun run index.ts` showing a table of 10 native ETH transfers with From, To, and Value (ETH) columns](/blog-assets/native-transfers-cli-output.png)
 
 ## Next Steps
 

--- a/blog/2026-04-28-dev-update-april-2026.md
+++ b/blog/2026-04-28-dev-update-april-2026.md
@@ -79,7 +79,7 @@ describe("ERC20 indexer", () => {
 
 ### Experimental ClickHouse Sink
 
-<img src="/blog-assets/dev-update-april-2026-1.png" alt="Experimental ClickHouse Sink" width="100%"/>
+<img src="/blog-assets/dev-update-april-2026-1.png" alt="Envio banner titled 'Using ClickHouse Sink' with 'HyperIndex V3' subtitle" width="100%"/>
 
 HyperIndex V3 Alpha introduces an experimental ClickHouse Sink. Postgres remains the primary database, with your entity data additionally replicated to ClickHouse for analytics workloads.
 
@@ -101,7 +101,7 @@ Star us on [GitHub](https://github.com/enviodev/hyperindex) ⭐
 
 ## The Top Hundred Polymarket Traders
 
-<img src="/blog-assets/dev-update-april-2026-2.png" alt="The Top Hundred Polymarket Traders" width="100%"/>
+<img src="/blog-assets/dev-update-april-2026-2.png" alt="Table titled 'Polymarket all-time realized PnL distribution' across 2,684,676 users analyzed, broken down by PnL bucket, users, percent of users, and aggregate PnL" width="100%"/>
 
 We released the Polymarket V2 Indexer this month, a drop-in reference for teams wanting to collect all v2 market data. It covers the new v2 markets end-to-end, designed to scale alongside Polymarket's growth.
 
@@ -117,7 +117,7 @@ Read the full breakdown: [https://x.com/jonjonclark/status/2049067586046816561?s
 
 ## Envio Docs MCP Server
 
-<img src="/blog-assets/dev-update-april-2026-3.png" alt="Envio Docs MCP Server" width="100%"/>
+<img src="/blog-assets/dev-update-april-2026-3.png" alt="Envio banner titled 'Introducing Docs MCP Server' with subtitle 'Live docs for your AI assistant' and AI assistant logos linked to a central node" width="100%"/>
 
 Envio docs now speak AI. Plug your AI coding assistant (Claude Code, Cursor, Copilot, and more) straight into our docs with the new Envio Docs MCP Server.
 
@@ -159,7 +159,7 @@ Big thanks to the EthCC team, sponsors, organisers, and volunteers for putting o
 
 ## Monad Traces Live on HyperSync
 
-<img src="/blog-assets/dev-update-april-2026-5.png" alt="Monad Traces Live on HyperSync" width="100%"/>
+<img src="/blog-assets/dev-update-april-2026-5.png" alt="GitHub repo card for enviodev/export-monad-traces with the Envio logo" width="100%"/>
 
 Monad traces are live on HyperSync, with full history from block 0.
 
@@ -207,7 +207,7 @@ More to come.
 
 ## Playlist of the Month
 
-<img src="/blog-assets/dev-update-april-2026-9.png" alt="Playlist of the month" width="100%"/>
+<img src="/blog-assets/dev-update-april-2026-9.png" alt="Spotify public playlist titled 'Apr 26' by Jordy Baby, 21 songs, 1 hr 28 min" width="100%"/>
 
 ▶ [Open Spotify](https://open.spotify.com/playlist/240pHTCbwvf6kBMdfWGmw9?si=bb40d616e82a49f3)
 

--- a/blog/2026-04-30-what-is-hypersync.md
+++ b/blog/2026-04-30-what-is-hypersync.md
@@ -10,7 +10,7 @@ last_update:
   author: Jordyn Laurier
 ---
 
-![Cover image for the What is HyperSync blog](/blog-assets/what-is-hypersync.png)
+!["What is HyperSync? The fastest way to query blockchain data" Envio blog cover](/blog-assets/what-is-hypersync.png)
 
 :::info TL;DR
 

--- a/blog/2026-05-06-revert-hyperindex-case-study.md
+++ b/blog/2026-05-06-revert-hyperindex-case-study.md
@@ -56,7 +56,7 @@ The indexer covers the full PancakeSwap V3 contract surface on BNB Smart Chain:
 
 Dynamic contract registration handles the Pool contracts. As new PancakeSwap V3 pools are created onchain by the Factory, the indexer registers them automatically without requiring a redeployment.
 
-<img src="/blog-assets/revert-hyperindex-case-study-2.png" alt="Revert Finance PancakeSwap V3 indexer running on Envio" width="100%"/>
+<img src="/blog-assets/revert-hyperindex-case-study-2.png" alt="Envio Cloud GraphQL playground showing a Position query and JSON response for the revert-indexer-2 deployment" width="100%"/>
 
 ## The Results
 

--- a/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
+++ b/blog/2026-05-14-ai-agents-acting-onchain-indexer.md
@@ -11,7 +11,7 @@ last_update:
   author: Jordyn Laurier
 ---
 
-<img src="/blog-assets/ai-agents-acting-onchain-indexer.png" alt="Why AI Agents Acting Onchain Need an Indexer" width="100%"/>
+<img src="/blog-assets/ai-agents-acting-onchain-indexer.png" alt="Envio blog cover: 'Why AI Agents Need an Indexer' with subtitle 'The data layer for onchain agents'" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2026-05-28-case-study-katana-sushiswap.md
+++ b/blog/2026-05-28-case-study-katana-sushiswap.md
@@ -8,7 +8,7 @@ image: /blog-assets/katana-sushiswap-case-study.png
 authors: ["j_o_r_d_y_s"]
 ---
 
-<img src="/blog-assets/katana-sushiswap-case-study.png" alt="How Katana Migrated SushiSwap Data from The Graph to Envio" width="100%"/>
+<img src="/blog-assets/katana-sushiswap-case-study.png" alt="Envio case study cover for Katana, headline reads Migrating SushiSwap Data Off The Graph" width="100%"/>
 
 <!--truncate-->
 

--- a/blog/2026-05-29-dev-update-may-2026.md
+++ b/blog/2026-05-29-dev-update-may-2026.md
@@ -280,7 +280,7 @@ This affects all HyperSync users and anyone self-hosting HyperIndex with a Hyper
 
 ## Polymarket's Top Traders Run on Indexed Data
 
-<img src="/blog-assets/dev-update-may-2026-14.png" alt="Polymarket's Top Traders Run on Indexed Data" width="100%"/>
+<img src="/blog-assets/dev-update-may-2026-14.png" alt="Banner reading 'The Top Hundred Polymarket Traders, Day 1: Bids on Everything'" width="100%"/>
 
 Co-founder Jonjon Clark published a data-driven series profiling the top 100 Polymarket traders by realised PnL, and the deeper he digs, the clearer it becomes that these operations live or die on fast, real-time access to onchain data, exactly the workload HyperIndex and HyperSync are built for. Here are a few that stand out.
 
@@ -292,7 +292,7 @@ $23.6M in realised PnL and a 95.4% win rate. It runs a live NBA model that price
 
 ### The 15-Minute Bitcoin Loop Trader
 
-<img src="/blog-assets/dev-update-may-2026-16.png" alt="The 15 minute Bitcoin loop Polymarket trader" width="100%"/>
+<img src="/blog-assets/dev-update-may-2026-16.png" alt="Scatter chart of buy and sell fills on a 15-minute Polymarket BTC binary, resolving UP redeems $1 and DOWN $0 at 03:15 UTC" width="100%"/>
 
 7.6 million fills across 32,021 markets in 111 days, about one fill per second, netting $2.38M. It posts resting bids on both sides of Polymarket's 15-minute BTC binaries and captures the spread off retail flow, completely indifferent to which way Bitcoin moves.
 
@@ -300,7 +300,7 @@ $23.6M in realised PnL and a 95.4% win rate. It runs a live NBA model that price
 
 ### The UMA Gap Trader
 
-<img src="/blog-assets/dev-update-may-2026-17.png" alt="The UMA gap Polymarket trader" width="100%"/>
+<img src="/blog-assets/dev-update-may-2026-17.png" alt="Histogram of every BUY by Polymarket wallet 0x8dcd…4eae showing 92% of buys land at $0.97 or above" width="100%"/>
 
 Number 26 on the leaderboard with $8M in lifetime realised PnL. Its cleanest mechanism is the settlement sweep, buying near-par winning tokens in the gap between when a result is known and when the UMA oracle finalises payout, for a 98.2% win rate across more than 4,000 positions.
 

--- a/blog/2026-06-02-index-sei-smart-contracts-envio.md
+++ b/blog/2026-06-02-index-sei-smart-contracts-envio.md
@@ -11,7 +11,7 @@ last_update:
   author: Jordyn Laurier
 ---
 
-<img src="/blog-assets/index-sei-smart-contracts-envio.png" alt="How to Index Sei Smart Contract Data in Minutes using Envio" width="100%"/>
+<img src="/blog-assets/index-sei-smart-contracts-envio.png" alt="Envio cover banner with Sei logo and headline 'Indexing Sei Data in Minutes: A step-by-step guide'" width="100%"/>
 
 <!--truncate-->
 


### PR DESCRIPTION
## Summary
- Replaces placeholder, project-name-only, and non-descriptive alt attributes with descriptions of what each image actually shows
- Covers 218 images across 51 blog posts
- No visible content changes; alt text only

## Test plan
- [ ] Spot-check a few posts on the deploy preview to confirm rendering is unchanged
- [ ] Confirm no Docusaurus build errors