### PR TITLE
Add v3.0.0 to Shipper's Logs

### DIFF
--- a/src/pages/videos.mdx
+++ b/src/pages/videos.mdx
@@ -11,6 +11,29 @@ Concise video recaps of every Envio release. Newest at the top. Skim the highlig
 
 ---
 
+## v3.0.0 — HyperIndex V3 Is Here 🚀
+
+<Video id="iptLiqa8eQ8" title="Envio v3.0.0" />
+
+Links: [What's new in V3](/docs/HyperIndex/whats-new-in-v3) · [GitHub release notes](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0) · [YouTube](https://www.youtube.com/watch?v=iptLiqa8eQ8)
+
+**Highlights**
+
+- 3× faster backfill (and faster still on v3.1 — ~50,000 events/sec on average)
+- New unified handlers API: `indexer.onEvent()` / `indexer.onBlock()` — no more generated package, `envio` package 88 MB smaller
+- Powerful `where` option: conditional event handlers, per-chain filters, and per-event start blocks
+- ESM migration with top-level `await` in handlers
+- Automatic handler registration from `src/handlers` — no more handler paths in config
+- New testing framework: run and snapshot-test your indexer programmatically, no live indexer needed
+- Experimental ClickHouse storage in dual mode with Postgres (supported on Envio Cloud dedicated plans)
+- HyperSync source improvements: server-side events replace polling, query cache (up to 90% egress reduction for self-hosters)
+- RPC source for real-time indexing with experimental WebSocket support
+- Experimental Solana support via slot handlers, plus block-handler-only indexers
+- pnpm no longer required — use npm, yarn, bun, or any package manager
+- Official Prometheus metrics endpoint and a cleaner TUI with live events/sec
+
+---
+
 ## v2.32.0 — Effect API Graduation, Console Insights, New Query
 
 <Video id="yvUVzV1ifig" title="Envio v2.32.0" />

--- a/src/pages/videos.mdx
+++ b/src/pages/videos.mdx
@@ -15,7 +15,7 @@ Concise video recaps of every Envio release. Newest at the top. Skim the highlig
 
 <Video id="iptLiqa8eQ8" title="Envio v3.0.0" />
 
-Links: [What's new in V3](/docs/HyperIndex/whats-new-in-v3) · [GitHub release notes](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0) · [YouTube](https://www.youtube.com/watch?v=iptLiqa8eQ8)
+Links: [What's new in V3](/docs/HyperIndex/whats-new-in-v3) · [Migrate to V3](/docs/HyperIndex/migrate-to-v3) · [GitHub release notes](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0) · [Introducing V3 (YouTube)](https://www.youtube.com/watch?v=iptLiqa8eQ8) · [What's New in V3 (YouTube)](https://www.youtube.com/watch?v=UgyO-G5pDtg) · [Migrate to V3 (YouTube)](https://www.youtube.com/watch?v=Tv6oY2e1Fjs)
 
 **Highlights**
 

--- a/src/pages/videos.mdx
+++ b/src/pages/videos.mdx
@@ -15,7 +15,7 @@ Concise video recaps of every Envio release. Newest at the top. Skim the highlig
 
 <Video id="iptLiqa8eQ8" title="Envio v3.0.0" />
 
-Links: [What's new in V3](/docs/HyperIndex/whats-new-in-v3) · [Migrate to V3](/docs/HyperIndex/migrate-to-v3) · [GitHub release notes](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0) · [Introducing V3 (YouTube)](https://www.youtube.com/watch?v=iptLiqa8eQ8) · [What's New in V3 (YouTube)](https://www.youtube.com/watch?v=UgyO-G5pDtg) · [Migrate to V3 (YouTube)](https://www.youtube.com/watch?v=Tv6oY2e1Fjs)
+Links: [What's new in V3](/docs/HyperIndex/whats-new-in-v3) · [Migrate to V3](/docs/HyperIndex/migrate-to-v3) · [GitHub release notes](https://github.com/enviodev/hyperindex/releases/tag/v3.0.0) · [Introducing HyperIndex V3 (YouTube)](https://www.youtube.com/watch?v=iptLiqa8eQ8) · [V2 vs V3 Comparison (YouTube)](https://www.youtube.com/watch?v=UgyO-G5pDtg) · [Migrate V2 to V3 (YouTube)](https://www.youtube.com/watch?v=Tv6oY2e1Fjs)
 
 **Highlights**
 


### PR DESCRIPTION
## Summary
- Adds the v3.0.0 entry to the top of [Shipper's Logs](https://docs.envio.dev/videos) with the new release recap video ([iptLiqa8eQ8](https://youtu.be/iptLiqa8eQ8)).
- Matches the existing entry structure (heading, `<Video />`, Links line, Highlights bullets).

## Test plan
- [x] Local dev server compiles cleanly (`yarn start --port 3001`)
- [ ] Visual check at http://localhost:3001/videos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new v3.0.0 release section prominently featuring HyperIndex V3. This section includes an embedded video presentation, direct links to documentation, GitHub, and YouTube resources, along with a comprehensive list of v3.0.0's major features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->