### PR TITLE
docs: embed v3 walkthrough videos on Whats New + Migrate to V3 pages

### DIFF
--- a/docs/HyperIndex/migrate-to-v3.md
+++ b/docs/HyperIndex/migrate-to-v3.md
@@ -4,6 +4,7 @@ title: Migrate to HyperIndex V3
 sidebar_label: Migrate to V3 🚀
 slug: /migrate-to-v3
 description: Step-by-step instructions for upgrading an existing HyperIndex V2 project to V3.
+image: /docs-assets/og/HyperIndex/migrate-to-v3.png
 ---
 
 # Migrate to HyperIndex V3
@@ -15,6 +16,8 @@ Easiest path — prompt your AI tool (Claude/Cursor/Codex):
 ```
 Upgrade my indexer to V3 by following the migration instructions step by step https://docs.envio.dev/docs/HyperIndex/migrate-to-v3
 ```
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Tv6oY2e1Fjs" title="Migrate to HyperIndex V3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Step 0: Prepare on V2 (Recommended)
 

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -4,6 +4,7 @@ title: What's New in HyperIndex V3
 sidebar_label: What's New in V3 ✨
 slug: /whats-new-in-v3
 description: Discover the new features in HyperIndex V3 — the unified handlers API, ESM and top-level await, automatic handler registration, a new testing framework, ClickHouse storage, Solana support, and more.
+image: /docs-assets/og/HyperIndex/whats-new-in-v3.png
 ---
 
 # What's New in HyperIndex V3
@@ -13,6 +14,8 @@ description: Discover the new features in HyperIndex V3 — the unified handlers
 HyperIndex V3 focuses on modernizing the codebase and laying the foundation for many more months of development. This page describes everything that's new. To upgrade an existing project from V2, follow the [Migrate to V3](./migrate-to-v3) guide.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/UgyO-G5pDtg" title="What's New in HyperIndex V3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Tv6oY2e1Fjs" title="HyperIndex V3 vs V2" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## New Features
 

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -12,6 +12,8 @@ description: Discover the new features in HyperIndex V3 — the unified handlers
 
 HyperIndex V3 focuses on modernizing the codebase and laying the foundation for many more months of development. This page describes everything that's new. To upgrade an existing project from V2, follow the [Migrate to V3](./migrate-to-v3) guide.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/UgyO-G5pDtg" title="What's New in HyperIndex V3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## New Features
 
 ### Unified Handlers API


### PR DESCRIPTION
## Summary
- Embed the [What's New in HyperIndex V3 walkthrough](https://youtu.be/UgyO-G5pDtg) on the What's New in V3 page.
- Embed the [Migrate to HyperIndex V3 walkthrough](https://youtu.be/Tv6oY2e1Fjs) on the Migrate to V3 page.

## Test plan
- [ ] Pages render with the YouTube embeds in place
- [ ] CI build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added embedded YouTube videos to the "What's New in HyperIndex V3" documentation page
  * Added embedded YouTube video to the "Migrate to HyperIndex V3" guide
  * Enhanced documentation pages with Open Graph images for improved social media sharing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->