### PR TITLE
docs(solana): expand HyperIndex Solana guide

### DIFF
--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -76,8 +76,9 @@ chains:
 :::note No EVM-style global fields
 For Solana, several EVM top-level fields don't apply: `contracts`,
 `rollback_on_reorg`, `save_full_history`, `raw_events`, a global
-`field_selection`, and `address_format`. Reorg-related options are fixed off
-(Solana indexes finalized data). Field selection is **per-instruction** only
+`field_selection`, and `address_format`. Reorg handling isn't a config knob:
+the HyperSync source rolls back on reorg automatically, while the RPC source
+indexes finalized data only. Field selection is **per-instruction** only
 (see [field selection](#field-selection)).
 :::
 
@@ -128,7 +129,7 @@ instruction apart from the program's others.
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
 | `name` | ✅ | — | The instruction name. For Anchor IDL programs this should match the IDL instruction (the snake_cased name is used to derive the default discriminator). Also the key in `onInstruction({ instruction: "<name>" })`. |
-| `discriminator` | — | — | Hex bytes that identify the instruction (e.g. `"0xc1209b3341d69c81"`). See [discriminators](/docs/HyperIndex/solana/decoding#discriminators). Without it, the instruction matches purely on program + filters and isn't decoded by discriminator. |
+| `discriminator` | — | — | Hex bytes that identify the instruction (e.g. `"0xc1209b3341d69c81"`). **Modern Anchor IDLs (0.30+) embed it, so HyperIndex reads it automatically; legacy Anchor IDLs and native/inline-schema instructions need it set explicitly.** See [discriminators](/docs/HyperIndex/solana/decoding#discriminators). Without a discriminator (embedded or configured), the instruction matches purely on program + filters and isn't decoded by discriminator. |
 | `is_inner` | — | *unset* | `true` = inner (CPI) only, `false` = top-level only, **omitted = matches both**. |
 | `args` | — | — | Inline argument schema (Borsh), `{ name, type }` per arg. Requires `accounts` too. Mutually exclusive with the program's `idl`. See [supported types](/docs/HyperIndex/solana/decoding#supported-argument-types). |
 | `accounts` | — | — | Inline ordered list of account names. The Nth name labels the Nth account. Requires `args` too. |

--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -27,36 +27,38 @@ name: my-solana-indexer
 description: Index Jupiter swaps and Metaplex NFT mints
 ecosystem: svm
 chains:
-  - rpc: https://api.mainnet-beta.solana.com
-    hypersync_config:
-      url: https://solana.hypersync.xyz   # optional; this is the default
-    start_block: 417995000                 # a SLOT number, not a block
-    programs_experimental:
-      # --- decoded from an Anchor IDL ---
-      - name: Jupiter
-        program_id: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
-        idl: idls/jupiter.json
-        instructions:
-          - name: sharedAccountsRoute
-            discriminator: "0xc1209b3341d69c81"
-            field_selection:
-              token_balance_fields: true
-      # --- decoded from an inline schema (no IDL) ---
-      - name: Raydium
-        program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
-        instructions:
-          - name: swap
-            discriminator: "0x09"
-            args:
-              - { name: amountIn, type: u64 }
-              - { name: minAmountOut, type: u64 }
-            accounts:
-              - tokenProgram
-              - amm
-              - userSourceTokenAccount
-              - userDestTokenAccount
-            field_selection:
-              token_balance_fields: true
+  - start_block: 417995000                 # a SLOT number, not a block
+    experimental:
+      hypersync_config:
+        url: https://solana.hypersync.xyz  # the HyperSync endpoint serving instructions
+      programs:
+        # --- decoded from an Anchor IDL ---
+        - name: Jupiter
+          program_id: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
+          idl: idls/jupiter.json
+          instructions:
+            - name: sharedAccountsRoute
+              discriminator: "0xc1209b3341d69c81"
+              field_selection:
+                token_balance_fields: true
+        # --- decoded from an inline schema (no IDL) ---
+        - name: Raydium
+          program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
+          instructions:
+            - name: swap
+              discriminator: "0x09"
+              args:
+                - { name: amountIn, type: u64 }
+                - { name: minAmountOut, type: u64 }
+              accounts:
+                - tokenProgram
+                - amm
+                - userSourceTokenAccount
+                - userDestTokenAccount
+              field_selection:
+                token_balance_fields: true
+                transaction_fields:
+                  - signatures
 ```
 
 ## Top-level fields
@@ -85,32 +87,37 @@ Each entry is one Solana cluster.
 
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `rpc` | ✅ | — | RPC URL. Used by [slot handlers](/docs/HyperIndex/solana/slot-handlers) and the [Effect API](/docs/HyperIndex/effect-api). |
-| `start_block` | ✅ | — | The **slot** to start indexing from. |
-| `hypersync_config.url` | — | `https://solana.hypersync.xyz` | The HyperSync endpoint that serves historical instructions. |
-| `end_block` | — | — | Stop at this slot (inclusive of the range processed). Useful for finite backfills and tests. |
-| `block_lag` | — | — | Stay this many slots behind the head. |
-| `skip` | — | `false` | Skip this chain. |
-| `programs_experimental` | — | — | Programs to index (see below). |
+| `start_block` | ✅ | - | The **slot** to start indexing from. |
+| `experimental` | - | - | HyperSync-backed instruction indexing: `hypersync_config` + `programs` (see below). The key is named `experimental` to signal that this shape is still evolving. |
+| `rpc` | - | - | RPC URL. Required only when `experimental` is not set; ignored in favour of the HyperSync source when it is. |
+| `end_block` | - | - | Stop at this slot (inclusive of the range processed). Useful for finite backfills and tests. |
+| `block_lag` | - | - | Stay this many slots behind the head. |
+| `skip` | - | `false` | Skip this chain. |
 
 :::tip EVM difference: no chain `id`
-EVM chains require an `id` (the public chain ID). Solana chains have **no `id`** —
-the cluster is identified by the `rpc` / `hypersync_config` you point at. Inside
+EVM chains require an `id` (the public chain ID). Solana chains have **no `id`** -
+the cluster is identified by the endpoints you point at. Inside
 handlers the Solana chain id is `0`.
 :::
 
-## `programs_experimental`
+## `experimental`
 
-The list of Solana programs to index on this chain. The YAML key is
-`programs_experimental` to signal that this shape is still evolving.
+Everything HyperSync-backed lives under the chain's `experimental` key:
 
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `name` | ✅ | — | A unique name you choose. Used in handlers (`onInstruction({ program: "<name>" })`) and generated types. |
-| `program_id` | ✅ | — | The base58 program address. |
-| `instructions` | ✅ | — | Instructions to match within this program (see below). |
-| `idl` | — | — | Path to an Anchor IDL JSON. If set, HyperIndex derives each instruction's `args` + `accounts` from it. **Mutually exclusive** with per-instruction inline `args`/`accounts`. |
-| `handler` | — | auto | Path to the file that registers this program's handlers. By default handler files are auto-loaded. |
+| `hypersync_config.url` | ✅ | - | The HyperSync endpoint that serves instructions (e.g. `https://solana.hypersync.xyz`). |
+| `programs` | ✅ | - | Solana programs to index on this chain (see below). |
+
+### `programs`
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | ✅ | - | A unique name you choose. Used in handlers (`onInstruction({ program: "<name>" })`) and generated types. |
+| `program_id` | ✅ | - | The base58 program address. |
+| `instructions` | ✅ | - | Instructions to match within this program (see below). |
+| `idl` | - | - | Path to an Anchor IDL JSON. If set, HyperIndex derives each instruction's `args` + `accounts` from it. **Mutually exclusive** with per-instruction inline `args`/`accounts`. |
+| `handler` | - | auto | Path to the file that registers this program's handlers. By default handler files are auto-loaded. |
 
 ## `instructions`
 
@@ -130,25 +137,30 @@ instruction apart from the program's others.
 
 ### Field selection
 
-By default a handler receives only the instruction itself. Opt into more data
-per instruction:
+By default a handler receives only the instruction itself, plus its block's
+`slot`/`time`/`hash`. Opt into more data per instruction:
 
-| Toggle | Adds to the event |
-| --- | --- |
-| `transaction_fields: true` | `event.transaction` — signatures, fee payer, fee, compute units, success, account keys. |
-| `token_balance_fields: true` | `event.transaction.tokenBalances` — pre/post SPL Token balances. **Implies `transaction_fields`.** |
-| `log_fields: true` | `event.logs` — program logs scoped to this instruction. |
+| Key | Value | Adds to the handler's `instruction` |
+| --- | --- | --- |
+| `transaction_fields` | list of field names | `instruction.transaction.<field>` for each selected field: `signatures`, `feePayer`, `success`, `err`, `fee`, `computeUnitsConsumed`, `accountKeys`, `recentBlockhash`, `version`, `transactionIndex`. |
+| `block_fields` | list of field names | `instruction.block.<field>` on top of the always-present `slot`/`time`/`hash`: `height`, `parentSlot`, `parentHash`. |
+| `token_balance_fields` | `true` | `instruction.transaction.tokenBalances`: pre/post SPL Token balances. Independent of `transaction_fields`. |
+| `log_fields` | `true` | `instruction.logs`: program logs scoped to this instruction. |
 
 ```yaml
 field_selection:
-  token_balance_fields: true   # also gives you transaction fields
+  transaction_fields:
+    - signatures
+    - feePayer
+  block_fields:
+    - height
+  token_balance_fields: true
   log_fields: true
 ```
 
-:::note `true` only, for now
-Each toggle currently accepts `true` (all fields) only. Per-field name lists are
-not yet supported.
-:::
+Unselected fields are typed as compile errors in the handler (`FieldNotSelected`),
+so reading a field you forgot to select fails at `tsc` time, not silently at
+runtime.
 
 ### Account filters
 

--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -76,9 +76,9 @@ chains:
 :::note No EVM-style global fields
 For Solana, several EVM top-level fields don't apply: `contracts`,
 `rollback_on_reorg`, `save_full_history`, `raw_events`, a global
-`field_selection`, and `address_format`. Reorg handling isn't a config knob:
-the HyperSync source rolls back on reorg automatically, while the RPC source
-indexes finalized data only. Field selection is **per-instruction** only
+`field_selection`, and `address_format`. Reorgs are handled automatically on
+the HyperSync source (it rolls back on reorg); the RPC source indexes finalized
+data only. Field selection is **per-instruction** only
 (see [field selection](#field-selection)).
 :::
 

--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -1,0 +1,195 @@
+---
+id: solana-configuration
+title: Solana Configuration File
+sidebar_label: Configuration
+slug: /solana/configuration
+description: The config.yaml reference for Solana (ecosystem svm) indexers — chains, programs, instructions, discriminators, and field selection.
+---
+
+# Solana Configuration File
+
+A Solana indexer is defined by a `config.yaml` with `ecosystem: svm`. It tells
+HyperIndex which chain to read, which programs and instructions to match, and how
+to decode them. This page is the field-by-field reference; for the *meaning* of
+discriminators, IDLs and argument types see [Decoding & IDLs](/docs/HyperIndex/solana/decoding).
+
+Add this line at the top of the file for editor autocompletion and validation:
+
+```yaml
+# yaml-language-server: $schema=./node_modules/envio/svm.schema.json
+```
+
+## A complete example
+
+```yaml title="config.yaml"
+# yaml-language-server: $schema=./node_modules/envio/svm.schema.json
+name: my-solana-indexer
+description: Index Jupiter swaps and Metaplex NFT mints
+ecosystem: svm
+chains:
+  - rpc: https://api.mainnet-beta.solana.com
+    hypersync_config:
+      url: https://solana.hypersync.xyz   # optional; this is the default
+    start_block: 417995000                 # a SLOT number, not a block
+    programs_experimental:
+      # --- decoded from an Anchor IDL ---
+      - name: Jupiter
+        program_id: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
+        idl: idls/jupiter.json
+        instructions:
+          - name: sharedAccountsRoute
+            discriminator: "0xc1209b3341d69c81"
+            field_selection:
+              token_balance_fields: true
+      # --- decoded from an inline schema (no IDL) ---
+      - name: Raydium
+        program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
+        instructions:
+          - name: swap
+            discriminator: "0x09"
+            args:
+              - { name: amountIn, type: u64 }
+              - { name: minAmountOut, type: u64 }
+            accounts:
+              - tokenProgram
+              - amm
+              - userSourceTokenAccount
+              - userDestTokenAccount
+            field_selection:
+              token_balance_fields: true
+```
+
+## Top-level fields
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | ✅ | — | Project name. |
+| `ecosystem` | ✅ | — | Must be `svm`. |
+| `chains` | ✅ | — | One or more chains to index (see below). |
+| `description` | — | — | Free-text description. |
+| `schema` | — | `schema.graphql` | Path to your GraphQL schema. |
+| `full_batch_size` | — | `5000` | Batch size for processing. |
+| `storage` | — | `postgres: true` | Storage backends (`postgres`, `clickhouse`). |
+
+:::note No EVM-style global fields
+For Solana, several EVM top-level fields don't apply: `contracts`,
+`rollback_on_reorg`, `save_full_history`, `raw_events`, a global
+`field_selection`, and `address_format`. Reorg-related options are fixed off
+(Solana indexes finalized data). Field selection is **per-instruction** only
+(see [field selection](#field-selection)).
+:::
+
+## `chains`
+
+Each entry is one Solana cluster.
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `rpc` | ✅ | — | RPC URL. Used by [slot handlers](/docs/HyperIndex/solana/slot-handlers) and the [Effect API](/docs/HyperIndex/effect-api). |
+| `start_block` | ✅ | — | The **slot** to start indexing from. |
+| `hypersync_config.url` | — | `https://solana.hypersync.xyz` | The HyperSync endpoint that serves historical instructions. |
+| `end_block` | — | — | Stop at this slot (inclusive of the range processed). Useful for finite backfills and tests. |
+| `block_lag` | — | — | Stay this many slots behind the head. |
+| `skip` | — | `false` | Skip this chain. |
+| `programs_experimental` | — | — | Programs to index (see below). |
+
+:::tip EVM difference: no chain `id`
+EVM chains require an `id` (the public chain ID). Solana chains have **no `id`** —
+the cluster is identified by the `rpc` / `hypersync_config` you point at. Inside
+handlers the Solana chain id is `0`.
+:::
+
+## `programs_experimental`
+
+The list of Solana programs to index on this chain. The YAML key is
+`programs_experimental` to signal that this shape is still evolving.
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | ✅ | — | A unique name you choose. Used in handlers (`onInstruction({ program: "<name>" })`) and generated types. |
+| `program_id` | ✅ | — | The base58 program address. |
+| `instructions` | ✅ | — | Instructions to match within this program (see below). |
+| `idl` | — | — | Path to an Anchor IDL JSON. If set, HyperIndex derives each instruction's `args` + `accounts` from it. **Mutually exclusive** with per-instruction inline `args`/`accounts`. |
+| `handler` | — | auto | Path to the file that registers this program's handlers. By default handler files are auto-loaded. |
+
+## `instructions`
+
+Each entry selects one instruction of the program to index. Only `name` is
+required, but in practice you'll add a `discriminator` so HyperIndex can tell your
+instruction apart from the program's others.
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | ✅ | — | The instruction name. For Anchor IDL programs this should match the IDL instruction (the snake_cased name is used to derive the default discriminator). Also the key in `onInstruction({ instruction: "<name>" })`. |
+| `discriminator` | — | — | Hex bytes that identify the instruction (e.g. `"0xc1209b3341d69c81"`). See [discriminators](/docs/HyperIndex/solana/decoding#discriminators). Without it, the instruction matches purely on program + filters and isn't decoded by discriminator. |
+| `is_inner` | — | *unset* | `true` = inner (CPI) only, `false` = top-level only, **omitted = matches both**. |
+| `args` | — | — | Inline argument schema (Borsh), `{ name, type }` per arg. Requires `accounts` too. Mutually exclusive with the program's `idl`. See [supported types](/docs/HyperIndex/solana/decoding#supported-argument-types). |
+| `accounts` | — | — | Inline ordered list of account names. The Nth name labels the Nth account. Requires `args` too. |
+| `account_filters` | — | — | Restrict matches by the pubkey in specific account positions (see below). |
+| `field_selection` | — | — | Opt into extra data on the event (see below). |
+
+### Field selection
+
+By default a handler receives only the instruction itself. Opt into more data
+per instruction:
+
+| Toggle | Adds to the event |
+| --- | --- |
+| `transaction_fields: true` | `event.transaction` — signatures, fee payer, fee, compute units, success, account keys. |
+| `token_balance_fields: true` | `event.transaction.tokenBalances` — pre/post SPL Token balances. **Implies `transaction_fields`.** |
+| `log_fields: true` | `event.logs` — program logs scoped to this instruction. |
+
+```yaml
+field_selection:
+  token_balance_fields: true   # also gives you transaction fields
+  log_fields: true
+```
+
+:::note `true` only, for now
+Each toggle currently accepts `true` (all fields) only. Per-field name lists are
+not yet supported.
+:::
+
+### Account filters
+
+Match an instruction only when specific account positions hold specific pubkeys —
+useful to index, say, only swaps that touch a particular pool or mint. Positions
+are `0`–`5`; within a position `values` are OR-ed, and across positions they are
+AND-ed.
+
+```yaml
+instructions:
+  - name: swap
+    discriminator: "0x09"
+    account_filters:
+      - position: 1
+        values:
+          - 58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2   # only this pool
+```
+
+Use `any_of` to OR several AND-groups together:
+
+```yaml
+    account_filters:
+      any_of:
+        - [ { position: 0, values: [So11111111111111111111111111111111111111112] } ]
+        - [ { position: 1, values: [EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v] } ]
+```
+
+## Choosing what to index
+
+Solana's highest-frequency programs (SPL Token, System) produce enormous volumes
+of instructions. Matching them directly can swamp a backfill. Two practical
+patterns:
+
+- **Index DeFi/protocol instructions and read value flow from token balances.**
+  Enabling `token_balance_fields` on a protocol instruction gives you the
+  transaction's net token movements without indexing every `Transfer`.
+- **Scope high-volume instructions with `account_filters` or a tight slot
+  window** (`start_block`/`end_block`) when you do need them.
+
+## Related
+
+- [Decoding & IDLs](/docs/HyperIndex/solana/decoding) — discriminators, IDLs, inline schemas, argument types.
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — what arrives in the handler.
+- [Schema file](/docs/HyperIndex/schema) — defining the entities you write to (same as EVM).

--- a/docs/HyperIndex/solana/decoding.md
+++ b/docs/HyperIndex/solana/decoding.md
@@ -3,7 +3,7 @@ id: solana-decoding
 title: Solana Decoding & IDLs
 sidebar_label: Decoding & IDLs
 slug: /solana/decoding
-description: How HyperIndex decodes Solana instructions — discriminators, Anchor IDLs, inline schemas, supported argument types, and the decoded output shape.
+description: How HyperIndex decodes Solana instructions - discriminators, Anchor IDLs, inline schemas, supported argument types, and the decoded params shape.
 ---
 
 # Decoding & IDLs
@@ -67,7 +67,7 @@ HyperIndex resolves an instruction's argument/account layout in this order:
 | **Anchor IDL** | Program has `idl:` set | HyperIndex derives `args` + `accounts` from the IDL for every instruction. |
 | **Inline schema** | Instruction has `args` + `accounts` | You declare the layout directly. Mutually exclusive with `idl`. |
 | **Bundled** | Program id matches a built-in schema | Currently only **Metaplex Token Metadata** — no `idl`/inline needed. |
-| **None** | No schema available | The instruction still matches and fires the handler, but `decoded` is `undefined` (you can read raw `instruction.data` / `instruction.accounts`). |
+| **None** | No schema available | The instruction still matches and fires the handler, but `params` is `undefined` (you can read raw `instruction.data` / `instruction.accounts`). |
 
 ### Anchor IDLs
 
@@ -78,15 +78,16 @@ argument layouts, ordered account names (including nested account groups), and t
 IDL `types` registry.
 
 ```yaml
-programs_experimental:
-  - name: Jupiter
-    program_id: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
-    idl: idls/jupiter.json
-    instructions:
-      - name: route
-        discriminator: "0xe517cb977ae3ad2a" # legacy IDL → supply the sighash
-      - name: sharedAccountsRoute
-        discriminator: "0xc1209b3341d69c81"
+experimental:
+  programs:
+    - name: Jupiter
+      program_id: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
+      idl: idls/jupiter.json
+      instructions:
+        - name: route
+          discriminator: "0xe517cb977ae3ad2a" # legacy IDL: supply the sighash
+        - name: sharedAccountsRoute
+          discriminator: "0xc1209b3341d69c81"
 ```
 
 With an IDL set, you only list each instruction's `name` (+ `discriminator` for
@@ -100,20 +101,21 @@ argument list (in order, after the discriminator); `accounts` is the ordered lis
 of account names. They must be provided **together**.
 
 ```yaml
-programs_experimental:
-  - name: Raydium
-    program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
-    instructions:
-      - name: swap
-        discriminator: "0x09"
-        args:
-          - { name: amountIn, type: u64 }
-          - { name: minAmountOut, type: u64 }
-        accounts:           # positional: accounts[0] is tokenProgram, etc.
-          - tokenProgram
-          - amm
-          - userSourceTokenAccount
-          - userDestTokenAccount
+experimental:
+  programs:
+    - name: Raydium
+      program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
+      instructions:
+        - name: swap
+          discriminator: "0x09"
+          args:
+            - { name: amountIn, type: u64 }
+            - { name: minAmountOut, type: u64 }
+          accounts:         # positional: accounts[0] is tokenProgram, etc.
+            - tokenProgram
+            - amm
+            - userSourceTokenAccount
+            - userDestTokenAccount
 ```
 
 :::warning Verify positional layouts
@@ -125,9 +127,9 @@ accounts beyond your named list still arrive — see [`extraAccounts`](#decoded-
 ## Supported argument types
 
 Use these in inline `args` (and they're what HyperIndex understands from IDLs).
-The right column is how each value appears in `decoded.args`.
+The right column is how each value appears in `params.args`.
 
-| `type` | Rendered in `decoded.args` as |
+| `type` | Rendered in `params.args` as |
 | --- | --- |
 | `bool` | boolean |
 | `u8` `u16` `u32`, `i8` `i16` `i32` | number |
@@ -154,10 +156,10 @@ args:
 
 ## Decoded output
 
-When a schema matches, `event.instruction.decoded` is:
+When a schema matches, `instruction.params` is:
 
 ```typescript
-type SvmDecodedInstruction = {
+type SvmInstructionParams = {
   name: string;                          // the instruction name
   args: unknown;                         // object keyed by arg name (typed after codegen)
   accounts: Record<string, string>;      // schema account name -> base58 pubkey
@@ -169,7 +171,7 @@ type SvmDecodedInstruction = {
   instruction; if you bypass that (see below) it's `unknown` — narrow it with a
   local type and read defensively.
 - **`accounts`** maps each schema account name to its base58 pubkey, e.g.
-  `decoded.accounts.mint`. Names come from the IDL or your inline `accounts` list.
+  `params.accounts.mint`. Names come from the IDL or your inline `accounts` list.
 - **`extraAccounts`** collects accounts present on-chain beyond your named list —
   Anchor `remaining_accounts`, optional accounts, or accounts resolved from an
   address lookup table.
@@ -180,7 +182,7 @@ Because `args` is loosely typed (and `u64`+ values are strings), read each field
 as possibly-absent so one missing field can't throw and kill the handler:
 
 ```typescript
-import { type SvmDecodedInstruction } from "envio";
+import { type SvmInstructionParams } from "envio";
 
 interface JupiterRouteArgs {
   inAmount: string;
@@ -190,18 +192,18 @@ interface JupiterRouteArgs {
 const bi = (x: unknown) =>
   x === undefined || x === null ? undefined : BigInt(x as string);
 
-function mapRoute(decoded: SvmDecodedInstruction) {
-  const a = decoded.args as Partial<JupiterRouteArgs>;
+function mapRoute(params: SvmInstructionParams) {
+  const a = params.args as Partial<JupiterRouteArgs>;
   return {
     inAmount: bi(a.inAmount),
     outAmount: bi(a.quotedOutAmount),
-    sourceMint: decoded.accounts.sourceMint,
-    destMint: decoded.accounts.destinationMint,
+    sourceMint: params.accounts.sourceMint,
+    destMint: params.accounts.destinationMint,
   };
 }
 ```
 
-## When `decoded` is `undefined`
+## When `params` is `undefined`
 
 Decoding returns `undefined` (rather than crashing) when:
 
@@ -209,7 +211,7 @@ Decoding returns `undefined` (rather than crashing) when:
 - there were too few accounts for the named list;
 - the argument bytes didn't decode cleanly (wrong/partial layout).
 
-The indexer keeps running and logs at debug. Always `if (!decoded) return;` before
+The indexer keeps running and logs at debug. Always `if (!params) return;` before
 using it — or fall back to the raw `instruction.data` and `instruction.accounts`.
 
 ## Known limitations
@@ -217,7 +219,7 @@ using it — or fall back to the raw `instruction.data` and `instruction.account
 - **`[u8; 32]` is always rendered as a base58 pubkey.** A 32-byte hash or Merkle
   root will look like a pubkey string.
 - **Account-count tolerance.** Surplus accounts go to `extraAccounts`; too few
-  means `decoded` is `undefined`.
+  means `params` is `undefined`.
 - **Address lookup tables.** ALT-resolved addresses are included in the
   instruction's account list and mapped positionally — there's no separate ALT
   handling to configure.
@@ -228,4 +230,4 @@ using it — or fall back to the raw `instruction.data` and `instruction.account
 ## Related
 
 - [Configuration](/docs/HyperIndex/solana/configuration) — where `idl`, `discriminator`, `args`, `accounts` live.
-- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — using `decoded` in handlers.
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — using `params` in handlers.

--- a/docs/HyperIndex/solana/decoding.md
+++ b/docs/HyperIndex/solana/decoding.md
@@ -1,0 +1,231 @@
+---
+id: solana-decoding
+title: Solana Decoding & IDLs
+sidebar_label: Decoding & IDLs
+slug: /solana/decoding
+description: How HyperIndex decodes Solana instructions — discriminators, Anchor IDLs, inline schemas, supported argument types, and the decoded output shape.
+---
+
+# Decoding & IDLs
+
+Solana instruction data is a packed [Borsh](https://borsh.io/) byte string with no
+self-describing structure — unlike an EVM log, there's no ABI travelling with it.
+To turn raw bytes into typed `args` and named `accounts`, HyperIndex needs two
+things per instruction:
+
+1. A **discriminator** — the leading bytes that identify which instruction it is.
+2. A **schema** — the argument layout and account names, from an Anchor IDL, an
+   inline declaration, or a bundled schema.
+
+## Discriminators
+
+The discriminator is the first N bytes of the instruction data. HyperIndex matches
+the leading bytes of every instruction in the matched program against the
+discriminators you configured; the longest configured length is tried first, so a
+program can mix 8-byte Anchor and 1-byte native instructions unambiguously.
+
+- **Format:** hex only, with optional `0x` prefix. Base58 and decimal are not accepted here (base58 is only for `program_id`).
+- **Length:** exactly **1, 2, 4, or 8 bytes** (2, 4, 8, or 16 hex digits).
+- **Anchor programs:** the discriminator is the 8-byte Anchor sighash —
+  `sha256("global:" + snake_case(instructionName))[0..8]`.
+- **Native / non-Anchor programs:** whatever leading byte(s) the program uses
+  (e.g. SPL Token Transfer is `0x03`; Raydium AMM v4 swap is `0x09`).
+
+```yaml
+instructions:
+  - name: sharedAccountsRoute
+    discriminator: "0xc1209b3341d69c81"  # 8-byte Anchor sighash
+  - name: swap
+    discriminator: "0x09"                # 1-byte native
+```
+
+### Computing an Anchor discriminator
+
+Modern Anchor IDLs (0.30+) embed the discriminator, so HyperIndex reads it from
+the IDL automatically. **Legacy Anchor IDLs don't include it**, so you compute it
+from the instruction name:
+
+```typescript
+import { createHash } from "node:crypto";
+
+function anchorDiscriminator(name: string): string {
+  const snake = name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  const hash = createHash("sha256").update(`global:${snake}`).digest();
+  return "0x" + hash.subarray(0, 8).toString("hex");
+}
+
+anchorDiscriminator("route");               // 0xe517cb977ae3ad2a
+anchorDiscriminator("sharedAccountsRoute"); // 0xc1209b3341d69c81
+```
+
+## Where the schema comes from
+
+HyperIndex resolves an instruction's argument/account layout in this order:
+
+| Source | When | How to use |
+| --- | --- | --- |
+| **Anchor IDL** | Program has `idl:` set | HyperIndex derives `args` + `accounts` from the IDL for every instruction. |
+| **Inline schema** | Instruction has `args` + `accounts` | You declare the layout directly. Mutually exclusive with `idl`. |
+| **Bundled** | Program id matches a built-in schema | Currently only **Metaplex Token Metadata** — no `idl`/inline needed. |
+| **None** | No schema available | The instruction still matches and fires the handler, but `decoded` is `undefined` (you can read raw `instruction.data` / `instruction.accounts`). |
+
+### Anchor IDLs
+
+Point a program at a standard Anchor IDL JSON file (relative to `config.yaml`).
+Both legacy (no embedded discriminator) and modern (0.30+, with discriminator)
+IDLs are supported through the same path. HyperIndex extracts instruction names,
+argument layouts, ordered account names (including nested account groups), and the
+IDL `types` registry.
+
+```yaml
+programs_experimental:
+  - name: Jupiter
+    program_id: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
+    idl: idls/jupiter.json
+    instructions:
+      - name: route
+        discriminator: "0xe517cb977ae3ad2a" # legacy IDL → supply the sighash
+      - name: sharedAccountsRoute
+        discriminator: "0xc1209b3341d69c81"
+```
+
+With an IDL set, you only list each instruction's `name` (+ `discriminator` for
+legacy IDLs) — the args and accounts come from the IDL. Don't add inline
+`args`/`accounts`; they're mutually exclusive with `idl`.
+
+### Inline schema (no IDL)
+
+For programs without an IDL, declare the layout yourself. `args` is the Borsh
+argument list (in order, after the discriminator); `accounts` is the ordered list
+of account names. They must be provided **together**.
+
+```yaml
+programs_experimental:
+  - name: Raydium
+    program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
+    instructions:
+      - name: swap
+        discriminator: "0x09"
+        args:
+          - { name: amountIn, type: u64 }
+          - { name: minAmountOut, type: u64 }
+        accounts:           # positional: accounts[0] is tokenProgram, etc.
+          - tokenProgram
+          - amm
+          - userSourceTokenAccount
+          - userDestTokenAccount
+```
+
+:::warning Verify positional layouts
+For native programs the account order is the program's canonical layout, not
+something HyperIndex can verify. Check it against a real transaction. Trailing
+accounts beyond your named list still arrive — see [`extraAccounts`](#decoded-output).
+:::
+
+## Supported argument types
+
+Use these in inline `args` (and they're what HyperIndex understands from IDLs).
+The right column is how each value appears in `decoded.args`.
+
+| `type` | Rendered in `decoded.args` as |
+| --- | --- |
+| `bool` | boolean |
+| `u8` `u16` `u32`, `i8` `i16` `i32` | number |
+| `u64` `u128` `i64` `i128` | **decimal string** (precision-safe) |
+| `f32` `f64` | number (`null` if NaN/Inf) |
+| `string` | string |
+| `bytes` | `0x`-prefixed hex string |
+| `pubkey` (alias `publicKey`) | base58 string |
+| `{ option: <type> }` | the value, or `null` |
+| `{ vec: <type> }` | array |
+| `{ array: [<type>, <len>] }` | array — **except `[u8, 32]`, rendered base58 as a pubkey** |
+| `{ defined: "<TypeName>" }` | resolved from the IDL's `types` registry |
+| `{ struct: [ {name,type}, … ] }` | object |
+| `{ enum: [ {name, fields?}, … ] }` | `{ VariantName: { …fields } }` |
+
+```yaml
+args:
+  - { name: amount,     type: u64 }
+  - { name: authority,  type: pubkey }
+  - { name: maybeOwner, type: { option: pubkey } }
+  - { name: route,      type: { vec: { defined: "RoutePlanStep" } } }
+  - { name: seedHash,   type: { array: [u8, 32] } }   # → base58 string
+```
+
+## Decoded output
+
+When a schema matches, `event.instruction.decoded` is:
+
+```typescript
+type SvmDecodedInstruction = {
+  name: string;                          // the instruction name
+  args: unknown;                         // object keyed by arg name (typed after codegen)
+  accounts: Record<string, string>;      // schema account name -> base58 pubkey
+  extraAccounts: readonly string[];      // accounts beyond the named list (base58)
+};
+```
+
+- **`args`** is keyed by your argument names. After `codegen` it's typed per
+  instruction; if you bypass that (see below) it's `unknown` — narrow it with a
+  local type and read defensively.
+- **`accounts`** maps each schema account name to its base58 pubkey, e.g.
+  `decoded.accounts.mint`. Names come from the IDL or your inline `accounts` list.
+- **`extraAccounts`** collects accounts present on-chain beyond your named list —
+  Anchor `remaining_accounts`, optional accounts, or accounts resolved from an
+  address lookup table.
+
+### Reading args safely
+
+Because `args` is loosely typed (and `u64`+ values are strings), read each field
+as possibly-absent so one missing field can't throw and kill the handler:
+
+```typescript
+import { type SvmDecodedInstruction } from "envio";
+
+interface JupiterRouteArgs {
+  inAmount: string;
+  quotedOutAmount: string;
+}
+
+const bi = (x: unknown) =>
+  x === undefined || x === null ? undefined : BigInt(x as string);
+
+function mapRoute(decoded: SvmDecodedInstruction) {
+  const a = decoded.args as Partial<JupiterRouteArgs>;
+  return {
+    inAmount: bi(a.inAmount),
+    outAmount: bi(a.quotedOutAmount),
+    sourceMint: decoded.accounts.sourceMint,
+    destMint: decoded.accounts.destinationMint,
+  };
+}
+```
+
+## When `decoded` is `undefined`
+
+Decoding returns `undefined` (rather than crashing) when:
+
+- the discriminator didn't match a configured instruction with a schema;
+- there were too few accounts for the named list;
+- the argument bytes didn't decode cleanly (wrong/partial layout).
+
+The indexer keeps running and logs at debug. Always `if (!decoded) return;` before
+using it — or fall back to the raw `instruction.data` and `instruction.accounts`.
+
+## Known limitations
+
+- **`[u8; 32]` is always rendered as a base58 pubkey.** A 32-byte hash or Merkle
+  root will look like a pubkey string.
+- **Account-count tolerance.** Surplus accounts go to `extraAccounts`; too few
+  means `decoded` is `undefined`.
+- **Address lookup tables.** ALT-resolved addresses are included in the
+  instruction's account list and mapped positionally — there's no separate ALT
+  handling to configure.
+- **Inline nominal types.** Reference IDL `types` via `{ defined: "Name" }`, or
+  declare shapes inline with `{ struct: … }` / `{ enum: … }`. A standalone inline
+  program-level `types` registry isn't available yet.
+
+## Related
+
+- [Configuration](/docs/HyperIndex/solana/configuration) — where `idl`, `discriminator`, `args`, `accounts` live.
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — using `decoded` in handlers.

--- a/docs/HyperIndex/solana/evm-vs-solana.md
+++ b/docs/HyperIndex/solana/evm-vs-solana.md
@@ -22,7 +22,7 @@ difference in one place.
 | ABI | Anchor IDL (or an inline schema) |
 | Event / log | Instruction |
 | `indexer.onEvent` | `indexer.onInstruction` |
-| `event.params.<name>` | `event.instruction.decoded.args.<name>` |
+| `event.params.<name>` | `instruction.params.args.<name>` |
 | Event signature / topic0 | Instruction discriminator |
 | Indexed event args | Account positions / `account_filters` |
 | `indexer.onBlock` | `indexer.onSlot` |
@@ -36,12 +36,12 @@ difference in one place.
 | | EVM | Solana |
 | --- | --- | --- |
 | `ecosystem` | `evm` (default) | `svm` |
-| What you list | `contracts` (with `abi_file_path`, `address`, `events`) | `programs_experimental` (with `program_id`, optional `idl`, `instructions`) |
-| Chain identity | `chains[].id` (public chain ID, required) | no `id` — identified by `rpc`/`hypersync_config` (chain id is `0` in handlers) |
+| What you list | `contracts` (with `abi_file_path`, `address`, `events`) | `experimental.programs` (with `program_id`, optional `idl`, `instructions`) |
+| Chain identity | `chains[].id` (public chain ID, required) | no `id` — identified by the configured endpoints (chain id is `0` in handlers) |
 | `start_block` | block number | **slot** number |
 | Matching key | event signature (from ABI) | `discriminator` (hex, 1/2/4/8 bytes) |
 | Decoding source | ABI | Anchor IDL, inline `args`+`accounts`, or bundled |
-| Field selection | global, rich block/transaction field lists | per-instruction toggles only: `transaction_fields`, `token_balance_fields`, `log_fields` (value `true`) |
+| Field selection | global, rich block/transaction field lists | per-instruction: `transaction_fields`/`block_fields` (field name lists), `token_balance_fields`/`log_fields` (`true`) |
 | Reorg options | `rollback_on_reorg`, `save_full_history` | not configurable — finalized data only |
 
 :::note `chains`, not `networks`
@@ -70,25 +70,25 @@ indexer.onEvent(
 ```typescript
 indexer.onInstruction(
   { program: "Jupiter", instruction: "sharedAccountsRoute" },
-  async ({ event, context }) => {
-    const decoded = event.instruction.decoded;
-    if (!decoded) return;                       // decode can fail → null-check
-    const inAmount = BigInt(decoded.args.inAmount); // u64 → decimal string
-    const sourceMint = decoded.accounts.sourceMint; // base58
-    const programId = event.instruction.programId;  // base58
-    const slot = event.slot;
-    const txSig = event.transaction?.signatures[0]; // needs transaction_fields
-    const isInner = event.instruction.isInner;      // CPI?
+  async ({ instruction, context }) => {
+    const params = instruction.params;
+    if (!params) return;                          // decode can fail: null-check
+    const inAmount = BigInt(params.args.inAmount);  // u64 arrives as decimal string
+    const sourceMint = params.accounts.sourceMint;  // base58
+    const programId = instruction.programId;        // base58
+    const slot = instruction.block.slot;
+    const txSig = instruction.transaction.signatures[0]; // needs transaction_fields: [signatures]
+    const isInner = instruction.isInner;            // CPI?
   },
 );
 ```
 
 Key handler-level differences:
 
-- **`decoded` is optional.** EVM `event.params` is always populated (the ABI is known); Solana decoding can fail, so always `if (!decoded) return;`.
+- **`params` is optional.** EVM `event.params` is always populated (the ABI is known); Solana decoding can fail, so always `if (!params) return;`.
 - **Numbers as strings.** `u64`/`u128`/`i64`/`i128` arrive as decimal strings — wrap in `BigInt(...)`. (Smaller ints are JS numbers.)
 - **Addresses are base58.** No `0x` lowercase/checksum concerns; pubkeys are base58 strings.
-- **Opt in to context.** Transaction metadata, token balances, and logs require [field selection](/docs/HyperIndex/solana/configuration#field-selection); on EVM the event always carries block/transaction context.
+- **Opt in to context.** Transaction fields, token balances, and logs require [field selection](/docs/HyperIndex/solana/configuration#field-selection); on EVM the event always carries block/transaction context.
 - **Chain id is `0`.** Single-cluster today; `context.chain.id === 0`.
 
 ## CPIs vs internal calls

--- a/docs/HyperIndex/solana/evm-vs-solana.md
+++ b/docs/HyperIndex/solana/evm-vs-solana.md
@@ -42,7 +42,7 @@ difference in one place.
 | Matching key | event signature (from ABI) | `discriminator` (hex, 1/2/4/8 bytes) |
 | Decoding source | ABI | Anchor IDL, inline `args`+`accounts`, or bundled |
 | Field selection | global, rich block/transaction field lists | per-instruction: `transaction_fields`/`block_fields` (field name lists), `token_balance_fields`/`log_fields` (`true`) |
-| Reorg options | `rollback_on_reorg`, `save_full_history` | not a config knob; the HyperSync source rolls back on reorg automatically, while the RPC source is finalized-only |
+| Reorg options | `rollback_on_reorg`, `save_full_history` | handled automatically on the HyperSync source (rolls back on reorg); the RPC source is finalized-only |
 
 :::note `chains`, not `networks`
 Current HyperIndex uses `chains` for both EVM and Solana. (Older versions used

--- a/docs/HyperIndex/solana/evm-vs-solana.md
+++ b/docs/HyperIndex/solana/evm-vs-solana.md
@@ -1,0 +1,140 @@
+---
+id: solana-evm-vs-solana
+title: EVM vs Solana
+sidebar_label: EVM vs Solana
+slug: /solana/evm-vs-solana
+description: Every difference between indexing EVM chains and Solana with HyperIndex — concepts, config, handlers, and what isn't supported yet.
+---
+
+# EVM vs Solana
+
+The HyperIndex workflow is the same on both: define a `config.yaml` and
+`schema.graphql`, write handlers, run `codegen`, then `dev`/`start`. What changes
+is the unit of work — EVM indexes **events** emitted by **contracts**, Solana
+indexes **instructions** executed by **programs**. This page collects every
+difference in one place.
+
+## Concept mapping
+
+| EVM | Solana |
+| --- | --- |
+| Smart contract | Program |
+| ABI | Anchor IDL (or an inline schema) |
+| Event / log | Instruction |
+| `indexer.onEvent` | `indexer.onInstruction` |
+| `event.params.<name>` | `event.instruction.decoded.args.<name>` |
+| Event signature / topic0 | Instruction discriminator |
+| Indexed event args | Account positions / `account_filters` |
+| `indexer.onBlock` | `indexer.onSlot` |
+| Block number | Slot number |
+| Address `0x…` (20 bytes, hex) | Pubkey (32 bytes, base58) |
+| Internal calls (not surfaced) | Inner instructions / CPIs (first-class) |
+| `bigint` params | `u64`+ args as **decimal strings** |
+
+## Config differences
+
+| | EVM | Solana |
+| --- | --- | --- |
+| `ecosystem` | `evm` (default) | `svm` |
+| What you list | `contracts` (with `abi_file_path`, `address`, `events`) | `programs_experimental` (with `program_id`, optional `idl`, `instructions`) |
+| Chain identity | `chains[].id` (public chain ID, required) | no `id` — identified by `rpc`/`hypersync_config` (chain id is `0` in handlers) |
+| `start_block` | block number | **slot** number |
+| Matching key | event signature (from ABI) | `discriminator` (hex, 1/2/4/8 bytes) |
+| Decoding source | ABI | Anchor IDL, inline `args`+`accounts`, or bundled |
+| Field selection | global, rich block/transaction field lists | per-instruction toggles only: `transaction_fields`, `token_balance_fields`, `log_fields` (value `true`) |
+| Reorg options | `rollback_on_reorg`, `save_full_history` | not configurable — finalized data only |
+
+:::note `chains`, not `networks`
+Current HyperIndex uses `chains` for both EVM and Solana. (Older versions used
+`networks` for EVM — if you see that in an old guide, it's the same idea.)
+:::
+
+## Handler differences
+
+**EVM:**
+
+```typescript
+indexer.onEvent(
+  { contract: "ERC20", event: "Transfer" },
+  async ({ event, context }) => {
+    const from = event.params.from;       // decoded by ABI
+    const amount = event.params.value;    // bigint
+    const chainId = event.chainId;
+    const contract = event.srcAddress;    // 0x… hex
+  },
+);
+```
+
+**Solana:**
+
+```typescript
+indexer.onInstruction(
+  { program: "Jupiter", instruction: "sharedAccountsRoute" },
+  async ({ event, context }) => {
+    const decoded = event.instruction.decoded;
+    if (!decoded) return;                       // decode can fail → null-check
+    const inAmount = BigInt(decoded.args.inAmount); // u64 → decimal string
+    const sourceMint = decoded.accounts.sourceMint; // base58
+    const programId = event.instruction.programId;  // base58
+    const slot = event.slot;
+    const txSig = event.transaction?.signatures[0]; // needs transaction_fields
+    const isInner = event.instruction.isInner;      // CPI?
+  },
+);
+```
+
+Key handler-level differences:
+
+- **`decoded` is optional.** EVM `event.params` is always populated (the ABI is known); Solana decoding can fail, so always `if (!decoded) return;`.
+- **Numbers as strings.** `u64`/`u128`/`i64`/`i128` arrive as decimal strings — wrap in `BigInt(...)`. (Smaller ints are JS numbers.)
+- **Addresses are base58.** No `0x` lowercase/checksum concerns; pubkeys are base58 strings.
+- **Opt in to context.** Transaction metadata, token balances, and logs require [field selection](/docs/HyperIndex/solana/configuration#field-selection); on EVM the event always carries block/transaction context.
+- **Chain id is `0`.** Single-cluster today; `context.chain.id === 0`.
+
+## CPIs vs internal calls
+
+On EVM, a contract calling another contract doesn't emit a separate indexable
+event for the internal call. On Solana, **cross-program invocations are real
+instructions** — if you index the inner program, you receive them, with
+`isInner: true` and an `instructionAddress` path that reconstructs the call tree.
+This makes Solana's composability directly indexable (e.g. the Raydium/Orca swaps
+underneath a Jupiter route). See
+[Inner instructions](/docs/HyperIndex/solana/instruction-handlers#inner-instructions-cpis).
+
+## Token balances & balance changes
+
+Solana instruction events can carry **pre/post SPL Token balance snapshots** for
+the whole transaction (`token_balance_fields: true`). This gives you net token
+movement (the balance *change*) without indexing every transfer instruction —
+there's no direct EVM equivalent built into the event. See
+[Token balances](/docs/HyperIndex/solana/instruction-handlers#token-balances-and-balance-changes).
+
+## Slots vs blocks
+
+- `start_block` is a **slot**. Use `GET https://solana.hypersync.xyz/height` to find the current head; HyperSync keeps a rolling window, so don't hard-code an ancient slot.
+- Some slots have **no block** (skipped leader). Slot handlers must handle the empty case.
+- The handler arg for `onSlot` is `{ slot: number }`, not a `block` object.
+
+## Not supported on Solana (yet)
+
+These EVM features have no Solana equivalent today:
+
+- **Reorg handling** (`rollback_on_reorg`) — Solana indexes finalized data.
+- **No-code contract import** — no `envio init svm contract-import`; configure programs by hand.
+- **Account-change / log handlers** — no `onAccount`; logs are an event field, not a handler.
+- **Dynamic/factory registration** — no Solana equivalent of [dynamic contracts](/docs/HyperIndex/dynamic-contracts) yet.
+- **Wildcard indexing** across all programs.
+- **ReScript** — Solana indexers are TypeScript only.
+- **Per-field selection** — toggles are `true`/absent, not field-name lists.
+
+What's the same: the [schema file](/docs/HyperIndex/schema), the entity
+`context` API, the [Effect API](/docs/HyperIndex/effect-api), local Docker dev,
+the GraphQL/Hasura layer, [preload optimization](/docs/HyperIndex/preload-optimization),
+and [Envio Cloud](/docs/HyperIndex/hosted-service) deployment.
+
+## Related
+
+- [Solana Overview](/docs/HyperIndex/solana)
+- [Configuration](/docs/HyperIndex/solana/configuration)
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers)
+- [Decoding & IDLs](/docs/HyperIndex/solana/decoding)

--- a/docs/HyperIndex/solana/evm-vs-solana.md
+++ b/docs/HyperIndex/solana/evm-vs-solana.md
@@ -42,7 +42,7 @@ difference in one place.
 | Matching key | event signature (from ABI) | `discriminator` (hex, 1/2/4/8 bytes) |
 | Decoding source | ABI | Anchor IDL, inline `args`+`accounts`, or bundled |
 | Field selection | global, rich block/transaction field lists | per-instruction: `transaction_fields`/`block_fields` (field name lists), `token_balance_fields`/`log_fields` (`true`) |
-| Reorg options | `rollback_on_reorg`, `save_full_history` | not configurable — finalized data only |
+| Reorg options | `rollback_on_reorg`, `save_full_history` | not a config knob; the HyperSync source rolls back on reorg automatically, while the RPC source is finalized-only |
 
 :::note `chains`, not `networks`
 Current HyperIndex uses `chains` for both EVM and Solana. (Older versions used
@@ -119,13 +119,11 @@ there's no direct EVM equivalent built into the event. See
 
 These EVM features have no Solana equivalent today:
 
-- **Reorg handling** (`rollback_on_reorg`) — Solana indexes finalized data.
 - **No-code contract import** — no `envio init svm contract-import`; configure programs by hand.
 - **Account-change / log handlers** — no `onAccount`; logs are an event field, not a handler.
 - **Dynamic/factory registration** — no Solana equivalent of [dynamic contracts](/docs/HyperIndex/dynamic-contracts) yet.
 - **Wildcard indexing** across all programs.
 - **ReScript** — Solana indexers are TypeScript only.
-- **Per-field selection** — toggles are `true`/absent, not field-name lists.
 
 What's the same: the [schema file](/docs/HyperIndex/schema), the entity
 `context` API, the [Effect API](/docs/HyperIndex/effect-api), local Docker dev,

--- a/docs/HyperIndex/solana/getting-started.md
+++ b/docs/HyperIndex/solana/getting-started.md
@@ -99,7 +99,7 @@ instruction, or IDL — requires `pnpm envio codegen` to regenerate the typed
 
 ## 4. Add your own program
 
-Open `config.yaml` and add a program under `programs_experimental` with the
+Open `config.yaml` and add a program under `experimental.programs` with the
 instructions you want, then write a handler. The shortest path:
 
 1. **Point at an Anchor IDL** if you have one — HyperIndex derives the argument and account layout for you ([IDL decoding](/docs/HyperIndex/solana/decoding#anchor-idls)).
@@ -110,32 +110,35 @@ instructions you want, then write a handler. The shortest path:
 ```yaml title="config.yaml"
 ecosystem: svm
 chains:
-  - rpc: https://api.mainnet-beta.solana.com
-    start_block: 417995000
-    programs_experimental:
-      - name: TokenMetadata
-        program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
-        instructions:
-          - name: CreateMetadataAccountV3
-            discriminator: "0x21"
-            field_selection:
-              transaction_fields: true
+  - start_block: 417995000
+    experimental:
+      hypersync_config:
+        url: https://solana.hypersync.xyz
+      programs:
+        - name: TokenMetadata
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions:
+            - name: CreateMetadataAccountV3
+              discriminator: "0x21"
+              field_selection:
+                transaction_fields:
+                  - signatures
 ```
 
 ```typescript title="src/handlers/TokenMetadataHandlers.ts"
-import { indexer, type TokenMetadataAccount } from "envio";
+import { indexer } from "envio";
 
 indexer.onInstruction(
   { program: "TokenMetadata", instruction: "CreateMetadataAccountV3" },
-  async ({ event, context }) => {
-    const decoded = event.instruction.decoded;
-    if (!decoded) return; // discriminator matched but decode failed — skip
+  async ({ instruction, context }) => {
+    const params = instruction.params;
+    if (!params) return; // discriminator matched but decode failed - skip
 
     context.TokenMetadataAccount.set({
-      id: decoded.accounts.metadata,
-      mint: decoded.accounts.mint ?? "",
-      createdAtSlot: event.slot,
-      lastTxSignature: event.transaction?.signatures[0],
+      id: params.accounts.metadata,
+      mint: params.accounts.mint ?? "",
+      createdAtSlot: instruction.block.slot,
+      lastTxSignature: instruction.transaction.signatures[0],
     });
   },
 );
@@ -144,6 +147,6 @@ indexer.onInstruction(
 ## Next steps
 
 - [Configuration](/docs/HyperIndex/solana/configuration) — every `config.yaml` field for Solana.
-- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — the full event object, token balances, CPIs, and testing.
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — the full instruction object, token balances, CPIs, and testing.
 - [Decoding & IDLs](/docs/HyperIndex/solana/decoding) — discriminators, IDLs, inline schemas, supported types.
 - [Deploy to Envio Cloud](/docs/HyperIndex/hosted-service) — host your Solana indexer the same way as EVM.

--- a/docs/HyperIndex/solana/getting-started.md
+++ b/docs/HyperIndex/solana/getting-started.md
@@ -1,0 +1,149 @@
+---
+id: solana-getting-started
+title: Getting Started on Solana
+sidebar_label: Getting Started
+slug: /solana/getting-started
+description: Scaffold, configure, and run your first Solana indexer with HyperIndex.
+---
+
+# Getting Started on Solana
+
+This guide takes you from nothing to a running Solana indexer with a live GraphQL
+API. If you've used HyperIndex on EVM the workflow is identical — only the config
+and handlers differ.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) v20+ and [pnpm](https://pnpm.io) (or npm/yarn/bun)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (for the local Postgres + GraphQL stack)
+- A HyperSync API token — the CLI's login flow sets this up for you, or generate one in the [Envio Cloud portal](https://envio.dev/app/api-tokens). See [API tokens](/docs/HyperSync/api-tokens).
+
+## 1. Scaffold a project
+
+```bash
+pnpx envio init
+```
+
+Choose **Solana** at the ecosystem prompt, then choose a template:
+
+- **Metaplex Token Metadata (instructions)** — indexes the Metaplex Token Metadata program's `CreateMetadataAccountV3` / `UpdateMetadataAccountV2` instructions. A realistic instruction-indexing starting point.
+- **Feature: Block Handler (`onSlot`)** — a minimal [slot handler](/docs/HyperIndex/solana/slot-handlers) that fetches each block over RPC.
+
+Non-interactive equivalents:
+
+```bash
+pnpx envio init svm template --template metaplex-token-metadata --name my-indexer
+pnpx envio init svm template --template feature-block-handler  --name my-indexer
+```
+
+:::note Solana is TypeScript-only
+The `--language` flag is ignored for Solana; projects are always scaffolded in
+TypeScript. There is no `contract-import` flow for Solana — unlike EVM/Fuel you
+wire up programs in `config.yaml` by hand (see [Configuration](/docs/HyperIndex/solana/configuration)).
+:::
+
+The template scaffolds:
+
+```
+my-indexer/
+├── config.yaml          # chain + program/instruction selection
+├── schema.graphql       # the entities you index into
+├── src/
+│   └── handlers/…ts     # your onInstruction / onSlot handlers
+├── .env                 # ENVIO_API_TOKEN, RPC URL
+└── package.json
+```
+
+`envio init` also runs codegen, installs dependencies, and initializes git.
+
+## 2. Pick a start slot
+
+`start_block` in `config.yaml` is a **slot number**, not a block number, and
+HyperSync for Solana keeps a rolling window of recent history — so don't hard-code
+an old slot. Query the current head and start somewhere sensible below it:
+
+```bash
+curl -s https://solana.hypersync.xyz/height
+# => {"height": 421234567}
+```
+
+Set `start_block` in `config.yaml` to, say, a few thousand slots below the head
+for a quick backfill, or to the slot your program was deployed at for a full history
+(within the retention window).
+
+## 3. Run it
+
+```bash
+pnpm install            # if you didn't let init do it
+pnpm envio codegen      # regenerate types from config.yaml + schema.graphql
+pnpm envio dev          # start Postgres + the indexer + GraphQL (Docker)
+```
+
+`envio dev` brings up the local stack and runs the indexer with hot reload. The
+GraphQL playground (Hasura) is at **http://localhost:8080** (default admin
+secret `testing`). See [Navigating Hasura](/docs/HyperIndex/navigating-hasura).
+
+To run the pieces separately:
+
+```bash
+pnpm envio local docker up   # start Postgres + Hasura
+pnpm envio codegen
+pnpm envio start             # run the indexer against the running stack
+```
+
+:::tip Re-run codegen after config/schema changes
+Editing `config.yaml` or `schema.graphql` — including adding a program,
+instruction, or IDL — requires `pnpm envio codegen` to regenerate the typed
+`envio` module and the entity types in `.envio/`.
+:::
+
+## 4. Add your own program
+
+Open `config.yaml` and add a program under `programs_experimental` with the
+instructions you want, then write a handler. The shortest path:
+
+1. **Point at an Anchor IDL** if you have one — HyperIndex derives the argument and account layout for you ([IDL decoding](/docs/HyperIndex/solana/decoding#anchor-idls)).
+2. **Or declare an inline schema** (`args` + `accounts`) for programs without an IDL ([inline schema](/docs/HyperIndex/solana/decoding#inline-schema-no-idl)).
+3. Add a `discriminator` per instruction so HyperIndex knows which instruction to match ([discriminators](/docs/HyperIndex/solana/decoding#discriminators)).
+4. Register a handler with [`indexer.onInstruction`](/docs/HyperIndex/solana/instruction-handlers).
+
+```yaml title="config.yaml"
+ecosystem: svm
+chains:
+  - rpc: https://api.mainnet-beta.solana.com
+    start_block: 417995000
+    programs_experimental:
+      - name: TokenMetadata
+        program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+        instructions:
+          - name: CreateMetadataAccountV3
+            discriminator: "0x21"
+            field_selection:
+              transaction_fields: true
+```
+
+```typescript title="src/handlers/TokenMetadataHandlers.ts"
+import { indexer, type TokenMetadataAccount } from "envio";
+
+indexer.onInstruction(
+  { program: "TokenMetadata", instruction: "CreateMetadataAccountV3" },
+  async ({ event, context }) => {
+    const decoded = event.instruction.decoded;
+    if (!decoded) return; // discriminator matched but decode failed — skip
+
+    context.TokenMetadataAccount.set({
+      id: decoded.accounts.metadata,
+      mint: decoded.accounts.mint ?? "",
+      createdAtSlot: event.slot,
+      lastTxSignature: event.transaction?.signatures[0],
+    });
+  },
+);
+```
+
+## Next steps
+
+- [Configuration](/docs/HyperIndex/solana/configuration) — every `config.yaml` field for Solana.
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — the full event object, token balances, CPIs, and testing.
+- [Decoding & IDLs](/docs/HyperIndex/solana/decoding) — discriminators, IDLs, inline schemas, supported types.
+- [Deploy to Envio Cloud](/docs/HyperIndex/hosted-service) — host your Solana indexer the same way as EVM.

--- a/docs/HyperIndex/solana/getting-started.md
+++ b/docs/HyperIndex/solana/getting-started.md
@@ -14,7 +14,7 @@ and handlers differ.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) v20+ and [pnpm](https://pnpm.io) (or npm/yarn/bun)
+- [Node.js](https://nodejs.org) v20+ and [pnpm](https://pnpm.io). The commands below use `pnpm`/`pnpx`; npm, Yarn, and Bun work too if you swap the equivalents
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (for the local Postgres + GraphQL stack)
 - A HyperSync API token — the CLI's login flow sets this up for you, or generate one in the [Envio Cloud portal](https://envio.dev/app/api-tokens). See [API tokens](/docs/HyperSync/api-tokens).
 
@@ -36,15 +36,9 @@ pnpx envio init svm template --template metaplex-token-metadata --name my-indexe
 pnpx envio init svm template --template feature-block-handler  --name my-indexer
 ```
 
-:::note Solana is TypeScript-only
-The `--language` flag is ignored for Solana; projects are always scaffolded in
-TypeScript. There is no `contract-import` flow for Solana — unlike EVM/Fuel you
-wire up programs in `config.yaml` by hand (see [Configuration](/docs/HyperIndex/solana/configuration)).
-:::
-
 The template scaffolds:
 
-```
+```text
 my-indexer/
 ├── config.yaml          # chain + program/instruction selection
 ├── schema.graphql       # the entities you index into
@@ -110,7 +104,7 @@ instructions you want, then write a handler. The shortest path:
 ```yaml title="config.yaml"
 ecosystem: svm
 chains:
-  - start_block: 417995000
+  - start_block: 417995000 # example only; query /height (step 2) and pick a recent slot within the retention window
     experimental:
       hypersync_config:
         url: https://solana.hypersync.xyz

--- a/docs/HyperIndex/solana/instruction-handlers.md
+++ b/docs/HyperIndex/solana/instruction-handlers.md
@@ -3,7 +3,7 @@ id: solana-instruction-handlers
 title: Solana Instruction Handlers
 sidebar_label: Instruction Handlers
 slug: /solana/instruction-handlers
-description: Register and write Solana instruction handlers with indexer.onInstruction — the event object, decoded args/accounts, token balances, CPIs, context, and testing.
+description: Register and write Solana instruction handlers with indexer.onInstruction - the instruction object, decoded params, token balances, CPIs, context, and testing.
 ---
 
 # Instruction Handlers
@@ -17,34 +17,34 @@ import { indexer } from "envio";
 
 indexer.onInstruction(
   { program: "<PROGRAM_NAME>", instruction: "<INSTRUCTION_NAME>" },
-  async ({ event, context }) => {
+  async ({ instruction, context }) => {
     // your logic here
   },
 );
 ```
 
 `program` and `instruction` are the `name`s you gave them in `config.yaml` under
-`programs_experimental` — not the on-chain program id or IDL name.
+`experimental.programs` - not the on-chain program id or IDL name.
 
 :::note Run codegen after config/schema changes
 The `envio` module exposes a unified `indexer` value plus types derived from your
 `config.yaml` and `schema.graphql`. Run **`pnpm codegen`** whenever you change
 either file. After codegen, `program`/`instruction` autocomplete and
-`event.instruction.decoded.args` / `.accounts` are typed per instruction.
+`instruction.params.args` / `.accounts` are typed per instruction.
 :::
 
 ## A complete handler
 
 ```typescript
-import { indexer, type TokenMetadataAccount } from "envio";
+import { indexer } from "envio";
 
 indexer.onInstruction(
   { program: "TokenMetadata", instruction: "CreateMetadataAccountV3" },
-  async ({ event, context }) => {
-    const decoded = event.instruction.decoded;
-    if (!decoded) return; // discriminator matched but Borsh decode failed
+  async ({ instruction, context }) => {
+    const params = instruction.params;
+    if (!params) return; // discriminator matched but Borsh decode failed
 
-    const { args, accounts } = decoded;
+    const { args, accounts } = params;
     const metadataPda = accounts.metadata;
     if (!metadataPda) return;
 
@@ -52,60 +52,57 @@ indexer.onInstruction(
       id: metadataPda,
       mint: accounts.mint ?? "",
       updateAuthority: accounts.update_authority,
-      createdAtSlot: event.slot,
-      lastTxSignature: event.transaction?.signatures[0],
+      createdAtSlot: instruction.block.slot,
+      lastTxSignature: instruction.transaction.signatures[0],
     });
   },
 );
 ```
 
-## The event object
+## The instruction object
 
-```typescript
-type SvmInstructionEvent = {
-  contractName: string;   // the program name from config
-  eventName: string;      // the instruction name from config
-  slot: number;           // always present
-  blockTime?: number;     // unix seconds, when available
-  instruction: SvmInstruction;
-  transaction?: SvmTransaction; // present with transaction_fields / token_balance_fields
-  logs?: SvmLog[];              // present with log_fields
-};
-```
-
-`slot`, `blockTime` and `instruction` are always available. `transaction` and
-`logs` appear only when you opt in via
-[field selection](/docs/HyperIndex/solana/configuration#field-selection).
-
-### `event.instruction`
+The handler receives `{ instruction, context }`. The instruction carries its own
+fields plus the block, parent transaction, and scoped logs:
 
 ```typescript
 type SvmInstruction = {
+  programName: string;               // the program name from config
+  instructionName: string;           // the instruction name from config
   programId: string;                 // base58
   data: string;                      // 0x-prefixed hex (raw instruction data)
   accounts: readonly string[];       // base58 pubkeys, in on-chain order
   instructionAddress: readonly number[]; // CPI path, e.g. [0] or [0,1]
   isInner: boolean;                  // true => inner (CPI) instruction
   d1?: string; d2?: string; d4?: string; d8?: string; // discriminator prefixes (hex)
-  decoded?: SvmDecodedInstruction;   // present when a schema matched (see Decoding)
+  params?: SvmInstructionParams;     // present when a schema matched (see Decoding)
+  block: { slot: number; time?: number; hash: string /* + block_fields */ };
+  transaction: SvmTransaction;       // fields per your transaction_fields selection
+  logs?: readonly SvmLog[];          // present with log_fields
 };
 ```
 
-- **`decoded`** is the friendly view: `{ name, args, accounts, extraAccounts }`. It's
-  optional — always null-check it. See [Decoding & IDLs](/docs/HyperIndex/solana/decoding)
+- **`params`** is the Borsh-decoded view: `{ name, args, accounts, extraAccounts }`.
+  It's optional - always null-check it. See [Decoding & IDLs](/docs/HyperIndex/solana/decoding)
   for the shape of `args` and `accounts`.
-- **`accounts`** (raw, positional, base58) is always present even when `decoded` is
-  not. `decoded.accounts` is the same list keyed by your schema's account names.
-- **`instructionAddress`** locates the instruction in the transaction's call tree —
+- **`accounts`** (raw, positional, base58) is always present even when `params` is
+  not. `params.accounts` is the same list keyed by your schema's account names.
+- **`instructionAddress`** locates the instruction in the transaction's call tree -
   see [Inner instructions](#inner-instructions-cpis).
+- **`block`** always carries `slot`, `time` (unix seconds, may be `undefined`), and
+  `hash`; select `height`/`parentSlot`/`parentHash` via `field_selection.block_fields`.
 
-### `event.transaction`
+### `instruction.transaction`
 
-Present when `transaction_fields: true` (or `token_balance_fields: true`):
+Always present as an object, but each field is only readable when selected via
+`field_selection.transaction_fields` (see
+[field selection](/docs/HyperIndex/solana/configuration#field-selection)).
+Unselected fields are typed as `FieldNotSelected`, so reading one is a compile
+error pointing at the config key to add.
 
 ```typescript
 type SvmTransaction = {
   signatures: readonly string[];   // signatures[0] is the transaction id
+  transactionIndex: number;
   feePayer?: string;
   success?: boolean;
   err?: string;
@@ -114,13 +111,13 @@ type SvmTransaction = {
   accountKeys: readonly string[];
   recentBlockhash?: string;
   version?: string;
-  tokenBalances?: readonly SvmTokenBalance[]; // with token_balance_fields
+  tokenBalances?: readonly SvmTokenBalance[]; // with token_balance_fields: true
 };
 ```
 
 ### Token balances and balance changes
 
-With `token_balance_fields: true`, each event's transaction carries **pre/post SPL
+With `token_balance_fields: true`, each instruction's transaction carries **pre/post SPL
 Token (and Token-2022) balance snapshots**. The `postAmount − preAmount` per token
 account is the balance *change* — so this is the cleanest way to capture net value
 flow without indexing every transfer instruction. The snapshots cover every token
@@ -139,11 +136,11 @@ type SvmTokenBalance = {
 ```typescript
 indexer.onInstruction(
   { program: "Jupiter", instruction: "sharedAccountsRoute" },
-  async ({ event, context }) => {
-    const txSig = event.transaction?.signatures[0];
+  async ({ instruction, context }) => {
+    const txSig = instruction.transaction.signatures[0];
     if (!txSig) return;
 
-    for (const b of event.transaction?.tokenBalances ?? []) {
+    for (const b of instruction.transaction.tokenBalances ?? []) {
       if (!b.account) continue;
       const pre = BigInt(b.preAmount ?? "0");
       const post = BigInt(b.postAmount ?? "0");
@@ -165,7 +162,7 @@ avoid precision loss. Wrap them in `BigInt(...)` for arithmetic.
 :::
 
 :::note Native SOL balances
-Today the handler event surfaces **token** balances. Native SOL (lamport) pre/post
+Today the handler surfaces **token** balances. Native SOL (lamport) pre/post
 balances are available from [HyperSync for Solana](/docs/HyperSync/solana) directly
 (the `balance` table) but are not yet exposed as a handler field-selection toggle —
 [let us know](https://discord.gg/envio) if you need them in handlers.
@@ -173,7 +170,7 @@ balances are available from [HyperSync for Solana](/docs/HyperSync/solana) direc
 
 ### Logs
 
-With `log_fields: true`, `event.logs` holds the program logs scoped to this
+With `log_fields: true`, `instruction.logs` holds the program logs scoped to this
 instruction:
 
 ```typescript
@@ -193,7 +190,7 @@ reconstruct the call tree:
   `[0, 1, 2]` one level deeper, and so on.
 
 ```typescript
-const addr = event.instruction.instructionAddress; // e.g. [0, 1]
+const addr = instruction.instructionAddress;        // e.g. [0, 1]
 const path = addr.join(".");                        // "0.1"
 const depth = addr.length - 1;                      // 1
 const parentPath = addr.length > 1 ? addr.slice(0, -1).join(".") : undefined;
@@ -246,41 +243,40 @@ deterministic entity ids and use `set` (which is insert-or-update). A common
 Solana id is the transaction signature combined with the instruction path:
 
 ```typescript
-const id = `${event.transaction?.signatures[0]}:${event.instruction.instructionAddress.join(".")}`;
+const id = `${instruction.transaction.signatures[0]}:${instruction.instructionAddress.join(".")}`;
 ```
 
 ## Testing
 
 Solana indexers are tested by running the indexer over a pinned slot window
-against live HyperSync and asserting on the changes it produces. Use a
-`config.test.yaml` with a finite `end_block`, select it with `ENVIO_CONFIG`, and
-drive it with `createTestIndexer`:
+against live HyperSync and asserting on the changes it produces. Pass the window
+as per-chain `startBlock`/`endBlock` overrides to `process` (the Solana chain id
+is `0`):
 
 ```typescript
-process.env.ENVIO_CONFIG = "config.test.yaml"; // must be set before importing envio
 import { describe, it, expect } from "vitest";
 import { createTestIndexer } from "envio";
 
 describe("my solana indexer", () => {
   it("indexes instructions in the pinned window", async () => {
     const indexer = createTestIndexer();
-    const result = await indexer.process({ chains: { 0: {} } });
+    const result = await indexer.process({
+      chains: { 0: { startBlock: 420_620_000, endBlock: 420_620_200 } },
+    });
 
     // result.changes is an array of per-batch checkpoints:
-    //   [{ <EntityName>: { sets: [...] }, eventsProcessed }, ...]
+    //   [{ block, chainId, eventsProcessed, <EntityName>: { sets: [...] } }, ...]
     const sets = result.changes.flatMap(
-      (c: any) => c.TokenMetadataAccount?.sets ?? [],
+      (c) => c.TokenMetadataAccount?.sets ?? [],
     );
     expect(sets.length).toBeGreaterThan(0);
-  }, 120_000); // generous timeout — this hits the network
+  }, 120_000); // generous timeout - this hits the network
 });
 ```
 
-```yaml title="config.test.yaml"
-# same as config.yaml, but a small finite window for determinism
-start_block: 417950000
-end_block: 417950500
-```
+To keep a separate test config instead, point the `ENVIO_CONFIG` environment
+variable at a `config.test.yaml` (with its own `start_block`/`end_block`) before
+importing `envio`.
 
 Because these tests hit the real endpoint, assert on **shape and invariants**
 (e.g. "produced rows", "deltas equal post − pre", "saw ≥ 2 programs") rather than
@@ -288,6 +284,6 @@ exact counts.
 
 ## Related
 
-- [Decoding & IDLs](/docs/HyperIndex/solana/decoding) — what `decoded.args` / `decoded.accounts` contain.
+- [Decoding & IDLs](/docs/HyperIndex/solana/decoding) - what `params.args` / `params.accounts` contain.
 - [Configuration](/docs/HyperIndex/solana/configuration) — field selection, account filters, `is_inner`.
 - [Slot Handlers](/docs/HyperIndex/solana/slot-handlers) — the other Solana handler type.

--- a/docs/HyperIndex/solana/instruction-handlers.md
+++ b/docs/HyperIndex/solana/instruction-handlers.md
@@ -1,0 +1,293 @@
+---
+id: solana-instruction-handlers
+title: Solana Instruction Handlers
+sidebar_label: Instruction Handlers
+slug: /solana/instruction-handlers
+description: Register and write Solana instruction handlers with indexer.onInstruction — the event object, decoded args/accounts, token balances, CPIs, context, and testing.
+---
+
+# Instruction Handlers
+
+On Solana you react to **instructions** instead of EVM events. Register a handler
+with `indexer.onInstruction`; it fires once for every matched instruction (top-level
+or inner) of the configured program.
+
+```typescript
+import { indexer } from "envio";
+
+indexer.onInstruction(
+  { program: "<PROGRAM_NAME>", instruction: "<INSTRUCTION_NAME>" },
+  async ({ event, context }) => {
+    // your logic here
+  },
+);
+```
+
+`program` and `instruction` are the `name`s you gave them in `config.yaml` under
+`programs_experimental` — not the on-chain program id or IDL name.
+
+:::note Run codegen after config/schema changes
+The `envio` module exposes a unified `indexer` value plus types derived from your
+`config.yaml` and `schema.graphql`. Run **`pnpm codegen`** whenever you change
+either file. After codegen, `program`/`instruction` autocomplete and
+`event.instruction.decoded.args` / `.accounts` are typed per instruction.
+:::
+
+## A complete handler
+
+```typescript
+import { indexer, type TokenMetadataAccount } from "envio";
+
+indexer.onInstruction(
+  { program: "TokenMetadata", instruction: "CreateMetadataAccountV3" },
+  async ({ event, context }) => {
+    const decoded = event.instruction.decoded;
+    if (!decoded) return; // discriminator matched but Borsh decode failed
+
+    const { args, accounts } = decoded;
+    const metadataPda = accounts.metadata;
+    if (!metadataPda) return;
+
+    context.TokenMetadataAccount.set({
+      id: metadataPda,
+      mint: accounts.mint ?? "",
+      updateAuthority: accounts.update_authority,
+      createdAtSlot: event.slot,
+      lastTxSignature: event.transaction?.signatures[0],
+    });
+  },
+);
+```
+
+## The event object
+
+```typescript
+type SvmInstructionEvent = {
+  contractName: string;   // the program name from config
+  eventName: string;      // the instruction name from config
+  slot: number;           // always present
+  blockTime?: number;     // unix seconds, when available
+  instruction: SvmInstruction;
+  transaction?: SvmTransaction; // present with transaction_fields / token_balance_fields
+  logs?: SvmLog[];              // present with log_fields
+};
+```
+
+`slot`, `blockTime` and `instruction` are always available. `transaction` and
+`logs` appear only when you opt in via
+[field selection](/docs/HyperIndex/solana/configuration#field-selection).
+
+### `event.instruction`
+
+```typescript
+type SvmInstruction = {
+  programId: string;                 // base58
+  data: string;                      // 0x-prefixed hex (raw instruction data)
+  accounts: readonly string[];       // base58 pubkeys, in on-chain order
+  instructionAddress: readonly number[]; // CPI path, e.g. [0] or [0,1]
+  isInner: boolean;                  // true => inner (CPI) instruction
+  d1?: string; d2?: string; d4?: string; d8?: string; // discriminator prefixes (hex)
+  decoded?: SvmDecodedInstruction;   // present when a schema matched (see Decoding)
+};
+```
+
+- **`decoded`** is the friendly view: `{ name, args, accounts, extraAccounts }`. It's
+  optional — always null-check it. See [Decoding & IDLs](/docs/HyperIndex/solana/decoding)
+  for the shape of `args` and `accounts`.
+- **`accounts`** (raw, positional, base58) is always present even when `decoded` is
+  not. `decoded.accounts` is the same list keyed by your schema's account names.
+- **`instructionAddress`** locates the instruction in the transaction's call tree —
+  see [Inner instructions](#inner-instructions-cpis).
+
+### `event.transaction`
+
+Present when `transaction_fields: true` (or `token_balance_fields: true`):
+
+```typescript
+type SvmTransaction = {
+  signatures: readonly string[];   // signatures[0] is the transaction id
+  feePayer?: string;
+  success?: boolean;
+  err?: string;
+  fee?: bigint;                    // lamports
+  computeUnitsConsumed?: bigint;
+  accountKeys: readonly string[];
+  recentBlockhash?: string;
+  version?: string;
+  tokenBalances?: readonly SvmTokenBalance[]; // with token_balance_fields
+};
+```
+
+### Token balances and balance changes
+
+With `token_balance_fields: true`, each event's transaction carries **pre/post SPL
+Token (and Token-2022) balance snapshots**. The `postAmount − preAmount` per token
+account is the balance *change* — so this is the cleanest way to capture net value
+flow without indexing every transfer instruction. The snapshots cover every token
+account touched by the transaction.
+
+```typescript
+type SvmTokenBalance = {
+  account?: string;     // token account (base58)
+  mint?: string;
+  owner?: string;
+  preAmount?: string;   // balance before the tx — u64 as a decimal string
+  postAmount?: string;  // balance after the tx  — u64 as a decimal string
+};
+```
+
+```typescript
+indexer.onInstruction(
+  { program: "Jupiter", instruction: "sharedAccountsRoute" },
+  async ({ event, context }) => {
+    const txSig = event.transaction?.signatures[0];
+    if (!txSig) return;
+
+    for (const b of event.transaction?.tokenBalances ?? []) {
+      if (!b.account) continue;
+      const pre = BigInt(b.preAmount ?? "0");
+      const post = BigInt(b.postAmount ?? "0");
+      context.TokenDelta.set({
+        id: `${txSig}:${b.account}`,
+        account: b.account,
+        mint: b.mint ?? "",
+        owner: b.owner,
+        delta: post - pre, // signed
+      });
+    }
+  },
+);
+```
+
+:::tip Amounts are strings
+`preAmount`/`postAmount` (and any `u64`+ decoded arg) are **decimal strings** to
+avoid precision loss. Wrap them in `BigInt(...)` for arithmetic.
+:::
+
+:::note Native SOL balances
+Today the handler event surfaces **token** balances. Native SOL (lamport) pre/post
+balances are available from [HyperSync for Solana](/docs/HyperSync/solana) directly
+(the `balance` table) but are not yet exposed as a handler field-selection toggle —
+[let us know](https://discord.gg/envio) if you need them in handlers.
+:::
+
+### Logs
+
+With `log_fields: true`, `event.logs` holds the program logs scoped to this
+instruction:
+
+```typescript
+type SvmLog = { kind: string; message: string };
+// kind is one of: invoke | success | failure | log | data | other
+```
+
+## Inner instructions (CPIs)
+
+HyperIndex decodes inner instructions (instructions invoked by other programs via
+cross-program invocation) exactly like top-level ones. Two fields let you
+reconstruct the call tree:
+
+- **`isInner`** — `false` for a top-level instruction, `true` for a CPI.
+- **`instructionAddress`** — an array describing the path: `[0]` is the first
+  top-level instruction, `[0, 1]` is the second inner instruction invoked by it,
+  `[0, 1, 2]` one level deeper, and so on.
+
+```typescript
+const addr = event.instruction.instructionAddress; // e.g. [0, 1]
+const path = addr.join(".");                        // "0.1"
+const depth = addr.length - 1;                      // 1
+const parentPath = addr.length > 1 ? addr.slice(0, -1).join(".") : undefined;
+```
+
+By default an instruction config (no `is_inner` set) matches **both** inner and
+outer occurrences, so you capture the full tree. Set `is_inner: true`/`false` in
+[config](/docs/HyperIndex/solana/configuration#instructions) to narrow it.
+
+:::info EVM difference
+EVM "internal calls" aren't surfaced as first-class events. On Solana, CPIs are
+real indexable instructions — a Jupiter route's underlying Raydium/Orca swaps are
+all visible if you index those programs.
+:::
+
+## The context object
+
+The handler's `context` is the same shape as EVM handlers (see the
+[Event Handlers context](/docs/HyperIndex/event-handlers#context-object)). For
+each entity in `schema.graphql` you get:
+
+```typescript
+context.<Entity>.set(entity);                 // insert or update
+await context.<Entity>.get(id);               // -> entity | undefined
+await context.<Entity>.getOrThrow(id, msg?);  // -> entity (throws if missing)
+await context.<Entity>.getOrCreate(entity);   // get, or set+return the default
+await context.<Entity>.getWhere({ field: { _eq: v } }); // query @index fields
+context.<Entity>.deleteUnsafe(id);
+```
+
+Plus:
+
+- `context.log` — structured logger (`info`/`warn`/`error`/`debug`).
+- `context.effect` — call an [Effect](/docs/HyperIndex/effect-api) (external/RPC calls, deduped and cached). Works in Solana handlers.
+- `context.chain` — `{ id, isRealtime }`. For Solana, `id` is `0`.
+- `context.isPreload` — see below.
+
+### Preload optimization (double-run)
+
+Preload optimization is always on in HyperIndex V3, which means **your handler
+runs twice** — once in a parallel preload pass to warm the entity cache, then in
+order. Reads are idempotent, so this is usually invisible, but guard
+non-idempotent side effects (e.g. external POSTs) with `if (context.isPreload) return;`.
+See [Preload Optimization](/docs/HyperIndex/preload-optimization).
+
+## Idempotent writes
+
+Backfills and the double-run pass mean handlers should be **idempotent**: build
+deterministic entity ids and use `set` (which is insert-or-update). A common
+Solana id is the transaction signature combined with the instruction path:
+
+```typescript
+const id = `${event.transaction?.signatures[0]}:${event.instruction.instructionAddress.join(".")}`;
+```
+
+## Testing
+
+Solana indexers are tested by running the indexer over a pinned slot window
+against live HyperSync and asserting on the changes it produces. Use a
+`config.test.yaml` with a finite `end_block`, select it with `ENVIO_CONFIG`, and
+drive it with `createTestIndexer`:
+
+```typescript
+process.env.ENVIO_CONFIG = "config.test.yaml"; // must be set before importing envio
+import { describe, it, expect } from "vitest";
+import { createTestIndexer } from "envio";
+
+describe("my solana indexer", () => {
+  it("indexes instructions in the pinned window", async () => {
+    const indexer = createTestIndexer();
+    const result = await indexer.process({ chains: { 0: {} } });
+
+    // result.changes is an array of per-batch checkpoints:
+    //   [{ <EntityName>: { sets: [...] }, eventsProcessed }, ...]
+    const sets = result.changes.flatMap(
+      (c: any) => c.TokenMetadataAccount?.sets ?? [],
+    );
+    expect(sets.length).toBeGreaterThan(0);
+  }, 120_000); // generous timeout — this hits the network
+});
+```
+
+```yaml title="config.test.yaml"
+# same as config.yaml, but a small finite window for determinism
+start_block: 417950000
+end_block: 417950500
+```
+
+Because these tests hit the real endpoint, assert on **shape and invariants**
+(e.g. "produced rows", "deltas equal post − pre", "saw ≥ 2 programs") rather than
+exact counts.
+
+## Related
+
+- [Decoding & IDLs](/docs/HyperIndex/solana/decoding) — what `decoded.args` / `decoded.accounts` contain.
+- [Configuration](/docs/HyperIndex/solana/configuration) — field selection, account filters, `is_inner`.
+- [Slot Handlers](/docs/HyperIndex/solana/slot-handlers) — the other Solana handler type.

--- a/docs/HyperIndex/solana/instruction-handlers.md
+++ b/docs/HyperIndex/solana/instruction-handlers.md
@@ -59,6 +59,13 @@ indexer.onInstruction(
 );
 ```
 
+:::note Reading `instruction.transaction`
+`instruction.transaction.signatures[0]` is only populated when the instruction
+opts into it via [field selection](/docs/HyperIndex/solana/configuration#field-selection)
+(`transaction_fields: [signatures]` in `config.yaml`). Without it the field is
+absent and won't type-check.
+:::
+
 ## The instruction object
 
 The handler receives `{ instruction, context }`. The instruction carries its own

--- a/docs/HyperIndex/solana/slot-handlers.md
+++ b/docs/HyperIndex/solana/slot-handlers.md
@@ -140,7 +140,7 @@ See [Preload Optimization](/docs/HyperIndex/preload-optimization).
 | --- | --- | --- |
 | Trigger | Every slot / interval | A matched program instruction |
 | Data source | RPC (via Effects) | HyperSync |
-| Config needed | None (self-registers) | `programs_experimental` entry |
+| Config needed | None (self-registers) | `experimental.programs` entry |
 | Best for | Time-series, snapshots, scheduled pulls | Decoding protocol activity |
 
 Reach for [instruction handlers](/docs/HyperIndex/solana/instruction-handlers) to

--- a/docs/HyperIndex/solana/slot-handlers.md
+++ b/docs/HyperIndex/solana/slot-handlers.md
@@ -1,0 +1,156 @@
+---
+id: solana-slot-handlers
+title: Solana Slot Handlers
+sidebar_label: Slot Handlers
+slug: /solana/slot-handlers
+description: Run logic on every Solana slot or an interval with indexer.onSlot, and enrich it with RPC data via the Effect API.
+---
+
+# Slot Handlers
+
+`indexer.onSlot` runs logic on every slot or at an interval — the Solana
+equivalent of EVM [block handlers](/docs/HyperIndex/block-handlers). Use it for
+time-series snapshots, periodic aggregations, or pulling extra data from RPC on a
+schedule with the [Effect API](/docs/HyperIndex/effect-api). For indexing program
+activity, reach for [instruction handlers](/docs/HyperIndex/solana/instruction-handlers)
+instead.
+
+```typescript
+import { indexer } from "envio";
+
+indexer.onSlot({ name: "MySlotHandler" }, async ({ slot, context }) => {
+  context.log.info(`Processing slot ${slot}`);
+});
+```
+
+Slot handlers **self-register** — they need no entry in `config.yaml` beyond the
+chain itself. With no `where`, the handler runs on every slot.
+
+## Options
+
+`indexer.onSlot(options, handler)`:
+
+- **`name`** (required) — unique name, used for logging, metrics, and progress tracking.
+- **`where`** (optional) — `({ chain }) => false | true | { slot: { _gte?, _lte?, _every? } }`. Evaluated once per chain at registration to decide which chains the handler runs on and over which slot range/interval.
+
+```typescript
+indexer.onSlot(
+  {
+    name: "SlotSampler",
+    where: ({ chain }) =>
+      chain.id === 0
+        ? {
+            slot: {
+              _gte: 385_453_000, // start slot (inclusive)
+              _lte: 385_500_000, // end slot (inclusive)
+              _every: 100,       // every 100th slot
+            },
+          }
+        : false,
+  },
+  async ({ slot, context }) => {
+    context.SlotPing.set({ id: slot.toString(), slot });
+  },
+);
+```
+
+:::note Differences from EVM `onBlock`
+- The handler argument is `{ slot: number, context }` — a plain slot number, **not** a `block` object.
+- The filter key is `slot` (with `_gte` / `_lte` / `_every`), not `block.number`.
+- There's no `interval` option; express intervals with `_every`. `_every` aligns to `_gte` (or the chain start) — it fires when `(slot − _gte) % _every === 0`.
+:::
+
+## The handler
+
+The handler receives `{ slot, context }`:
+
+- **`slot`** — the slot number being processed (a plain `number`).
+- **`context`** — entity operations (one object per `schema.graphql` entity, with `get` / `getOrThrow` / `getWhere` / `getOrCreate` / `set` / `deleteUnsafe`), plus `context.log`, `context.effect`, `context.chain` (`id` is `0` for Solana), and `context.isPreload`. This is the same context as EVM handlers — see the [Event Handlers context](/docs/HyperIndex/event-handlers#context-object).
+
+## Enriching with RPC data via Effects
+
+A slot number alone is rarely enough — pair `onSlot` with an
+[Effect](/docs/HyperIndex/effect-api) to fetch block/transaction/account data from
+RPC. Effects are deduplicated and cached, and can be rate-limited so you don't
+exhaust your RPC provider. `S` (from `envio`) builds the input/output schemas
+(it's the [Sury](https://github.com/DZakh/sury) library).
+
+```typescript
+import { indexer, createEffect, S } from "envio";
+
+const blockSchema = S.schema({
+  blockhash: S.string,
+  blockHeight: S.nullable(S.number),
+  blockTime: S.nullable(S.number),
+});
+
+const getBlock = createEffect(
+  {
+    name: "getBlock",
+    input: { slot: S.number },
+    output: S.nullable(blockSchema),
+    rateLimit: { calls: 3, per: "second" },
+  },
+  async ({ input }) => {
+    const res = await fetch(process.env.ENVIO_MAINNET_RPC_URL!, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getBlock",
+        params: [input.slot, { maxSupportedTransactionVersion: 1, transactionDetails: "none" }],
+      }),
+    });
+    const { result } = await res.json();
+    return result ?? null;
+  },
+);
+
+indexer.onSlot({ name: "BlockTracker" }, async ({ slot, context }) => {
+  const block = await context.effect(getBlock, { slot });
+  if (!block) {
+    context.log.info(`Slot ${slot} has no block (skipped leader)`);
+    return; // some slots produce no block
+  }
+  context.BlockInfo.set({
+    id: slot.toString(),
+    hash: block.blockhash,
+    height: block.blockHeight ?? undefined,
+    time: block.blockTime ? new Date(block.blockTime * 1000) : undefined,
+  });
+});
+```
+
+:::tip Not every slot has a block
+On Solana a slot may be skipped (the leader produced no block). Handle the empty
+result rather than assuming `getBlock` always returns data.
+:::
+
+### Preload double-run
+
+Like all V3 handlers, slot handlers run twice (a parallel preload pass to warm the
+cache, then the ordered pass). Effects are cached across both runs, so reads are
+cheap, but guard non-idempotent side effects with `if (context.isPreload) return;`.
+See [Preload Optimization](/docs/HyperIndex/preload-optimization).
+
+## Slot handlers vs instruction handlers
+
+| | Slot handler | Instruction handler |
+| --- | --- | --- |
+| Trigger | Every slot / interval | A matched program instruction |
+| Data source | RPC (via Effects) | HyperSync |
+| Config needed | None (self-registers) | `programs_experimental` entry |
+| Best for | Time-series, snapshots, scheduled pulls | Decoding protocol activity |
+
+Reach for [instruction handlers](/docs/HyperIndex/solana/instruction-handlers) to
+index *what programs did*, and slot handlers to do something *on a cadence*. They
+compose — an instruction handler can record an event, and a slot handler can
+periodically roll those events into a snapshot. For raw, low-level data over large
+ranges, query [HyperSync for Solana](/docs/HyperSync/solana) directly.
+
+## Related
+
+- [Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers) — the main Solana handler type.
+- [Effect API](/docs/HyperIndex/effect-api) — external/RPC calls, caching, rate limiting.
+- [Configuration](/docs/HyperIndex/solana/configuration) — chains, RPC, programs, and start slot.

--- a/docs/HyperIndex/solana/solana.md
+++ b/docs/HyperIndex/solana/solana.md
@@ -1,58 +1,98 @@
 ---
 id: solana
 title: Solana
-sidebar_label: Solana
+sidebar_label: Overview
 slug: /solana
-description: Early Solana support in HyperIndex. Slot Handler, Effect API, and Envio Cloud today; deeper instruction/log-level handlers in progress.
+description: Index Solana programs with HyperIndex — instruction-level handlers, IDL-aware decoding, CPI/inner-instruction support, token balances & balance changes, and slot handlers.
 ---
 
-:::info Early — and the right moment to shape it
-Solana support in HyperIndex is **early**. The slot handler, the Effect API, and Envio Cloud deployment all work today, and teams are using them for real workloads. The higher-level abstractions (instruction-level handlers, IDL-aware decoding, log handlers) are actively being built, and we'd rather help you pick the right path now than have you fight with an early prototype. **If you're evaluating Solana indexing, [reach out on Discord](https://discord.gg/envio)** — we can tell you which pieces are stable, which are still moving, and often suggest a better data path for your specific use case (NFTs, AMMs, token flows, wallet activity, custom programs, etc.).
+# Indexing on Solana
+
+HyperIndex indexes Solana programs at the **instruction level**. You select the
+programs and instructions you care about, HyperIndex decodes them — arguments and
+accounts — using your Anchor IDL or an inline schema, and writes the results to
+Postgres with an auto-generated GraphQL API. Inner instructions (CPIs), **token
+balances and balance changes**, transaction metadata and program logs are all
+available.
+
+It is powered by [HyperSync for Solana](/docs/HyperSync/solana), the same
+high-performance data engine behind EVM indexing, so historical backfills are
+fast and you never touch an RPC node for the bulk of indexing.
+
+:::info Early access — and a good time to shape it
+Solana support is **experimental and pre-release**. The program/instruction
+config surface (`programs_experimental`) may change, indexers are
+**TypeScript-only**, and the indexer tracks **finalized data** (no reorg
+handling — see [below](#what-is-not-supported-yet)). The APIs documented here are
+the latest in active development. If you're building on Solana, say hello on
+[Discord](https://discord.gg/envio) — we can tell you which pieces are stable,
+which are moving, and often suggest a better data path for your use case.
 :::
 
-## What's supported today
+## Two ways to index Solana
 
-- [Slot Handler](/docs/HyperIndex/block-handlers) — `indexer.onSlot` for slot-driven indexing.
-- [Effect API](/docs/HyperIndex/effect-api) — pull additional data on demand from RPC or any source.
-- [Envio Cloud](/docs/HyperIndex/hosted-service) — deploy and host Solana indexers the same way as EVM ones.
-- **Raw Solana data via [HyperSync](/docs/HyperSync/solana)** — slots, transactions, instructions, logs, balances, token balances, rewards. Today HyperSync is consumed directly (Rust client or HTTP); we recommend it as the starting point for any workload that needs more than slot-level orchestration.
+| Approach | API | Data source | Use it for |
+| --- | --- | --- | --- |
+| **Instruction handlers** | [`indexer.onInstruction`](/docs/HyperIndex/solana/instruction-handlers) | HyperSync | The main path — decode and index program instructions (swaps, deposits, mints, transfers…), including inner/CPI instructions, with token balance changes. |
+| **Slot handlers** | [`indexer.onSlot`](/docs/HyperIndex/solana/slot-handlers) | RPC (via the [Effect API](/docs/HyperIndex/effect-api)) | Per-slot orchestration, time-series snapshots, or pulling extra data from RPC on a schedule. |
+
+Most indexers use instruction handlers. Slot handlers are for cases where you
+need to run logic on a slot cadence rather than react to a specific instruction.
+For raw, low-level data you can also query [HyperSync for Solana](/docs/HyperSync/solana) directly.
 
 ## Quickstart
 
 ```bash
-pnpx envio init svm
+pnpx envio init
 ```
 
-## What's stable vs. what's still evolving
+Choose **Solana** when prompted, then pick a starter template (a Metaplex NFT
+instruction indexer, or a minimal slot handler). See
+[Getting Started](/docs/HyperIndex/solana/getting-started) for the full walkthrough.
 
-**Stable enough to build on**
+## Mental model: coming from EVM?
 
-- The `onSlot` handler API and the project layout produced by `envio init svm`.
-- The Effect API for fetching slot data on demand.
-- Envio Cloud deployment for Solana indexers.
-- The underlying HyperSync query shape and table model (see [HyperSync for Solana](/docs/HyperSync/solana#whats-stable-vs-whats-still-evolving)).
+If you've used HyperIndex on EVM, the shift is mostly vocabulary:
 
-**Still evolving — check in if you depend on these**
+| EVM | Solana |
+| --- | --- |
+| Contract + ABI | Program + IDL |
+| Event (`onEvent`) | Instruction (`onInstruction`) |
+| `event.params` | `event.instruction.decoded.args` |
+| Topic0 / event signature | Instruction discriminator |
+| Block (`onBlock`) | Slot (`onSlot`) |
+| Hex addresses `0x…` | Base58 addresses |
+| `start_block` = block number | `start_block` = **slot** number |
 
-- Instruction-level and log-level handlers (today you fetch by slot and decode yourself, or query HyperSync directly).
-- IDL-aware decoding and program-aware helpers inside HyperIndex.
-- Reorg handling — HyperIndex Solana currently tracks **finalized slots only**, resulting in **~20s latency**.
-- HyperSync as a first-class source inside HyperIndex (today the slot handler is RPC-driven; HyperSync is consumed directly).
+See [EVM vs Solana](/docs/HyperIndex/solana/evm-vs-solana) for the full picture.
 
-If the piece you need is in the second list, please talk to us before building around the limitation — there's a good chance we can sequence the work to unblock you, or suggest a HyperSync-direct path that gets you the data you need today.
+## What's supported today
 
-## Recommended path for new projects
+- **Instruction indexing** via [`indexer.onInstruction`](/docs/HyperIndex/solana/instruction-handlers) — match by program + discriminator.
+- **IDL-aware decoding** — point at a standard Anchor IDL (legacy or 0.30+) and HyperIndex derives the argument and account layout. No IDL? Declare an [inline schema](/docs/HyperIndex/solana/decoding#inline-schema-no-idl).
+- **Inner instructions (CPIs)** — decoded the same way as top-level ones, with a full instruction-address path so you can reconstruct the call tree.
+- **Token balances & balance changes** — pre/post SPL Token (and Token-2022) balances per transaction, so you get the net token movement without indexing every transfer. See [token balances](/docs/HyperIndex/solana/instruction-handlers#token-balances-and-balance-changes).
+- **Transaction metadata & logs** — fee payer, fee, compute units, success, signatures, and per-instruction program logs (opt-in via [field selection](/docs/HyperIndex/solana/configuration#field-selection)).
+- **Slot handlers** via [`indexer.onSlot`](/docs/HyperIndex/solana/slot-handlers) + the [Effect API](/docs/HyperIndex/effect-api) for RPC enrichment.
+- **Local dev + GraphQL + Envio Cloud** — the same workflow and hosting as EVM.
 
-For most Solana use cases today, the fastest path to useful data is:
+## What is not supported yet
 
-1. **Start with [HyperSync for Solana](/docs/HyperSync/solana)** to validate that the raw data you need (instructions, accounts, logs, token balances) is available and shaped the way you expect.
-2. **Use the HyperIndex `onSlot` handler + Effect API** for orchestration, state, and derived entities on top of that data.
-3. **Tell us what you're building** — we'll point you at the right primitive and let you know what's about to land.
+- **Reorg handling.** Solana indexers track finalized data only; there is no rollback-on-reorg. Expect a short latency at the head.
+- **Native SOL balance fields on handlers.** Pre/post **token** balances are surfaced today; native SOL (lamport) balances are available via [HyperSync](/docs/HyperSync/solana) directly but not yet as a handler field-selection toggle.
+- **Account-change subscriptions.** There is no `onAccount`/program-account handler. Account *state* is available only as the accounts referenced by an instruction (plus per-transaction token balances).
+- **A separate log handler.** Logs are a field on the instruction event, not their own handler.
+- **No-code contract import.** Solana has no `contract-import` flow — you configure programs/instructions by hand. (IDLs are wired up in `config.yaml`, not auto-imported.)
+- **ReScript.** Solana indexers are TypeScript only.
+- **Per-field selection.** Field-selection toggles accept `true` only, not field name lists (yet).
 
-## Working with us
+If the piece you need is on this list, [tell us on Discord](https://discord.gg/envio) — there's a good chance we can sequence the work to unblock you, or point you at a [HyperSync-direct](/docs/HyperSync/solana) path that gets the data today.
 
-This is genuinely a good time to be a design partner on Solana:
+## In this section
 
-- **[Discord](https://discord.gg/envio)** — fastest way to reach the team.
-- Share a sample program, transaction signature, or the entities you need to index, and we'll map it to a concrete plan.
-- Missing a field, decoder, or handler shape? File it on [GitHub](https://github.com/enviodev/hyperindex/issues) or tell us on Discord — early feedback shapes what ships next.
+- **[Getting Started](/docs/HyperIndex/solana/getting-started)** — scaffold and run your first Solana indexer.
+- **[Configuration](/docs/HyperIndex/solana/configuration)** — the `config.yaml` reference for `ecosystem: svm`.
+- **[Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers)** — `onInstruction`, the event object, token balances, CPIs, testing.
+- **[Decoding & IDLs](/docs/HyperIndex/solana/decoding)** — discriminators, Anchor IDLs, inline schemas, supported types.
+- **[Slot Handlers](/docs/HyperIndex/solana/slot-handlers)** — `onSlot` and RPC enrichment.
+- **[EVM vs Solana](/docs/HyperIndex/solana/evm-vs-solana)** — every difference in one place.

--- a/docs/HyperIndex/solana/solana.md
+++ b/docs/HyperIndex/solana/solana.md
@@ -21,9 +21,8 @@ fast and you never touch an RPC node for the bulk of indexing.
 
 :::info Early access — and a good time to shape it
 Solana support is **experimental and pre-release**. The program/instruction
-config surface (the chain-level `experimental` key) may change, indexers are
-**TypeScript-only**, and the indexer tracks **finalized data** (no reorg
-handling — see [below](#what-is-not-supported-yet)). The APIs documented here are
+config surface (the chain-level `experimental` key) may change, and indexers are
+**TypeScript-only**. The APIs documented here are
 the latest in active development. If you're building on Solana, say hello on
 [Discord](https://discord.gg/envio) — we can tell you which pieces are stable,
 which are moving, and often suggest a better data path for your use case.
@@ -78,7 +77,6 @@ See [EVM vs Solana](/docs/HyperIndex/solana/evm-vs-solana) for the full picture.
 
 ## What is not supported yet
 
-- **Reorg handling.** Solana indexers track finalized data only; there is no rollback-on-reorg. Expect a short latency at the head.
 - **Native SOL balance fields on handlers.** Pre/post **token** balances are surfaced today; native SOL (lamport) balances are available via [HyperSync](/docs/HyperSync/solana) directly but not yet as a handler field-selection toggle.
 - **Account-change subscriptions.** There is no `onAccount`/program-account handler. Account *state* is available only as the accounts referenced by an instruction (plus per-transaction token balances).
 - **A separate log handler.** Logs are a field on the instruction event, not their own handler.

--- a/docs/HyperIndex/solana/solana.md
+++ b/docs/HyperIndex/solana/solana.md
@@ -21,7 +21,7 @@ fast and you never touch an RPC node for the bulk of indexing.
 
 :::info Early access — and a good time to shape it
 Solana support is **experimental and pre-release**. The program/instruction
-config surface (`programs_experimental`) may change, indexers are
+config surface (the chain-level `experimental` key) may change, indexers are
 **TypeScript-only**, and the indexer tracks **finalized data** (no reorg
 handling — see [below](#what-is-not-supported-yet)). The APIs documented here are
 the latest in active development. If you're building on Solana, say hello on
@@ -58,7 +58,7 @@ If you've used HyperIndex on EVM, the shift is mostly vocabulary:
 | --- | --- |
 | Contract + ABI | Program + IDL |
 | Event (`onEvent`) | Instruction (`onInstruction`) |
-| `event.params` | `event.instruction.decoded.args` |
+| `event.params` | `instruction.params.args` |
 | Topic0 / event signature | Instruction discriminator |
 | Block (`onBlock`) | Slot (`onSlot`) |
 | Hex addresses `0x…` | Base58 addresses |
@@ -92,7 +92,7 @@ If the piece you need is on this list, [tell us on Discord](https://discord.gg/e
 
 - **[Getting Started](/docs/HyperIndex/solana/getting-started)** — scaffold and run your first Solana indexer.
 - **[Configuration](/docs/HyperIndex/solana/configuration)** — the `config.yaml` reference for `ecosystem: svm`.
-- **[Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers)** — `onInstruction`, the event object, token balances, CPIs, testing.
+- **[Instruction Handlers](/docs/HyperIndex/solana/instruction-handlers)** — `onInstruction`, the instruction object, token balances, CPIs, testing.
 - **[Decoding & IDLs](/docs/HyperIndex/solana/decoding)** — discriminators, Anchor IDLs, inline schemas, supported types.
 - **[Slot Handlers](/docs/HyperIndex/solana/slot-handlers)** — `onSlot` and RPC enrichment.
 - **[EVM vs Solana](/docs/HyperIndex/solana/evm-vs-solana)** — every difference in one place.

--- a/sidebarsHyperIndex.js
+++ b/sidebarsHyperIndex.js
@@ -117,7 +117,22 @@ module.exports = {
       ],
     },
     networksSection,
-    "solana/solana",
+    {
+      type: "category",
+      label: "Solana",
+      link: {
+        type: "doc",
+        id: "solana/solana",
+      },
+      items: [
+        "solana/solana-getting-started",
+        "solana/solana-configuration",
+        "solana/solana-instruction-handlers",
+        "solana/solana-decoding",
+        "solana/solana-slot-handlers",
+        "solana/solana-evm-vs-solana",
+      ],
+    },
     "fuel/fuel",
     // Divider to split off the bottom section (LLM docs + legal), matching the
     // divider under the top quick-links section.


### PR DESCRIPTION
## Summary

Expands the HyperIndex Solana documentation from a single overview page into a full guide section, and wires the new pages into the HyperIndex sidebar under **Solana**.

New pages:
- **Getting Started** (`solana/getting-started`) — scaffold, configure, and run a first Solana indexer
- **Configuration** (`solana/configuration`) — `config.yaml` reference for `ecosystem: svm` (chains, programs, instructions, discriminators, field selection)
- **Instruction Handlers** (`solana/instruction-handlers`) — `indexer.onInstruction`, decoded args/accounts, token balances, CPIs, context, testing
- **Decoding & IDLs** (`solana/decoding`) — discriminators, Anchor IDLs, inline schemas, supported argument types, decoded output shape
- **Slot Handlers** (`solana/slot-handlers`) — `indexer.onSlot` and Effect API enrichment
- **EVM vs Solana** (`solana/evm-vs-solana`) — concept/config/handler differences and current limitations

Also expands the existing `solana.md` overview and updates `sidebarsHyperIndex.js`.

## Verification
- `yarn docusaurus build` passes with `onBrokenLinks: "throw"`, confirming all internal cross-links (including links to `effect-api`, `preload-optimization`, `event-handlers`, `HyperSync/solana`, etc.) resolve.
- All seven Solana pages render under `build/docs/HyperIndex/solana/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new Solana HyperIndex pages covering configuration, decoding/IDL behavior, instruction handlers, slot handlers, and a full “getting started” guide.
  * Rewrote the main Solana overview to clarify the instruction-level indexing model, inner/CPI support, token balance tracking, logs, and current limitations.
  * Added a dedicated “Solana” sidebar category with links to all Solana-related pages, including an EVM-vs-Solana comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->