### PR TITLE
docs(solana): update query API for v0.0.7 client

### DIFF
--- a/docs/HyperSync/Solana/solana-curl-examples.md
+++ b/docs/HyperSync/Solana/solana-curl-examples.md
@@ -54,14 +54,13 @@ curl -sSN -H "Accept: text/event-stream" "$URL/height/sse"
 curl_query '{
   "from_slot": 391800000,
   "to_slot": 391800100,
-  "fields": {
+  "field_selection": {
     "instruction": ["slot", "transaction_index", "program_id", "accounts", "data", "d8"],
     "transaction": ["slot", "signatures", "fee_payer", "success", "fee"]
   },
   "instructions": [{
     "program_id": ["whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"],
-    "d8": ["0xf8c69e91e17587c8"],
-    "include_transaction": true
+    "d8": ["0xf8c69e91e17587c8"]
   }]
 }' | jq '{next_slot, sample_instruction: .instructions[0], sample_tx: .transactions[0]}'
 ```
@@ -74,7 +73,7 @@ curl_query '{
 curl_query '{
   "from_slot": 391800000,
   "to_slot": 391800100,
-  "fields": {
+  "field_selection": {
     "instruction": ["slot", "program_id", "accounts", "data", "d1"],
     "token_balance": ["slot", "transaction_index", "account", "mint", "owner", "pre_amount", "post_amount"]
   },
@@ -93,7 +92,7 @@ Each object in `instructions` is OR-ed. This is the â€œmatch by program id onlyâ
 curl_query '{
   "from_slot": 391800000,
   "to_slot": 391800100,
-  "fields": {
+  "field_selection": {
     "instruction": ["slot", "program_id", "data", "d8"]
   },
   "instructions": [
@@ -109,13 +108,12 @@ curl_query '{
 curl_query '{
   "from_slot": 391800000,
   "to_slot": 391800100,
-  "fields": {
+  "field_selection": {
     "transaction": ["slot", "signatures", "fee_payer", "success", "fee", "compute_units_consumed"],
     "instruction": ["slot", "program_id", "data", "accounts"]
   },
   "transactions": [{
-    "fee_payer": ["MfDuWeqSHEqTFVYZ7LoexgAK9dxk7cy4DFJWjWMGVWa"],
-    "include_instructions": true
+    "fee_payer": ["MfDuWeqSHEqTFVYZ7LoexgAK9dxk7cy4DFJWjWMGVWa"]
   }]
 }'
 ```
@@ -128,13 +126,12 @@ curl_query '{
 curl_query '{
   "from_slot": 391800000,
   "to_slot": 391800100,
-  "fields": {
+  "field_selection": {
     "instruction": ["slot", "program_id", "accounts", "data", "d8", "a2"],
     "transaction": ["slot", "fee_payer", "success"]
   },
   "instructions": [{
-    "program_id": ["6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"],
-    "include_transaction": true
+    "program_id": ["6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"]
   }]
 }'
 ```
@@ -145,13 +142,12 @@ curl_query '{
 curl_query '{
   "from_slot": 391800000,
   "to_slot": 391800100,
-  "fields": {
+  "field_selection": {
     "log": ["slot", "program_id", "kind", "message"],
     "transaction": ["slot", "fee_payer", "success"]
   },
   "logs": [{
-    "program_id": ["675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"],
-    "include_transaction": true
+    "program_id": ["675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"]
   }]
 }'
 ```
@@ -168,7 +164,7 @@ while [ "$SLOT" -lt "$TO" ]; do
   RESP=$(curl_query "{
     \"from_slot\": $SLOT,
     \"to_slot\": $TO,
-    \"fields\": { \"instruction\": [\"slot\", \"program_id\", \"d8\"] },
+    \"field_selection\": { \"instruction\": [\"slot\", \"program_id\", \"d8\"] },
     \"instructions\": [{ \"program_id\": [\"whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc\"] }]
   }")
   echo "$RESP" | jq '.instructions | length, .next_slot'

--- a/docs/HyperSync/Solana/solana-query.md
+++ b/docs/HyperSync/Solana/solana-query.md
@@ -28,7 +28,7 @@ Some slots have **no block**; the `blocks` array can be sparse across the reques
   "instructions": [ ... ],
   "transactions": [ ... ],
   "logs": [ ... ],
-  "fields": { ... }
+  "field_selection": { ... }
 }
 ```
 
@@ -47,10 +47,8 @@ Some slots have **no block**; the `blocks` array can be sparse across the reques
 | `d1` / `d2` / `d4` / `d8` | First _N_ bytes of instruction data, as hex. **`0x` prefix is optional** (`"0x03"` and `"03"` are equivalent). |
 | `a0` - `a9` | Account pubkey at that **index in the instruction's account metas** (`a0` = first account, `a2` = third). Which account is "the mint", "the pool", etc. is **defined by the program's IDL / instruction layout**, not by Solana globally. |
 | `is_inner` | `true` = inner only, `false` = outer only, **omitted** = both. |
-| `include_transaction` | Also return the parent transaction row(s). |
-| `include_logs` | Also return log rows tied to matched instructions. |
 
-**`instruction_address`:** When you join logs or instructions, this array encodes **where** the instruction sits in the transaction: outer-only indices use one element, e.g. `[2]` = third top-level instruction; inner instructions append an index, e.g. `[2, 0]` = first inner instruction inside that outer instruction.
+**`instruction_address`:** This array encodes **where** the instruction sits in the transaction: outer-only indices use one element, e.g. `[2]` = third top-level instruction; inner instructions append an index, e.g. `[2, 0]` = first inner instruction inside that outer instruction.
 
 ### TransactionSelection
 
@@ -58,7 +56,6 @@ Some slots have **no block**; the `blocks` array can be sparse across the reques
 |---|---|
 | `fee_payer` | Match fee payer pubkey. |
 | `success` | `true` = succeeded only, `false` = failed only, **omitted** = both (same pattern as `is_inner`). |
-| `include_instructions` | Also return all instructions in matched transactions. |
 
 ### LogSelection
 
@@ -66,8 +63,6 @@ Some slots have **no block**; the `blocks` array can be sparse across the reques
 |---|---|
 | `program_id` | Match log emitter program. |
 | `kind` | Parsed log line category (see below). |
-| `include_transaction` | Also return parent transaction. |
-| `include_instruction` | Also return related instruction rows. |
 
 #### Log `kind` values
 
@@ -84,11 +79,11 @@ These mirror the usual Solana runtime log line shapes (see the [transactions](ht
 
 ## Field selection
 
-Use `fields` to choose columns per logical table. Omit a table key to receive **all** columns for that table (when rows are returned).
+Use `field_selection` to choose columns per logical table. Omit a table key to receive **all** columns for that table (when rows are returned).
 
 ```json
 {
-  "fields": {
+  "field_selection": {
     "block": ["slot", "blockhash", "block_time"],
     "instruction": ["slot", "program_id", "data", "d8"],
     "transaction": ["slot", "fee_payer", "success"]
@@ -110,6 +105,16 @@ Use `fields` to choose columns per logical table. Omit a table key to receive **
 
 **`is_committed` (instruction):** Whether this instruction row is part of the **executed** instruction trace for the landed transaction (as opposed to being present only for structural / edge cases). Always interpret next to `transaction.success` and `transaction.err`: failed transactions can still include instructions up to the failure point.
 
+## Join behavior
+
+The server automatically joins related rows based on which tables you include in `field_selection`. For example, if your query filters on `instructions` and you also select `transaction` fields, the server returns the parent transaction for each matched instruction — no extra flags needed.
+
+:::note Join modes not yet available
+Solana HyperSync currently operates on a single default join mode. More granular control — for example fetching only the directly matched rows with no joins, or fetching all rows belonging to matched transactions — is planned but not yet exposed.
+
+If you have specific join or filtering requirements that the current API cannot satisfy, we would love to hear about your use case. Reach out on [Discord](https://discord.gg/envio) or open an issue on [GitHub](https://github.com/enviodev/hypersync-client-solana/issues).
+:::
+
 ## Limits (optional)
 
 Advanced knobs (defaults are usually fine):
@@ -123,7 +128,7 @@ Advanced knobs (defaults are usually fine):
 
 ## Response
 
-Top-level keys include `next_slot`, `total_execution_time_ms`, optional `rollback_guard`, and one array per table when present: `blocks`, `transactions`, `instructions`, `logs`, `balances`, `token_balances`, `rewards`—each holds **row objects** shaped by your `fields` selection.
+Top-level keys include `next_slot`, `total_execution_time_ms`, optional `rollback_guard`, and one array per table when present: `blocks`, `transactions`, `instructions`, `logs`, `balances`, `token_balances`, `rewards`—each holds **row objects** shaped by your `field_selection`.
 
 ### Example fragment (illustrative)
 

--- a/docs/HyperSync/Solana/solana.md
+++ b/docs/HyperSync/Solana/solana.md
@@ -49,7 +49,7 @@ curl -sS "https://solana.hypersync.xyz/query" \
   -d '{
     "from_slot": 391800000,
     "to_slot": 391800010,
-    "fields": { "instruction": ["slot", "program_id", "d8"] },
+    "field_selection": { "instruction": ["slot", "program_id", "d8"] },
     "instructions": [
       { "program_id": ["6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"] }
     ]
@@ -65,7 +65,7 @@ We want you to be able to build against this without guessing what will move und
 **Stable enough to build on**
 
 - The **endpoint** (`https://solana.hypersync.xyz`) and **bearer-token auth** model.
-- The **request shape** for `POST /query`: `from_slot` / `to_slot`, the `instructions` / `transactions` / `logs` selection arrays, `fields` projection, and the AND-within-object / OR-across-objects semantics.
+- The **request shape** for `POST /query`: `from_slot` / `to_slot`, the `instructions` / `transactions` / `logs` selection arrays, `field_selection` projection, and the AND-within-object / OR-across-objects semantics.
 - The **core filter primitives**: `program_id`, discriminator filters (`d1` / `d2` / `d4` / `d8`), account-position filters (`a0`–`a9`), `is_inner`, `success`, `fee_payer`, log `kind`.
 - The **table model**: `block`, `transaction`, `instruction`, `log`, `balance`, `token_balance`, `reward`, with the fields listed in [Query & Response](./solana-query#available-fields-by-table).
 - **Pagination** via `next_slot` and **reorg detection** via `rollback_guard`.


### PR DESCRIPTION
## Summary

- Renames `fields` to `field_selection` throughout the Solana HyperSync docs (query shape, field selection section, response section, all curl examples including the pagination loop). The legacy `fields` alias is removed in v0.0.7 — only `field_selection` is accepted now.
- Removes `include_transaction`, `include_logs`, `include_instructions`, `include_instruction` (and the other per-selection `include_*` join flags) from all selection type tables and curl examples — these flags are removed in v0.0.7; the server now always applies the single default join driven by `field_selection`.
- Adds a new **Join behavior** section to `solana-query.md` explaining that joins are now driven by which tables appear in `field_selection`, with a note that join modes are not yet exposed and inviting feedback.
- Removes a block of accidentally injected unrelated content (GitHub OAuth / Vercel text) from `solana.md`.

> Note: the docs describe the cleaned-up v0.0.7 query API. In v0.0.6 both the `fields` alias and the `include_*` flags still worked; v0.0.7 ([CHANGELOG](https://github.com/enviodev/hypersync-client-solana/blob/main/CHANGELOG.md)) is the release that removes them. The v0.0.7 `new_with_agent` / `createWithAgent` client constructors are intentionally not documented here — these docs are curl/HTTP-focused and the client libraries are still in development.

## Test plan

- [ ] Verify query shape examples in `solana-query.md` use `field_selection`
- [ ] Verify no `fields` (legacy alias) references remain in any Solana doc
- [ ] Verify no `include_*` flags remain in any Solana doc
- [ ] Verify curl examples still make sense without `include_*` (joins are implicit via `field_selection`)
- [ ] Verify the join behavior note reads clearly and the Discord link is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Solana network in HyperSync platform.

* **Documentation**
  * Added comprehensive Solana HyperSync API documentation with query schema, pagination guidance, and curl code examples.
  * Updated supported networks documentation with service tier guidance explaining reliability and service quality factors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Solana HyperSync documentation and curl examples to reflect current API usage patterns.
  * Removed deprecated flag references from query examples.
  * Added detailed guidance for instruction address filtering.
  * Documented automatic row joining behavior based on selected fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->