### PR TITLE
Reorder showcase: x402stats and RWA Radar to top

### DIFF
--- a/src/pages/showcase/_data.js
+++ b/src/pages/showcase/_data.js
@@ -30,6 +30,28 @@ const sites = [
     tags: [tags.hyperindex],
   },
   {
+    slug: "x402stats",
+    title: "x402stats",
+    description:
+      "A real-time analytics dashboard for the x402 payment protocol on Base — volume, facilitators, services, buyers, and a live payment feed.",
+    longDescription:
+      "x402stats is a real-time analytics dashboard for the x402 payment protocol on Base. Built with Envio's HyperIndex, it tracks total payment volume (in USDC), payment counts, active services, and buyers across configurable time ranges (24h, 7d, 30d, and all-time). A live feed streams payments as they happen, while leaderboards rank the top services accepting x402 and the top facilitators clearing those payments (grouped by brand and aggregated across their operator wallets). The dashboard also breaks data down by facilitator, marketplace of services, individual payments, and buyer wallets, alongside higher-level insights and health metrics such as payment attribution and volume drift. It additionally taps Envio's HyperSync to pull on-chain trace data, enabling a deeper, transaction-level view of x402 flows. Together these give developers, builders, and researchers a single, fast window into the x402 ecosystem on Base.",
+    image: "/img/showcase/x402stats.gif",
+    source: "https://x402stats.ai",
+    tags: [tags.hyperindex, tags.hypersync],
+  },
+  {
+    slug: "rwa-radar",
+    title: "RWA Radar",
+    description:
+      "A real-time analytics dashboard for tracking real-world assets (RWAs) across multiple sectors and chains.",
+    longDescription:
+      "RWA Radar is a real-time analytics dashboard that tracks real-world assets (RWAs) on-chain across multiple sectors, including stablecoins, credit, stocks, securities, and more. Built with Envio's HyperIndex, dashboard shows token activity across multiple blockchain networks, providing sector-level breakdowns, volume metrics, and historical trends. You can view multichain data for any single asset in one unified view and export dashboard data as CSV, PDF, or XLSX for your own analysis. The dashboard gives researchers, investors, and DeFi developers a comprehensive window into the growing RWA ecosystem.",
+    video: "/img/showcase/rwaradar.mp4",
+    source: "https://rwaradar.io",
+    tags: [tags.hyperindex],
+  },
+  {
     slug: "stable-volume",
     title: "Stable Volume",
     description:
@@ -168,28 +190,6 @@ const sites = [
     image: "/img/showcase/poly-whales-tui.png",
     source: "https://www.npmjs.com/package/poly-whales",
     tags: [tags.hypersync],
-  },
-  {
-    slug: "rwa-radar",
-    title: "RWA Radar",
-    description:
-      "A real-time analytics dashboard for tracking real-world assets (RWAs) across multiple sectors and chains.",
-    longDescription:
-      "RWA Radar is a real-time analytics dashboard that tracks real-world assets (RWAs) on-chain across multiple sectors, including stablecoins, credit, stocks, securities, and more. Built with Envio's HyperIndex, dashboard shows token activity across multiple blockchain networks, providing sector-level breakdowns, volume metrics, and historical trends. You can view multichain data for any single asset in one unified view and export dashboard data as CSV, PDF, or XLSX for your own analysis. The dashboard gives researchers, investors, and DeFi developers a comprehensive window into the growing RWA ecosystem.",
-    video: "/img/showcase/rwaradar.mp4",
-    source: "https://rwaradar.io",
-    tags: [tags.hyperindex],
-  },
-  {
-    slug: "x402stats",
-    title: "x402stats",
-    description:
-      "A real-time analytics dashboard for the x402 payment protocol on Base — volume, facilitators, services, buyers, and a live payment feed.",
-    longDescription:
-      "x402stats is a real-time analytics dashboard for the x402 payment protocol on Base. Built with Envio's HyperIndex, it tracks total payment volume (in USDC), payment counts, active services, and buyers across configurable time ranges (24h, 7d, 30d, and all-time). A live feed streams payments as they happen, while leaderboards rank the top services accepting x402 and the top facilitators clearing those payments (grouped by brand and aggregated across their operator wallets). The dashboard also breaks data down by facilitator, marketplace of services, individual payments, and buyer wallets, alongside higher-level insights and health metrics such as payment attribution and volume drift. It additionally taps Envio's HyperSync to pull on-chain trace data, enabling a deeper, transaction-level view of x402 flows. Together these give developers, builders, and researchers a single, fast window into the x402 ecosystem on Base.",
-    image: "/img/showcase/x402stats.gif",
-    source: "https://x402stats.ai",
-    tags: [tags.hyperindex, tags.hypersync],
   },
 ];
 


### PR DESCRIPTION
Move x402stats to 3rd and RWA Radar to 4th position in the showcase list, surfacing them above the older entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized showcase items to improve presentation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->