### PR TITLE
Tidy showcase copy for x402stats and RWA Radar

### DIFF
--- a/src/pages/showcase/_data.js
+++ b/src/pages/showcase/_data.js
@@ -33,7 +33,7 @@ const sites = [
     slug: "x402stats",
     title: "x402stats",
     description:
-      "A real-time analytics dashboard for the x402 payment protocol on Base — volume, facilitators, services, buyers, and a live payment feed.",
+      "A real-time analytics dashboard for the x402 payment protocol on Base: volume, facilitators, services, buyers, and a live payment feed.",
     longDescription:
       "x402stats is a real-time analytics dashboard for the x402 payment protocol on Base. Built with Envio's HyperIndex, it tracks total payment volume (in USDC), payment counts, active services, and buyers across configurable time ranges (24h, 7d, 30d, and all-time). A live feed streams payments as they happen, while leaderboards rank the top services accepting x402 and the top facilitators clearing those payments (grouped by brand and aggregated across their operator wallets). The dashboard also breaks data down by facilitator, marketplace of services, individual payments, and buyer wallets, alongside higher-level insights and health metrics such as payment attribution and volume drift. It additionally taps Envio's HyperSync to pull on-chain trace data, enabling a deeper, transaction-level view of x402 flows. Together these give developers, builders, and researchers a single, fast window into the x402 ecosystem on Base.",
     image: "/img/showcase/x402stats.gif",
@@ -46,7 +46,7 @@ const sites = [
     description:
       "A real-time analytics dashboard for tracking real-world assets (RWAs) across multiple sectors and chains.",
     longDescription:
-      "RWA Radar is a real-time analytics dashboard that tracks real-world assets (RWAs) on-chain across multiple sectors, including stablecoins, credit, stocks, securities, and more. Built with Envio's HyperIndex, dashboard shows token activity across multiple blockchain networks, providing sector-level breakdowns, volume metrics, and historical trends. You can view multichain data for any single asset in one unified view and export dashboard data as CSV, PDF, or XLSX for your own analysis. The dashboard gives researchers, investors, and DeFi developers a comprehensive window into the growing RWA ecosystem.",
+      "RWA Radar is a real-time analytics dashboard that tracks real-world assets (RWAs) on-chain across multiple sectors, including stablecoins, credit, stocks, securities, and more. Built with Envio's HyperIndex, the dashboard shows token activity across multiple blockchain networks, providing sector-level breakdowns, volume metrics, and historical trends. You can view multichain data for any single asset in one unified view and export dashboard data as CSV, PDF, or XLSX for your own analysis. The dashboard gives researchers, investors, and DeFi developers a comprehensive window into the growing RWA ecosystem.",
     video: "/img/showcase/rwaradar.mp4",
     source: "https://rwaradar.io",
     tags: [tags.hyperindex],


### PR DESCRIPTION
Small copy cleanup in the showcase data:

- Replace the em dash in the x402stats description with a colon.
- Fix a missing article in the RWA Radar description ("the dashboard shows...").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated showcase site content descriptions with minor text refinements for improved clarity and punctuation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->