### PR TITLE
Fix benchmark number on migrate-from-alchemy

### DIFF
--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -3,7 +3,7 @@ id: migrate-from-alchemy
 title: Migrate from Alchemy to Envio
 sidebar_label: Migrate from Alchemy
 slug: /migrate-from-alchemy
-description: Easily migrate your existing Alchemy subgraphs to Envio for 143x faster indexing than subgraphs, multichain support, and a better developer experience.
+description: Easily migrate your existing Alchemy subgraphs to Envio for 142x faster indexing than subgraphs, multichain support, and a better developer experience.
 ---
 
 :::note
@@ -17,7 +17,7 @@ Migrating Alchemy subgraphs to Envio’s HyperIndex is a simple and developer-fr
 If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our [Quickstart](/docs/HyperIndex/quickstart) guide before you begin your migration from Alchemy. If you are new to the category entirely, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.
 
 ## Why Migrate to Envio’s HyperIndex?
-- **High Speed Performance**: 143x faster than subgraphs
+- **High Speed Performance**: 142x faster than subgraphs
 - **Lower Costs**: Reduced infrastructure requirements and operational expenses
 - **Better Developer Experience**: Simplified configuration and deployment
 - **Multichain Native**: Index data across multiple EVM chains through a single HyperIndex project

--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -17,7 +17,7 @@ Migrating Alchemy subgraphs to Envio’s HyperIndex is a simple and developer-fr
 If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our [Quickstart](/docs/HyperIndex/quickstart) guide before you begin your migration from Alchemy. If you are new to the category entirely, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.
 
 ## Why Migrate to Envio’s HyperIndex?
-- **High Speed Performance**: 142x faster than subgraphs
+- **High-Speed Performance**: 142x faster than subgraphs
 - **Lower Costs**: Reduced infrastructure requirements and operational expenses
 - **Better Developer Experience**: Simplified configuration and deployment
 - **Multichain Native**: Index data across multiple EVM chains through a single HyperIndex project


### PR DESCRIPTION
The migrate from Alchemy page cited 143x for the Sentio Uniswap V2 Factory benchmark in two places, the frontmatter meta description and the Why Migrate body list.

The correct figure per the open-indexer-benchmark repo is 142x, so both have been updated to match. This brings the page in line with the fix already shipped across the other pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance metrics in the migration guide documentation to reflect current benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->