### PR TITLE
Update robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -14,6 +14,12 @@ Allow: /
 User-agent: ClaudeBot
 Allow: /
 
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
 User-agent: PerplexityBot
 Allow: /
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -14,9 +14,6 @@ Allow: /
 User-agent: ClaudeBot
 Allow: /
 
-User-agent: anthropic-ai
-Allow: /
-
 User-agent: PerplexityBot
 Allow: /
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,32 @@
 User-agent: *
 Allow: /
 
+# AI and answer-engine crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 Sitemap: https://docs.envio.dev/sitemap.xml


### PR DESCRIPTION
Adds explicit per-user-agent `Allow: /` rules to robots.txt. The wildcard default and sitemap line are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated crawler permissions to explicitly allow access for multiple AI and search crawlers to the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->