### PR TITLE
docs: bring HyperIndex examples and guides up to date with V3

### DIFF
--- a/docs/HyperIndex/Advanced/performance/historical-sync.md
+++ b/docs/HyperIndex/Advanced/performance/historical-sync.md
@@ -19,14 +19,9 @@ Historical sync is an important aspect of maintaining and populating your databa
 - **Slow Performance**: Unfortunately, historical sync for chains using RPC endpoints is not fast. The process is slower due to the limitations of RPC endpoints.
 - **No Local Caching**: We do not have any form of local caching at the moment. This feature was disabled in a previous release due to stability concerns.
 
-### Loaders and Historical Sync
+## Preload Optimization
 
-- **Improved Speed**: Using loaders can improve the speed of historical sync. However, the effectiveness of loaders varies:
-  - **Entity Reuse**: Loaders are more beneficial when the same entities are frequently reused and updated.
-  - **Performance Impact**: For many indexes, the performance difference with loaders is not very large. Loaders are not highly important unless performance is of the utmost importance.
-
-### Future Improvements (v2)
-
-- **preHandlers**: In version 2, we are restructuring the way loaders work into pre-handlers. This change will make loading entities before the handler in batches more ergonomic using preHandler functions, further enhancing the performance and ease of use for historical sync.
+- **Always on in V3**: Preload Optimization is enabled automatically in HyperIndex V3, with no flag to turn it on or off. It speeds up historical sync by batching the entity reads in your handlers into a small number of database queries, and by running external calls in parallel through the Effect API.
+- **Biggest gains**: The benefit is largest when your handlers read and update the same entities frequently, or when they make external calls. For details on how it works and how to write handlers that take advantage of it, see [Preload Optimization](/docs/HyperIndex/preload-optimization).
 
 By understanding these factors, you can better optimize the performance of your historical sync processes.

--- a/docs/HyperIndex/Examples/example-aerodrome-velodrome.md
+++ b/docs/HyperIndex/Examples/example-aerodrome-velodrome.md
@@ -29,5 +29,5 @@ The [Velodrome & Aerodrome Indexer](https://github.com/enviodev/velodrome-indexe
 For implementation details, usage examples, and setup instructions, see the project's [README](https://github.com/enviodev/velodrome-indexer/blob/main/README.md).
 
 :::note
-This indexer was built by Envio partners and community builders. While it provides a valuable reference implementation, it may not be using the latest version of Envio's tooling. Always perform appropriate testing and data validation before using in production environments.
+This indexer was built by Envio partners and community builders and serves as a valuable reference implementation. As with any indexer, perform appropriate testing and data validation before using in production environments.
 :::

--- a/docs/HyperIndex/Examples/example-example-cross-chain-messaging.md
+++ b/docs/HyperIndex/Examples/example-example-cross-chain-messaging.md
@@ -10,6 +10,10 @@ description: Explore cross-chain messaging and track events across multiple chai
 
 This blockchain indexer demonstrates how to track and index cross-chain messaging protocols at scale, providing a complete view of message passing across multiple blockchains.
 
+:::warning Targets HyperIndex V2
+This example links to a third-party community repository that targets HyperIndex **V2** and is now archived (last updated December 2024), so it does not reflect current V3 APIs. We keep it here as a conceptual reference for cross-chain indexing patterns. If you are starting a new project, build on the current [V3 docs](/docs/HyperIndex/overview) and see [Migrate to V3](/docs/HyperIndex/migrate-to-v3) for the latest syntax.
+:::
+
 ## Overview
 
 The [ORMP Indexer](https://github.com/ringecosystem/ormpexer/tree/main) showcases advanced multichain indexing techniques for tracking cross-chain communication. It offers a practical example of how to:
@@ -36,5 +40,5 @@ This blockchain indexer can serve as a foundation for applications requiring vis
 - Message delivery verification tools
 
 :::note
-This blockchain indexer was built by Envio partners and community builders. While it provides a valuable reference implementation, it may not be using the latest version of Envio's tooling. Always perform appropriate testing and data validation before using in production environments.
+This blockchain indexer was built by Envio partners and community builders. As noted above it targets HyperIndex V2 and is no longer maintained, so always perform appropriate testing and data validation, and follow the current V3 docs, before using these patterns in production.
 :::

--- a/docs/HyperIndex/Examples/example-sablier.md
+++ b/docs/HyperIndex/Examples/example-sablier.md
@@ -12,27 +12,23 @@ The following blockchain indexers serve as exceptional reference implementations
 
 ## Overview
 
-[Sablier](https://sablier.com/) is a token streaming protocol that enables real-time finance on the blockchain, allowing tokens to be streamed continuously over time. These official Sablier indexers track streaming activity across 18 different EVM-compatible chains, providing comprehensive data through a unified GraphQL API.
+[Sablier](https://sablier.com/) is a token streaming protocol that enables real-time finance on the blockchain, allowing tokens to be streamed continuously over time. These official Sablier indexers track streaming activity across many EVM-compatible chains, providing comprehensive data through a unified GraphQL API.
 
 ## Professional Indexer Suite
 
-Sablier maintains three specialized indexers, each targeting a specific part of their protocol:
+Sablier maintains two public indexers, each targeting a specific part of their protocol:
 
-### 1. [Lockup Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/lockup)
+### 1. [Streams Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/streams)
 
-Tracks the core Sablier lockup contracts, which handle the streaming of tokens with fixed durations and amounts. This indexer provides data about stream creation, cancellation, and withdrawal events. Used primarily for the vesting functionality of Sablier.
+Tracks Sablier's payment-stream data across both the Lockup and Flow products. Lockup covers streams with fixed durations and amounts (creation, cancellation, and withdrawal events), while Flow covers open-ended streaming with dynamic flow rates. For more detail, see the [Lockup indexer docs](https://docs.sablier.com/api/lockup/indexers) and the [Flow indexer docs](https://docs.sablier.com/api/flow/indexers).
 
-### 2. [Flow Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/flow)
+### 2. [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
 
-Monitors Sablier's advanced streaming functionality, allowing for dynamic flow rates and more complex streaming scenarios. This indexer captures stream modifications, batch operations, and other flow-specific events. Powers the payments side of the Sablier application.
-
-### 3. [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
-
-Tracks Sablier's Merkle Airdrops, which enables efficient batch stream creation using cryptographic proofs. This indexer captures data about batch creations, claims, and related activities. Used for both Airstreams and Instant Airdrops functionality.
+Tracks Sablier's Merkle airdrop campaigns, which enable efficient batch stream creation using cryptographic proofs. This indexer captures data about campaign creation, claims, and related activity, powering both Airstreams and Instant Airdrops. For more detail, see the [Airdrops indexer docs](https://docs.sablier.com/api/airdrops/indexers).
 
 ## Key Features
 
-- **Comprehensive Multichain Support**: Indexes data across 18 different EVM chains
+- **Comprehensive Multichain Support**: Indexes data across many EVM-compatible chains
 - **Professionally Maintained**: Used in production by the Sablier team and their partners
 - **Extensive Test Coverage**: Includes comprehensive testing to ensure data accuracy
 - **Optimized Performance**: Implements efficient data processing techniques
@@ -50,16 +46,15 @@ These blockchain indexers demonstrate several development best practices:
 - **Comprehensive Entity Relationships**: Well-designed data model with proper relationships
 - **Thorough Input Validation**: Robust error handling and input validation
 - **Detailed Changelogs**: Documentation of breaking changes and migrations
-- **Handler/Loader Pattern**: Envio indexers use an optimized pattern with loaders to pre-fetch entities and handlers to process them
+- **Preload Optimization**: Envio indexers benefit from always-on [Preload Optimization](/docs/HyperIndex/preload-optimization), which batches entity reads and runs external calls in parallel through the Effect API
 
 ## Getting Started
 
 To use these indexers as a reference for your own development:
 
-1. Clone the specific repository based on your needs:
-   - [Lockup Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/lockup-envio)
-   - [Flow Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/flow-envio)
-   - [Merkle Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/merkle-envio)
+1. Clone the indexer that matches your needs:
+   - [Streams Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/streams)
+   - [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
 2. Review the file structure and implementation patterns
 3. Examine the event handlers for efficient data processing techniques
 4. Study the schema design for effective entity modeling

--- a/docs/HyperIndex/Examples/example-uniswap-v4.md
+++ b/docs/HyperIndex/Examples/example-uniswap-v4.md
@@ -14,7 +14,7 @@ This [official Uniswap V4 indexer](https://github.com/enviodev/uniswap-v4-indexe
 
 ## Key Features
 
-- **Multichain Support**: Indexes Uniswap V4 deployments across 10 different blockchain networks in real-time
+- **Multichain Support**: Indexes Uniswap V4 deployments across 15 different blockchain networks in real-time
 - **Complete Pool Metrics**: Tracks pool statistics including volume, TVL, fees, and other critical metrics
 - **Swap Analysis**: Monitors swap events and liquidity changes with high precision
 - **Hook Integration**: In-progress support for Uniswap V4 hooks and their events

--- a/docs/HyperIndex/Tutorials/greeter-tutorial.md
+++ b/docs/HyperIndex/Tutorials/greeter-tutorial.md
@@ -217,7 +217,7 @@ Now that you've mastered the basics, you can:
 - Try the [Contract Import](../contract-import.md) feature to index any deployed contract
 - Customize the event handlers to implement more complex indexing logic
 - Add relationships between entities in your schema
-- Explore the [Advanced Querying](../Advanced/loaders.md) features
+- Explore [Preload Optimization](../Advanced/preload-optimization.md) for faster handlers
 - Create aggregated statistics from your indexed data
 
 For more tutorials and examples, visit the [Envio Documentation](https://docs.envio.dev/) or join our [Discord community](https://discord.gg/envio) for support.

--- a/docs/HyperIndex/migration-guide.md
+++ b/docs/HyperIndex/migration-guide.md
@@ -13,7 +13,7 @@ Please reach out to our team on [Discord](https://discord.gg/envio) for personal
 :::
 
 :::tip Already on HyperIndex V2?
-This page covers migrating from The Graph to Envio. If you are upgrading an existing HyperIndex project from V2 to V3, follow the [Migrate to V3](./migrate-to-v3) guide instead. Some examples below still use the V2 handler syntax (`Contract.Event.handler(...)`, `networks:`); the V3 equivalents (`indexer.onEvent(...)`, `chains:`) are documented in that guide.
+This page covers migrating from The Graph to Envio, with all examples shown in current HyperIndex V3 syntax (`indexer.onEvent(...)`, `chains:`). If instead you are upgrading an existing HyperIndex project from V2 to V3, follow the [Migrate to V3](./migrate-to-v3) guide.
 :::
 
 ## Introduction
@@ -109,7 +109,7 @@ HyperIndex - `config.yaml`
 ```yaml
 # yaml-language-server: $schema=./node_modules/envio/evm.schema.json
 name: uni-v4-indexer
-networks:
+chains:
   - id: 1
     start_block: 21689089
     contracts:      
@@ -179,19 +179,23 @@ export function handleSubscription(event: SubscriptionEvent): void {
 <div className="col col--6">
 HyperIndex - `eventHandler.ts`
 ```typescript
-PoolManager.Subscription.handler( async (event, context) => {
-  const entity = {
-    id: event.transaction.hash + event.logIndex,
-    tokenId: event.params.tokenId,
-    address: event.params.subscriber,
-    blockNumber: event.block.number,
-    logIndex: event.logIndex,
-    position: event.params.tokenId
-  }
+import { indexer } from "envio";
 
-context.Subscription.set(entity);
-})
+indexer.onEvent(
+  { contract: "PoolManager", event: "Subscription" },
+  async ({ event, context }) => {
+    const entity = {
+      id: event.transaction.hash + event.logIndex,
+      tokenId: event.params.tokenId,
+      address: event.params.subscriber,
+      blockNumber: event.block.number,
+      logIndex: event.logIndex,
+      position: event.params.tokenId,
+    };
 
+    context.Subscription.set(entity);
+  },
+);
 ```
 
 </div>
@@ -205,7 +209,7 @@ HyperIndex is a powerful tool that can be used to index any contract. There are 
 - Multichain indexing in V3 always runs in unordered mode, which is the most common need and provides better performance — see [Multichain Indexing](../HyperIndex/multichain-indexing). (In V2 this required setting `unordered_multichain_mode: true`; in V3 there is no opt-in, and the V2 `multichain: ordered` mode has been removed.)
 - Use wildcard indexing to index by event signatures rather than by contract address.
 - HyperIndex uses the standard GraphQL query language, whereas TheGraph uses a custom GraphQL syntax. You can read about the differences and how to convert queries in our [Query Conversion Guide](/docs/HyperIndex/query-conversion). We also provide a query converter tool for backwards compatibility with existing TheGraph queries.
-- Loaders are a powerful feature to optimize historical sync performance. You can read more about them [here](../HyperIndex/loaders).
+- Preload Optimization is always on in V3 and speeds up historical sync by batching the entity reads in your handlers and running external calls in parallel. You can read more about it [here](/docs/HyperIndex/preload-optimization).
 - HyperIndex is very flexible and can be used to index offchain data too or send messages to a queue etc for fetching external data, you can further optimise the fetching by using the [effects api](/docs/HyperIndex/effect-api)
 
 ### Transaction receipts
@@ -235,10 +239,15 @@ field_selection:
 ```
 
 ```typescript
-MyContract.Transfer.handler(async ({ event, context }) => {
-  const { status, gasUsed } = event.transaction;
-  // ...
-});
+import { indexer } from "envio";
+
+indexer.onEvent(
+  { contract: "MyContract", event: "Transfer" },
+  async ({ event, context }) => {
+    const { status, gasUsed } = event.transaction;
+    // ...
+  },
+);
 ```
 
 See the full list of available `transaction_fields` in the [Configuration File](../HyperIndex/configuration-file#field-selection) docs.


### PR DESCRIPTION
Refreshes several HyperIndex docs pages that still referenced removed V2 concepts, validated against the live V3 docs and the linked repositories.

## Changes
- **historical-sync**: removed the `preHandlers` / "Future Improvements (v2)" content and the loaders-as-live-feature section; documented always-on Preload Optimization instead.
- **example-sablier**: fixed the broken "Getting Started" links (the old `sablier-labs/subgraphs/apps/*-envio` paths 404) and updated to the current public indexers (Streams + Airdrops); de-V2'd the loader bullet.
- **migration-guide** (from The Graph): updated the code snippets to V3 syntax (`indexer.onEvent`, `import { indexer } from "envio"`, `chains:`) and refreshed the banner.
- **cross-chain-messaging**: added a clear note that the linked community example targets V2 and is archived.
- **uniswap-v4**: corrected the network count to match the repo config.
- **greeter**: relinked the removed loaders page to Preload Optimization.
- **aerodrome**: corrected an inaccurate "may not be latest tooling" caveat (repo is current V3).

## Validation
- Checked every claim against the live V3 docs (Preload Optimization, Migrate to V3) and the actual GitHub repos.
- `docusaurus build` passes (no broken links).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated historical sync guidance highlighting Preload Optimization as always-enabled in V3.
  * Refreshed example project documentation with version compatibility warnings and current offerings.
  * Updated Sablier example to reflect current indexer lineup and performance benefits.
  * Expanded Uniswap V4 example coverage from 10 to 15 blockchain networks.
  * Enhanced migration guide with clearer V2-to-V3 syntax and feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->