### PR TITLE
fix: redirect /docs/HyperIndex/example-ens to avoid 404

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,6 +144,10 @@ const redirectsList = [
     to: "/docs/HyperIndex/overview",
   },
   {
+    from: "/docs/HyperIndex/example-ens",
+    to: "/docs/HyperIndex/overview",
+  },
+  {
     from: "/docs/logging",
     to: "/docs/HyperIndex/logging",
   },


### PR DESCRIPTION
Adds a redirect for `/docs/HyperIndex/example-ens` → `/docs/HyperIndex/overview`.

This path was returning a 404 (surfaced in Google Search Console). A redirect already exists for the `/docs/example-ens` variant; this mirrors it for the `/docs/HyperIndex/` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added URL redirect in documentation configuration to route to the overview page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->