### PR TITLE
chore: update env vars to include envio prefix

### DIFF
--- a/blog/2026-05-21-migrate-from-ponder-to-envio.md
+++ b/blog/2026-05-21-migrate-from-ponder-to-envio.md
@@ -123,7 +123,7 @@ chains:
 | --- | --- | --- |
 | Config format | `ponder.config.ts` (TypeScript) | `config.yaml` (YAML) |
 | Chain reference | Named + viem object | Numeric chain ID |
-| RPC URL | In config | `RPC_URL_<chainId>` env var |
+| RPC URL | In config | `ENVIO_RPC_URL_<chainId>` env var |
 | ABI source | TypeScript import | JSON file (`abi_file_path`) |
 | Events to index | Inferred from handlers | Explicit `events:` list |
 | Handler file | Inferred | Auto-discovered from `src/handlers/` |

--- a/docs/HyperIndex/Guides/contract-state.md
+++ b/docs/HyperIndex/Guides/contract-state.md
@@ -195,7 +195,7 @@ import { createEffect, S } from "envio";
 
 import { getERC20BytesContract, getERC20Contract } from "./utils";
 
-const RPC_URL = process.env.RPC_URL;
+const RPC_URL = process.env.ENVIO_RPC_URL;
 
 const client = createPublicClient({
   chain: mainnet,

--- a/docs/HyperIndex/migrate-from-ponder.md
+++ b/docs/HyperIndex/migrate-from-ponder.md
@@ -104,7 +104,7 @@ Key differences:
 | --------------- | ------------------------------- | -------------------------------- |
 | Config format   | `ponder.config.ts` (TypeScript) | `config.yaml` (YAML)             |
 | Chain reference | Named + viem object             | Numeric chain ID                 |
-| RPC URL         | In config                       | `RPC_URL_<chainId>` env var      |
+| RPC URL         | In config                       | `ENVIO_RPC_URL_<chainId>` env var |
 | ABI source      | TypeScript import               | JSON file (`abi_file_path`)      |
 | Events to index | Inferred from handlers          | Explicit `events:` list          |
 | Handler file    | Inferred                        | Explicit `handler:` per contract |

--- a/docs/HyperIndexV2/Guides/contract-state.md
+++ b/docs/HyperIndexV2/Guides/contract-state.md
@@ -194,7 +194,7 @@ import { createEffect, S } from "envio";
 
 import { getERC20BytesContract, getERC20Contract } from "./utils";
 
-const RPC_URL = process.env.RPC_URL;
+const RPC_URL = process.env.ENVIO_RPC_URL;
 
 const client = createPublicClient({
   chain: mainnet,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the correct RPC environment variable name in migration guides and key differences tables.
  * Updated example code to use the new RPC URL environment variable for contract-state and token metadata workflows.
  * Improved consistency across migration and guide documentation so setup instructions match the expected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->