### PR TITLE
Add 301 redirects for remaining 404s from docs/blog restructure

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -217,6 +217,111 @@
       "source": "/docs/async-mode.md",
       "destination": "/docs/HyperIndex/overview.md",
       "permanent": true
+    },
+    {
+      "source": "/blog/clickhouse-sink-hyperindex-v3",
+      "destination": "/blog/clickhouse-storage-hyperindex-v3",
+      "permanent": true
+    },
+    {
+      "source": "/blog/clickhouse-sink-hyperindex-v3.md",
+      "destination": "/blog/clickhouse-storage-hyperindex-v3.md",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-april-2024",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-april-2024.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-june-2024",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-june-2024.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-july-2024",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-july-2024.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-1",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-1.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-3",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-3.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-6",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-6.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-real-time-indexing-powers-peppy-finance",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-real-time-indexing-powers-peppy-finance.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/2024/11/08/06-hosted-service-v2",
+      "destination": "/blog/hosted-service-v2",
+      "permanent": true
+    },
+    {
+      "source": "/blog/2024/11/08/06-hosted-service-v2.md",
+      "destination": "/blog/hosted-service-v2.md",
+      "permanent": true
+    },
+    {
+      "source": "/blog/2024/:month/:day/:slug",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/status",
+      "destination": "/docs/HyperIndex/hosted-service",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/status.md",
+      "destination": "/docs/HyperIndex/hosted-service.md",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
Adds 301 redirects in vercel.json for URLs from the July 2026 GSC audit that were verified as live 404s before this change. Every candidate URL from the audit list was re-checked against production on 2026-07-02 and all ten still returned 404, so none needed to be dropped from the fix.

## Redirects added (pre-fix status verified via curl against docs.envio.dev)

| Old URL | Pre-fix status | Redirects to |
| --- | --- | --- |
| /blog/clickhouse-sink-hyperindex-v3 | 404 | /blog/clickhouse-storage-hyperindex-v3 |
| /blog/envio-developer-update-april-2024 | 404 | /blog |
| /blog/envio-developer-update-june-2024 | 404 | /blog |
| /blog/envio-developer-update-july-2024 | 404 | /blog |
| /blog/envio-developer-community-update-no-1 | 404 | /blog |
| /blog/envio-developer-community-update-no-3 | 404 | /blog |
| /blog/envio-developer-community-update-no-6 | 404 | /blog |
| /blog/envio-real-time-indexing-powers-peppy-finance | 404 | /blog |
| /blog/2024/11/08/06-hosted-service-v2 | 404 | /blog/hosted-service-v2 |
| /docs/HyperIndex/status | 404 | /docs/HyperIndex/hosted-service |

Notes:

- The clickhouse redirect follows the rename to blog/2026-04-24-clickhouse-storage.md (slug /clickhouse-storage-hyperindex-v3), confirmed in git history and returning 200 in production.
- The 2024 dev updates, community updates, and peppy-finance post were pruned deliberately, so they point at /blog.
- The dated URL redirects to /blog/hosted-service-v2 (200 in production, matching blog/2024-11-08-hosted-service-v2.md). A generic /blog/2024/:month/:day/:slug to /blog pattern is added after the specific rule to catch any other stale dated blog URLs; no current post uses dated slugs, and the specific redirect sits above it so it is not shadowed.
- No standalone /docs/HyperIndex/status page ever existed in git history (only supported-networks/status-sepolia), so it points at /docs/HyperIndex/hosted-service per the audit fallback.
- Every /blog and /docs entry has a matching .md variant redirect per existing convention. The .md variants of pruned posts point at /blog (not /blog.md) because /blog.md returns 404 in production.
- All destinations verified 200 in production. No existing redirects, rewrites, or headers (including the X-Robots-Tag noindex rules) were modified. JSON validated, no duplicate sources, and no destination is itself a redirect source (no loops). Full site build passes.

## Follow-ups for reviewer

1. After deploy, someone with Search Console access should hit "Validate fix" on the Not found (404) reason under Indexing then Pages, for BOTH properties: sc-domain:envio.dev and sc-domain:docs.envio.dev.
2. No action needed: none. Every URL on the audit candidate list was still 404 in production at verification time, so all ten received redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for legacy blog and docs URLs so old links now send visitors to the correct current pages.
  * Added redirects for several outdated blog post paths, including date-based URLs, to keep content accessible and avoid broken pages.
  * Updated HyperIndex documentation links to point to the current hosted service page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->