### PR TITLE
fix(seo): redirect double /blog/blog/ URLs and harden broken-link guard

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -283,7 +283,7 @@ const config = {
   organizationName: "enviodev",
   projectName: "indexer-docs",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenMarkdownLinks: "throw",
   customFields: {
     hyperSyncChainCount: networkCountData.hyperSyncChainCount,
   },

--- a/vercel.json
+++ b/vercel.json
@@ -74,11 +74,6 @@
       "permanent": true
     },
     {
-      "source": "/blog/blog/:slug",
-      "destination": "/blog/:slug",
-      "permanent": true
-    },
-    {
       "source": "/docs/HyperIndex/v2/:slug",
       "destination": "/docs/v2/HyperIndex/:slug",
       "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,11 @@
   ],
   "redirects": [
     {
+      "source": "/blog/blog/:slug*",
+      "destination": "/blog/:slug*",
+      "permanent": true
+    },
+    {
       "source": "/blog/tags/:tag*",
       "destination": "/blog/tag/:tag*",
       "permanent": true


### PR DESCRIPTION
Resolves a recurring Search Console 404 on double-prefixed blog URLs (`/blog/blog/<slug>`).

- Add a Vercel 301 redirect `/blog/blog/:slug*` -> `/blog/:slug*` so any double-prefixed URL resolves instead of 404ing.
- Set `onBrokenMarkdownLinks: throw` (`onBrokenLinks` was already `throw`) so broken internal links fail the build.

Production build passes clean with the stricter setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broken Markdown links now fail the documentation build instead of only warning, making link issues easier to catch early.
  * Updated legacy blog redirects so requests to `/blog/blog/...` permanently redirect to the corresponding `/blog/...` page (including deeper path variations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->