### PR TITLE
feat(docs): visual refresh, flat product nav, and Copy page menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -306,6 +306,10 @@ const config = {
       href: "/custom.css",
       type: "text/css",
     },
+    {
+      href: "https://fonts.googleapis.com/css2?family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap",
+      type: "text/css",
+    },
   ],
 
   themeConfig:
@@ -335,49 +339,53 @@ const config = {
         },
         items: [
           {
-            to: "docs/HyperIndex/overview",
-            label: "HyperIndex Docs",
+            type: "dropdown",
+            label: "HyperIndex",
             position: "left",
-          },
-          {
-            type: "custom-hyperIndexVersionDropdown",
-            position: "left",
+            items: [
+              {
+                label: "v3 (latest)",
+                to: "docs/HyperIndex/overview",
+                activeBaseRegex:
+                  "^/docs/HyperIndex/(?!(hosted-service|self-hosting|organisation-setup|envio-cloud-cli))",
+              },
+              {
+                label: "v2",
+                to: "docs/v2/HyperIndex/overview",
+                activeBaseRegex: "^/docs/v2/HyperIndex/",
+              },
+            ],
           },
           {
             to: "docs/HyperSync/overview",
-            label: "HyperSync Docs",
+            label: "HyperSync",
             position: "left",
+            activeBaseRegex: "^/docs/HyperSync/",
           },
           {
             to: "docs/HyperRPC/overview-hyperrpc",
-            label: "HyperRPC Docs",
+            label: "HyperRPC",
             position: "left",
+            activeBaseRegex: "^/docs/HyperRPC/",
           },
           {
-            href: "https://envio.dev/changelog",
-            label: "Changelog",
+            to: "docs/HyperIndex/hosted-service",
+            label: "Envio Cloud",
             position: "left",
-          },
-          {
-            to: "videos",
-            label: "Shipper's Logs",
-            position: "left",
-          },
-          {
-            to: "showcase",
-            label: "Showcase",
-            position: "left",
-            className: "navbar__item--showcase",
-          },
-          {
-            to: "/blog",
-            label: "Blog",
-            position: "left",
+            activeBaseRegex:
+              "^/docs/HyperIndex/(hosted-service|self-hosting|organisation-setup|envio-cloud-cli)",
           },
           {
             href: "https://github.com/enviodev",
-            label: "GitHub",
             position: "right",
+            className: "header-github-link",
+            "aria-label": "Envio on GitHub",
+          },
+          {
+            href: "https://envio.dev/app",
+            label: "Sign in",
+            position: "right",
+            className: "navbar__item--signin",
           },
         ],
       },

--- a/scripts/consolidate-hyperindex-docs.js
+++ b/scripts/consolidate-hyperindex-docs.js
@@ -471,7 +471,15 @@ function parseSidebarOrder(sidebarPath) {
       return module.exports;
     })`)(mockRequire);
 
-    return extractFileOrderFromSidebar(sidebarConfig.someSidebar);
+    // Envio Cloud (hosted-service) pages live in a separate `envioCloudSidebar`
+    // export. Append them so they are still included when the consolidated LLM
+    // docs are regenerated. No-op for sidebars without that key.
+    return [
+      ...extractFileOrderFromSidebar(sidebarConfig.someSidebar),
+      ...(sidebarConfig.envioCloudSidebar
+        ? extractFileOrderFromSidebar(sidebarConfig.envioCloudSidebar)
+        : []),
+    ];
   } catch (error) {
     console.error(`Error parsing sidebar ${sidebarPath}:`, error.message);
     return [];

--- a/sidebarsHyperIndex.js
+++ b/sidebarsHyperIndex.js
@@ -1,13 +1,15 @@
 var { supportedNetworks } = require("./supported-networks.json");
 
+// Plain collapsible category (no `link`) so its caret renders identically to
+// every other category. The overview page is preserved as the first item so
+// it's still reachable from the sidebar.
 const networksSection = {
   type: "category",
   label: "Supported Networks",
-  link: {
-    type: "doc",
-    id: "supported-networks/index",
-  },
-  items: supportedNetworks,
+  items: [
+    { type: "doc", id: "supported-networks/index", label: "Overview" },
+    ...supportedNetworks,
+  ],
 };
 
 module.exports = {
@@ -49,21 +51,6 @@ module.exports = {
         "Examples/example-sablier",
         "Examples/example-velodrome-aerodrome",
         // "Examples/example-cross-chain-messaging",
-      ],
-    },
-    {
-      type: "category",
-      label: "Envio Cloud",
-      collapsed: false,
-      items: [
-        "Hosted_Service/hosted-service",
-        "Hosted_Service/hosted-service-features",
-        "Hosted_Service/hosted-service-deployment",
-        "Hosted_Service/hosted-service-monitoring",
-        "Hosted_Service/envio-cloud-cli",
-        "Hosted_Service/hosted-service-billing",
-        "Hosted_Service/self-hosting",
-        "Hosted_Service/organisation-setup",
       ],
     },
     {
@@ -132,6 +119,18 @@ module.exports = {
     networksSection,
     "solana/solana",
     "fuel/fuel",
+    // Divider to split off the bottom section (LLM docs + legal), matching the
+    // divider under the top quick-links section.
+    {
+      type: "html",
+      value: "<hr />",
+      className: "menu-section-divider",
+    },
+    {
+      type: "link",
+      label: "Support",
+      href: "https://discord.gg/envio",
+    },
     {
       type: "link",
       label: "LLM Documentation",
@@ -163,5 +162,30 @@ module.exports = {
     //     "dashboard-alerts",
     //   ],
     // },
+  ],
+
+  // Envio Cloud is its own section: the hosted-service pages live here in a
+  // dedicated sidebar (not inside the HyperIndex tree). Docusaurus shows this
+  // sidebar automatically on any of these pages. URLs are unchanged — this is
+  // purely a navigation restructure, no content or slug changes.
+  envioCloudSidebar: [
+    "Hosted_Service/hosted-service",
+    "Hosted_Service/hosted-service-features",
+    "Hosted_Service/hosted-service-deployment",
+    "Hosted_Service/hosted-service-monitoring",
+    "Hosted_Service/envio-cloud-cli",
+    "Hosted_Service/hosted-service-billing",
+    "Hosted_Service/self-hosting",
+    "Hosted_Service/organisation-setup",
+    {
+      type: "html",
+      value: "<hr />",
+      className: "menu-section-divider",
+    },
+    {
+      type: "link",
+      label: "Support",
+      href: "https://discord.gg/envio",
+    },
   ],
 };

--- a/sidebarsHyperIndexV2.js
+++ b/sidebarsHyperIndexV2.js
@@ -168,6 +168,16 @@ module.exports = {
     },
     "fuel/fuel",
     {
+      type: "html",
+      value: "<hr />",
+      className: "menu-section-divider",
+    },
+    {
+      type: "link",
+      label: "Support",
+      href: "https://discord.gg/envio",
+    },
+    {
       type: "link",
       label: "LLM Documentation",
       href: "/docs/HyperIndex-LLM/hyperindex-complete",

--- a/sidebarsHyperRPC.js
+++ b/sidebarsHyperRPC.js
@@ -3,6 +3,16 @@ module.exports = {
       "overview-hyperrpc",
       "hyperrpc-supported-networks",
       {
+        type: "html",
+        value: "<hr />",
+        className: "menu-section-divider",
+      },
+      {
+        type: "link",
+        label: "Support",
+        href: "https://discord.gg/envio",
+      },
+      {
         type: "link",
         label: "LLM Documentation",
         href: "/docs/HyperRPC-LLM/hyperrpc-complete",

--- a/sidebarsHyperSync.js
+++ b/sidebarsHyperSync.js
@@ -41,6 +41,16 @@ module.exports = {
       ],
     },
     {
+      type: "html",
+      value: "<hr />",
+      className: "menu-section-divider",
+    },
+    {
+      type: "link",
+      label: "Support",
+      href: "https://discord.gg/envio",
+    },
+    {
       type: "link",
       label: "LLM Documentation",
       href: "/docs/HyperSync-LLM/hypersync-complete",

--- a/src/components/CopyPageButton/index.js
+++ b/src/components/CopyPageButton/index.js
@@ -1,0 +1,225 @@
+import React, {useState, useRef, useEffect} from 'react';
+import {useLocation} from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import styles from './styles.module.css';
+
+const MCP_URL = 'https://docs.envio.dev/mcp';
+
+// One-click MCP-server install deep links (config pre-encoded for each editor).
+const CURSOR_DEEPLINK =
+  'cursor://anysphere.cursor-deeplink/mcp/install?name=envio-docs&config=eyJ1cmwiOiJodHRwczovL2RvY3MuZW52aW8uZGV2L21jcCJ9';
+const VSCODE_DEEPLINK =
+  'vscode:mcp/install?%7B%22name%22%3A%22envio-docs%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdocs.envio.dev%2Fmcp%22%7D';
+// Codex sets up MCP via ~/.codex/config.toml, so we copy a ready-to-paste block.
+const CODEX_CONFIG = `[mcp_servers.envio_docs]
+command = "npx"
+args = ["-y", "mcp-remote", "https://docs.envio.dev/mcp"]`;
+
+/* --- Icons (inline SVG so they stay self-contained + theme-aware) ------ */
+const svg = (props) => ({
+  width: 17,
+  height: 17,
+  viewBox: '0 0 24 24',
+  'aria-hidden': true,
+  ...props,
+});
+
+function CopyIcon() {
+  return (
+    <svg {...svg({fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round'})}>
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+function CheckIcon() {
+  return (
+    <svg {...svg({fill: 'none', stroke: 'currentColor', strokeWidth: 2.5, strokeLinecap: 'round', strokeLinejoin: 'round'})}>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+function MarkdownIcon() {
+  return (
+    <svg {...svg({fill: 'currentColor'})}>
+      <path d="M22.27 19.385H1.73A1.73 1.73 0 0 1 0 17.655V6.345a1.73 1.73 0 0 1 1.73-1.73h20.54A1.73 1.73 0 0 1 24 6.345v11.31a1.73 1.73 0 0 1-1.73 1.73zM5.769 15.923v-4.5l2.308 2.885 2.307-2.885v4.5h2.308V8.078h-2.308l-2.307 2.885-2.308-2.885H3.46v7.847zM21.232 12h-2.309V8.077h-2.307V12h-2.308l3.461 4.039z" />
+    </svg>
+  );
+}
+function OpenAIIcon() {
+  return (
+    <svg {...svg({fill: 'currentColor'})}>
+      <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.998-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.08 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.677l5.815 3.354-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.856-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zM8.307 12.863l-2.02-1.164a.08.08 0 0 1-.038-.057V6.074a4.5 4.5 0 0 1 7.376-3.454l-.142.08L8.704 5.46a.795.795 0 0 0-.393.68zm1.098-2.365 2.602-1.5 2.607 1.5v3l-2.597 1.5-2.607-1.5z" />
+    </svg>
+  );
+}
+function ClaudeIcon() {
+  return (
+    <svg {...svg({fill: 'currentColor'})}>
+      <path d="M4.709 15.955l4.72-2.647.079-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.365-.462-.158-1.008.656-.722.881.06.225.061 2.213 1.688 1.351.99 1.766 1.302.259.157.103-.074.013-.051-.116-.194-.962-1.74-1.028-1.773-.457-.734-.121-.44a2.13 2.13 0 0 1-.073-.518l.749-1.017.414-.133.998.134.42.364.622 1.42 1.009 2.243 1.566 3.051.457.905.245.837.091.256h.159v-.147l.128-1.717.237-2.11.23-2.717.08-.765.376-.91.75-.494.585.28.483.689-.067.445-.286 1.856-.559 2.906-.364 1.948h.212l.243-.242.983-1.305 1.65-2.064.728-.819.85-.905.547-.43h1.033l.76 1.128-.34 1.165-1.063 1.347-.881 1.142-1.263 1.7-.79 1.36.073.11.188-.02 2.856-.607 1.543-.28 1.841-.315.833.388.091.395-.328.806-1.967.487-2.307.461-3.436.813-.043.03.05.061 1.548.146.662.036h1.619l3.018.225.79.522.473.639-.079.485-1.214.618-1.64-.388-3.826-.911-1.312-.327h-.181v.109l1.093 1.069 2.006 1.81 2.509 2.33.127.578-.321.455-.34-.048-2.204-1.657-.85-.746-1.926-1.62h-.126v.17l.443.648 2.343 3.522.121 1.08-.169.354-.606.212-.668-.121-1.374-1.926-1.415-2.166-1.14-1.943-.14.08-.674 7.253-.316.37-.729.281-.607-.462-.322-.746.322-1.476.389-1.924.315-1.53.286-1.899.169-.632-.011-.042-.14.018-1.434 1.967-2.18 2.945-1.723 1.845-.415.164-.716-.371.067-.662.4-.589 2.389-3.035 1.44-1.883.929-1.085-.006-.159h-.055L4.132 18.56l-1.13.145-.487-.455.06-.746.232-.243 1.907-1.311z" />
+    </svg>
+  );
+}
+function PerplexityIcon() {
+  return (
+    <svg {...svg({fill: 'currentColor'})}>
+      <path d="M19.785 0v7.272H22.5V17.62h-2.935V24l-7.037-6.194v6.145h-1.091v-6.152L4.392 24v-6.465H1.5V7.188h2.884V0l7.053 6.494V.19h1.09v6.49L19.785 0zm-7.257 9.044v7.319l5.946 5.234V14.44l-5.946-5.397zm-1.099-.08l-5.946 5.398v7.235l5.946-5.234V8.965zm8.136 7.58h1.844V8.271h-6.386l4.542 4.123v4.15zm-8.5-8.202H4.478v8.275h1.844v-4.15l4.743-4.125zM5.469 3.383v3.516l5.454 4.955.53-.481-5.984-7.99zm13.028 0l-5.632 7.99.53.482 5.102-4.635V3.383z" />
+    </svg>
+  );
+}
+function McpIcon() {
+  return (
+    <svg {...svg({fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round'})}>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+function CursorIcon() {
+  return (
+    <svg {...svg({fill: 'currentColor'})}>
+      <path d="M12 2 3 7v10l9 5 9-5V7l-9-5Zm0 2.31L18.26 8 12 11.69 5.74 8 12 4.31ZM5 9.5l6 3.53v6.96l-6-3.33V9.5Zm14 0v7.16l-6 3.33V13.03l6-3.53Z" />
+    </svg>
+  );
+}
+function VsCodeIcon() {
+  return (
+    <svg {...svg({fill: 'currentColor'})}>
+      <path d="M23.15 2.587 18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 20.06V3.939a1.5 1.5 0 0 0-.85-1.352Zm-5.146 14.861L10.826 12l7.178-5.448v10.896Z" />
+    </svg>
+  );
+}
+function CodexIcon() {
+  return (
+    <svg {...svg({fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round'})}>
+      <rect x="2.5" y="4" width="19" height="16" rx="2" />
+      <path d="M7 9l3 3-3 3M13.5 15H17" />
+    </svg>
+  );
+}
+
+function Chevron({open}) {
+  return (
+    <svg {...svg({width: 14, height: 14, fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round'})}
+      style={{transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s ease'}}>
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+export default function CopyPageButton() {
+  const {pathname} = useLocation();
+  const {siteConfig} = useDocusaurusContext();
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState('');
+  const ref = useRef(null);
+  const isBrowser = useIsBrowser();
+
+  const mdPath = pathname.replace(/\/$/, '') + '.md';
+  const mdUrl = siteConfig.url + mdPath;
+  const aiPrompt = encodeURIComponent(
+    `Read this Envio documentation page for full context, then help me put it into action, whether that's answering questions, writing code, or debugging. Here's the page: ${mdUrl}`,
+  );
+
+  useEffect(() => {
+    function onDocClick(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    }
+    document.addEventListener('click', onDocClick);
+    return () => document.removeEventListener('click', onDocClick);
+  }, []);
+
+  // Client-only: keep the button out of the SSR HTML so crawlers reach the
+  // article content first (same pattern as the version banner).
+  if (!isBrowser) {
+    return null;
+  }
+
+  async function copyText(text, key) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(key);
+      setTimeout(() => setCopied(''), 2000);
+    } catch (e) {
+      /* clipboard unavailable */
+    }
+  }
+
+  async function copyPage() {
+    try {
+      const res = await fetch(mdPath);
+      await copyText(await res.text(), 'page');
+    } catch (e) {
+      /* ignore */
+    }
+    setOpen(false);
+  }
+
+  const items = [
+    {icon: <CopyIcon />, label: 'Copy page', desc: 'Copy as Markdown, ready to feed an LLM', onClick: copyPage},
+    {icon: <MarkdownIcon />, label: 'View as Markdown', desc: 'Open the raw Markdown for this page', href: mdPath, external: true},
+    {icon: <OpenAIIcon />, label: 'Open in ChatGPT', desc: 'Ask ChatGPT about this page', href: `https://chatgpt.com/?q=${aiPrompt}`, external: true},
+    {icon: <ClaudeIcon />, label: 'Open in Claude', desc: 'Ask Claude about this page', href: `https://claude.ai/new?q=${aiPrompt}`, external: true},
+    {icon: <PerplexityIcon />, label: 'Open in Perplexity', desc: 'Ask Perplexity about this page', href: `https://www.perplexity.ai/search?q=${aiPrompt}`, external: true},
+    {icon: <McpIcon />, label: 'Copy MCP Server', desc: "Connect your AI to Envio's docs MCP", onClick: () => {copyText(MCP_URL, 'mcp'); setOpen(false);}, copiedKey: 'mcp'},
+    {icon: <CursorIcon />, label: 'Connect to Cursor', desc: 'Install the Envio docs MCP in Cursor', href: CURSOR_DEEPLINK, external: true},
+    {icon: <VsCodeIcon />, label: 'Connect to VS Code', desc: 'Install the Envio docs MCP in VS Code', href: VSCODE_DEEPLINK, external: true},
+    {icon: <CodexIcon />, label: 'Connect to Codex', desc: 'Copy MCP config for Codex', onClick: () => {copyText(CODEX_CONFIG, 'codex'); setOpen(false);}, copiedKey: 'codex'},
+  ];
+
+  return (
+    <div className={styles.wrapper} ref={ref}>
+      <div className={styles.split}>
+        <button type="button" className={styles.mainBtn} onClick={copyPage}>
+          {copied === 'page' ? <CheckIcon /> : <CopyIcon />}
+          {copied === 'page' ? 'Copied!' : 'Copy page'}
+        </button>
+        <button
+          type="button"
+          className={styles.caretBtn}
+          onClick={() => setOpen((o) => !o)}
+          aria-label="More copy options"
+          aria-expanded={open}>
+          <Chevron open={open} />
+        </button>
+      </div>
+
+      {open && (
+        <div className={styles.menu} role="menu">
+          {items.map((it, i) =>
+            it.href ? (
+              <a
+                key={i}
+                href={it.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.item}
+                onClick={() => setOpen(false)}>
+                <span className={styles.itemIcon} aria-hidden>{it.icon}</span>
+                <span className={styles.itemText}>
+                  <span className={styles.itemLabel}>
+                    {it.label}
+                    {it.external && <span className={styles.ext} aria-hidden>↗</span>}
+                  </span>
+                  <span className={styles.itemDesc}>{it.desc}</span>
+                </span>
+              </a>
+            ) : (
+              <button key={i} type="button" className={styles.item} onClick={it.onClick}>
+                <span className={styles.itemIcon} aria-hidden>{it.icon}</span>
+                <span className={styles.itemText}>
+                  <span className={styles.itemLabel}>
+                    {copied === it.copiedKey ? 'Copied!' : it.label}
+                  </span>
+                  <span className={styles.itemDesc}>{it.desc}</span>
+                </span>
+              </button>
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CopyPageButton/index.js
+++ b/src/components/CopyPageButton/index.js
@@ -137,22 +137,28 @@ export default function CopyPageButton() {
     return null;
   }
 
+  function flagError() {
+    setCopied('error');
+    setTimeout(() => setCopied(''), 2000);
+  }
+
   async function copyText(text, key) {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(key);
       setTimeout(() => setCopied(''), 2000);
     } catch (e) {
-      /* clipboard unavailable */
+      flagError();
     }
   }
 
   async function copyPage() {
     try {
       const res = await fetch(mdPath);
+      if (!res.ok) throw new Error(`Could not fetch ${mdPath}: ${res.status}`);
       await copyText(await res.text(), 'page');
     } catch (e) {
-      /* ignore */
+      flagError();
     }
     setOpen(false);
   }
@@ -174,7 +180,7 @@ export default function CopyPageButton() {
       <div className={styles.split}>
         <button type="button" className={styles.mainBtn} onClick={copyPage}>
           {copied === 'page' ? <CheckIcon /> : <CopyIcon />}
-          {copied === 'page' ? 'Copied!' : 'Copy page'}
+          {copied === 'page' ? 'Copied!' : copied === 'error' ? 'Failed' : 'Copy page'}
         </button>
         <button
           type="button"

--- a/src/components/CopyPageButton/styles.module.css
+++ b/src/components/CopyPageButton/styles.module.css
@@ -1,0 +1,136 @@
+/* Floats top-right of the doc content, aligned with the page title (h1) so
+   the button sits inline with the heading rather than above it. */
+.wrapper {
+  position: relative;
+  float: right;
+  margin: 0.35rem 0 0.5rem 1.25rem;
+  z-index: 5;
+}
+
+/* Split button: "Copy page" + caret */
+.split {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--ifm-background-color);
+}
+
+.mainBtn,
+.caretBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: transparent;
+  border: none;
+  color: var(--ifm-font-color-base);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  font-family: inherit;
+}
+
+.mainBtn {
+  padding: 7px 12px;
+}
+
+.caretBtn {
+  padding: 7px 8px;
+  border-left: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.mainBtn:hover,
+.caretBtn:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+/* Dropdown menu */
+.menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 300px;
+  padding: 6px;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+[data-theme='dark'] .menu {
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
+}
+
+.item {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 11px;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ifm-font-color-base);
+  font-family: inherit;
+  width: 100%;
+  transition: background 0.12s ease;
+  text-decoration: none;
+}
+
+.itemIcon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  margin-top: 2px;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.itemText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.item .itemLabel,
+.item .itemDesc {
+  text-decoration: none;
+}
+
+.item:hover {
+  background: var(--ifm-color-emphasis-100);
+  text-decoration: none;
+  color: var(--ifm-font-color-base);
+}
+
+.itemLabel {
+  font-size: 0.875rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.itemDesc {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.ext {
+  font-size: 0.7rem;
+  opacity: 0.6;
+}
+
+/* On narrow screens, don't float — sit above the content full-width-ish */
+@media (max-width: 996px) {
+  .wrapper {
+    float: none;
+    margin: 0 0 1rem 0;
+  }
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,6 +79,9 @@
    navbar in HTML, so we anchor the navbar with position: fixed and shift
    the main wrapper down. Without this, navbar text would appear visually
    beneath the article. See src/theme/Layout/index.tsx. */
+/* Fixed to the top of the viewport (stays put on scroll). Renders after the
+   content in the DOM for crawler source-order; position: fixed re-anchors it
+   to the top visually. */
 .navbar {
   position: fixed;
   top: 0;
@@ -647,4 +650,413 @@ table td {
   .theme-doc-markdown h3 {
     font-size: 1.375rem;
   }
+}
+
+/* =====================================================================
+   ENVIO BRAND REFRESH  (Goldsky-inspired, on-brand for Envio)
+   Cosmetic layer only — no content changes. Clean and restrained:
+   Geist typography, generous whitespace, soft rounded cards, and a
+   single coral accent used sparingly. The coral→gold gradient is held
+   back for the wordmark and one small sidebar indicator only.
+   ===================================================================== */
+
+:root {
+  /* Envio brand tokens (from envio.dev/brand) */
+  --envio-coral: #ff8267;
+  --envio-gold: #fdd700;
+  --envio-gradient: linear-gradient(135deg, #ff8267 0%, #fdd700 100%);
+
+  /* Single accent, used sparingly */
+  --envio-accent: #f4613f; /* slightly deeper coral for text/contrast */
+  --envio-accent-tint: rgba(255, 130, 103, 0.09); /* hover surface */
+  --envio-accent-tint-strong: rgba(255, 130, 103, 0.14); /* active surface */
+  --envio-hairline: rgba(0, 0, 0, 0.07);
+
+  /* Geist as the primary typeface, with the existing system stack as fallback */
+  --ifm-font-family-base: "Geist", -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", Arial, sans-serif;
+  --ifm-font-family-monospace: "Geist Mono", Menlo, Monaco, Consolas,
+    "Roboto Mono", "SFMono-Regular", monospace;
+
+  --ifm-link-color: var(--envio-accent);
+  --ifm-menu-color-active: var(--envio-accent);
+
+  /* A touch more air between elements — Mintlify/Goldsky-style spacing */
+  --ifm-spacing-vertical: 1.15rem;
+}
+
+/* Warm surfaces in dark mode to match the brand's #1E1F23 */
+[data-theme="dark"] {
+  --envio-accent: #ff9077; /* brighter coral reads better on dark */
+  --envio-hairline: rgba(255, 255, 255, 0.08);
+  --ifm-background-color: #17181c;
+  --ifm-background-surface-color: #1e1f23;
+}
+
+/* Softer, warmer off-white for light mode — pure white was too harsh. */
+html:not([data-theme="dark"]) {
+  --ifm-background-color: #f7f6f3;
+  --ifm-background-surface-color: #efeeea;
+}
+
+/* --- Navbar: keep it clean; just a soft hairline --------------------- */
+.navbar {
+  border-bottom: 1px solid var(--envio-hairline);
+  box-shadow: none;
+}
+
+[data-theme="dark"] .navbar {
+  border-bottom: 1px solid var(--envio-hairline);
+  box-shadow: none;
+}
+
+/* Goldsky-style: the logo occupies the sidebar-width zone, and its right
+   border lines up with the sidebar's right edge — so the product tabs sit
+   past the divider, aligned with the content column. */
+@media (min-width: 997px) {
+  .navbar__brand {
+    width: calc(
+      var(--doc-sidebar-width, 300px) - var(--ifm-navbar-padding-horizontal, 1rem)
+    );
+    margin-right: 0;
+    padding-right: 1rem;
+    border-right: 1px solid var(--ifm-toc-border-color);
+  }
+
+  /* Product tabs start just past the divider */
+  .navbar__items > .navbar__item:first-of-type,
+  .navbar__items > .dropdown:first-of-type {
+    margin-left: 1rem;
+  }
+
+  /* Search now lives in the left sidebar on desktop — hide the navbar copy */
+  .navbar .DocSearch-Button {
+    display: none !important;
+  }
+}
+
+/* Active section tab highlights in the brand orange. For the HyperIndex
+   dropdown, Docusaurus marks the active child but not the parent link, so we
+   colour the parent when it contains an active item via :has(). */
+.navbar__link--active,
+.navbar__item--active > .navbar__link,
+.navbar__item.dropdown:has(.dropdown__link--active) > .navbar__link {
+  color: var(--envio-coral) !important;
+  font-weight: 600;
+}
+
+/* --- Sidebar: subtly emphasise top-level categories (not all-caps) --- */
+.theme-doc-sidebar-item-category-level-1
+  > .menu__list-item-collapsible
+  > .menu__link {
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.menu__link {
+  padding: 7px 12px;
+}
+
+/* The sidebar header sits above and stays fixed; the DocSidebar fills the
+   remaining space and scrolls internally (min-height:0 lets the flex child
+   shrink so its inner .menu scrollbar engages — clean scroll like live docs).
+   Also drops the DocSidebar's own navbar-height offset (header handles it). */
+[class*="theme-DocSidebar-Desktop-styles-module"] {
+  height: auto !important;
+  max-height: none !important;
+  position: static !important;
+  padding-top: 0.5rem !important;
+}
+
+/* The whole sidebar scrolls as one (sidebarViewport). Disable the DocSidebar's
+   own inner scroll so there's a single, unified scrollbar. */
+.theme-doc-sidebar-container nav.menu {
+  overflow: visible !important;
+}
+
+/* Right-hand table of contents: start below the breadcrumb divider line
+   (not level with it), and stick below the fixed navbar when scrolled. */
+@media (min-width: 997px) {
+  .theme-doc-toc-desktop {
+    margin-top: 4rem;
+    top: calc(var(--ifm-navbar-height) + 1rem);
+  }
+}
+
+/* Section divider in the sidebar (e.g. above LLM Documentation), matching the
+   line under the top quick-links section. */
+.menu-section-divider {
+  margin: 0.75rem 0;
+}
+
+/* Align the page title (first h1) with the floated "Copy page" button so they
+   sit inline. The breadcrumb's own bottom margin keeps the spacing above. */
+.theme-doc-markdown > h1:first-child,
+.theme-doc-markdown > header:first-child h1 {
+  margin-top: 0.35rem;
+}
+
+.menu-section-divider hr {
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--ifm-toc-border-color);
+}
+
+/* The linked-category caret (Supported Networks) uses Infima's default,
+   which already matches the inline carets (same icon + rotation). Only
+   neutralise the separate button's hover box so it doesn't look distinct. */
+.menu__caret:hover {
+  background: transparent;
+}
+
+/* Soft hover + soft active — no heavy fills */
+.menu__link:hover,
+[data-theme="dark"] .menu__link:hover {
+  background: var(--envio-accent-tint);
+  color: var(--envio-accent);
+}
+
+.menu__link--active,
+.menu__link--active:hover,
+[data-theme="dark"] .menu__link--active,
+[data-theme="dark"] .menu__link--active:hover {
+  background: var(--envio-accent-tint-strong);
+  color: var(--envio-accent);
+  font-weight: 600;
+}
+
+/* Envio Cloud category — one small gradient indicator so it's spottable */
+.menu__link[href*="Hosted_Service"] {
+  position: relative;
+  font-weight: 600;
+}
+
+.menu__link[href*="Hosted_Service"]::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--envio-gradient);
+}
+
+/* --- Links: neutral (NOT orange) — body colour, underlined ----------- */
+article a {
+  color: var(--ifm-font-color-base);
+  text-decoration: underline;
+  text-decoration-color: var(--ifm-color-emphasis-400);
+  text-underline-offset: 2px;
+  transition: text-decoration-color 0.2s ease;
+}
+
+article a:hover {
+  color: var(--ifm-font-color-base);
+  text-decoration-color: currentColor;
+}
+
+/* --- Cards: soft, rounded, hover-lift (echoes Goldsky's card grid) --- */
+.card {
+  border: 1px solid var(--envio-hairline);
+  border-radius: 12px;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  border-color: var(--envio-accent);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="dark"] .card:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+/* --- Table of contents active state — soft, coral --------------------- */
+.table-of-contents__link:hover {
+  background: var(--envio-accent-tint);
+  color: var(--envio-accent);
+}
+
+.table-of-contents__link--active,
+[data-theme="dark"] .table-of-contents__link--active {
+  background: transparent;
+  color: var(--envio-accent);
+  font-weight: 600;
+  border-left: 2px solid var(--envio-accent);
+  border-radius: 0;
+}
+
+/* --- Code blocks: clean neutral border, rounded --------------------- */
+.prism-code {
+  border: 1px solid var(--envio-hairline);
+  border-radius: 8px;
+}
+
+/* --- Pagination: subtle coral affordance ---------------------------- */
+.pagination-nav__link {
+  border-radius: 12px;
+  transition: border-color 0.2s ease;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--envio-accent);
+}
+
+.pagination-nav__sublabel {
+  color: var(--envio-accent);
+}
+
+/* --- Primary buttons: brand gradient -------------------------------- */
+.button--primary {
+  background: var(--envio-gradient);
+  border: none;
+  color: #17181c;
+  font-weight: 600;
+}
+
+.button--primary:hover {
+  filter: brightness(1.05);
+  color: #17181c;
+}
+
+/* --- Breadcrumb hover ------------------------------------------------ */
+.breadcrumbs__link:hover {
+  background: var(--envio-accent-tint);
+  color: var(--envio-accent);
+}
+
+/* --- Navbar dropdowns: rounded, soft shadow, coral active ------------ */
+.dropdown__menu {
+  border-radius: 10px;
+  border: 1px solid var(--envio-hairline);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.12);
+  /* Match the default Docusaurus dropdown: no margin-top, and use padding
+     for the visual spacing. This keeps the menu box overlapping the trigger
+     so hovering down onto v2/v3 never crosses a dead zone. */
+  padding: 8px;
+  margin-top: 0;
+}
+
+[data-theme="dark"] .dropdown__menu {
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
+}
+
+.dropdown__link {
+  border-radius: 6px;
+  font-size: 0.875rem;
+  padding: 7px 12px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.dropdown__link:hover {
+  background: var(--envio-accent-tint);
+  color: var(--envio-accent);
+}
+
+.dropdown__link--active,
+.dropdown__link--active:hover {
+  background: var(--envio-accent-tint-strong);
+  color: var(--envio-accent);
+  font-weight: 600;
+}
+
+/* Dropdown caret + hover state on the navbar trigger */
+.navbar__item.dropdown > .navbar__link:hover {
+  color: var(--envio-accent);
+}
+
+/* --- GitHub navbar link shown as the GitHub mark, not text ----------- */
+.header-github-link {
+  display: flex;
+  align-items: center;
+}
+
+.header-github-link::before {
+  content: "";
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  background-color: currentColor;
+  -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>')
+    no-repeat center / contain;
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>')
+    no-repeat center / contain;
+}
+
+.header-github-link:hover {
+  opacity: 0.7;
+}
+
+/* --- Sign in: filled white button on the far right (like the landing) --- */
+.navbar__item--signin {
+  border-radius: 8px;
+  padding: 6px 16px;
+  font-weight: 600;
+  background: #ffffff !important;
+  color: #000000 !important;
+  transition: opacity 0.2s ease;
+}
+
+.navbar__item--signin:hover {
+  opacity: 0.85;
+  color: #000000 !important;
+  text-decoration: none;
+}
+
+/* Clean button — drop the auto external-link icon */
+.navbar__item--signin svg {
+  display: none;
+}
+
+/* Order the right cluster: GitHub, dark-mode toggle, then Sign in (rightmost),
+   with breathing room between each. */
+.navbar__items--right {
+  align-items: center;
+  gap: 0.4rem;
+}
+.navbar__items--right > .header-github-link {
+  order: 1;
+}
+.navbar__items--right > [class*="toggle_"] {
+  order: 2;
+}
+.navbar__items--right > .navbar__item--signin {
+  order: 3;
+  margin-left: 0.5rem;
+}
+
+/* Keep the navbar dark in both themes (stays dark even in light mode) */
+.navbar {
+  background: rgba(0, 0, 0, 0.95) !important;
+  border-bottom: 1px solid #262626 !important;
+}
+.navbar
+  .navbar__link:not(.navbar__link--active):not(.navbar__item--signin) {
+  color: #e5e5e5 !important;
+}
+.navbar
+  .navbar__link:not(.navbar__link--active):not(.navbar__item--signin):hover {
+  color: #ffffff !important;
+}
+.navbar__brand {
+  border-right-color: #333 !important;
+}
+.header-github-link::before {
+  background-color: #e5e5e5;
+}
+.navbar__items--right > [class*="toggle_"],
+.navbar__items--right > [class*="toggle_"] button {
+  color: #e5e5e5;
+}
+/* Sign in stays black-on-white in every state. High specificity + [data-theme]
+   is needed to beat `[data-theme="dark"] .navbar__item:hover { color:#fff }`. */
+[data-theme="dark"] .navbar .navbar__item--signin,
+[data-theme="dark"] .navbar .navbar__item--signin:hover,
+.navbar .navbar__item--signin,
+.navbar .navbar__item--signin:hover {
+  background: #ffffff !important;
+  color: #000000 !important;
 }

--- a/src/theme/DocItem/Content/index.js
+++ b/src/theme/DocItem/Content/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Content from '@theme-original/DocItem/Content';
+import CopyPageButton from '@site/src/components/CopyPageButton';
+
+// Renders the "Copy page / AI actions" split button at the top-right of the
+// article (floated), then the normal MDX content.
+export default function ContentWrapper(props) {
+  return (
+    <>
+      <CopyPageButton />
+      <Content {...props} />
+    </>
+  );
+}

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,45 +1,21 @@
 import React from 'react';
 import Layout from '@theme-original/DocItem/Layout';
-import { useActivePlugin } from '@docusaurus/plugin-content-docs/client';
-import useIsBrowser from '@docusaurus/useIsBrowser';
+import {useActivePlugin} from '@docusaurus/plugin-content-docs/client';
 import Head from '@docusaurus/Head';
-import Admonition from '@theme/Admonition';
-import Link from '@docusaurus/Link';
 
 export default function LayoutWrapper(props) {
   const activePlugin = useActivePlugin();
   const pluginId = activePlugin?.pluginId;
-  // Defer the version banner to client-side render so it does not appear
-  // in the SSR HTML stream above the article. This keeps the
-  // content-start-position low for HTML→markdown agent crawlers. Users
-  // still see the banner after hydration.
-  const isBrowser = useIsBrowser();
 
+  // The version banner itself lives in src/theme/DocVersionBanner — it renders
+  // inside the content column so it matches the article width. Here we only
+  // keep the v2 noindex directive.
   return (
     <>
       {pluginId === 'HyperIndexV2' && (
         <Head>
           <meta name="robots" content="noindex" />
         </Head>
-      )}
-      {isBrowser && pluginId === 'HyperIndexV2' && (
-        <Admonition type="warning" title="You're viewing v2 documentation">
-          <p>
-            This is the <strong>v2</strong> HyperIndex documentation. We highly
-            recommend migrating to <strong>v3</strong> — follow the{' '}
-            <Link to="/docs/HyperIndex/migrate-to-v3">v3 migration guide</Link>.
-          </p>
-        </Admonition>
-      )}
-      {isBrowser && pluginId === 'HyperIndex' && (
-        <Admonition type="info" title="You're viewing v3 documentation">
-          <p>
-            This is the <strong>v3</strong> HyperIndex documentation. Still on
-            an older version? Open the{' '}
-            <Link to="/docs/v2/HyperIndex/overview">v2 documentation</Link> and
-            consider <Link to="/docs/HyperIndex/migrate-to-v3">migrating to v3</Link>.
-          </p>
-        </Admonition>
       )}
       <Layout {...props} />
     </>

--- a/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -3,11 +3,51 @@ import clsx from 'clsx';
 import {prefersReducedMotion, ThemeClassNames} from '@docusaurus/theme-common';
 import {useDocsSidebar} from '@docusaurus/theme-common/internal';
 import {useLocation} from '@docusaurus/router';
+import Link from '@docusaurus/Link';
 import DocSidebar from '@theme/DocSidebar';
+import SearchBar from '@theme/SearchBar';
 import ExpandButton from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
 import type {Props} from '@theme/DocRoot/Layout/Sidebar';
 
 import styles from './styles.module.css';
+
+// Quick links surfaced at the top of the sidebar (Goldsky-style), moved out
+// of the top navbar to keep the product tabs clean. External links get an
+// arrow affordance.
+const SIDEBAR_LINKS = [
+  {label: 'Changelog', href: 'https://envio.dev/changelog', external: true},
+  {label: 'Showcase', to: '/showcase'},
+  {label: 'Blog', to: '/blog'},
+  {label: "Shipper's Logs", to: '/videos'},
+];
+
+function SidebarHeader() {
+  return (
+    <div className={styles.sidebarHeader}>
+      <div className={styles.sidebarSearch}>
+        <SearchBar />
+      </div>
+      <nav className={styles.sidebarLinks} aria-label="Quick links">
+        {SIDEBAR_LINKS.map((item) =>
+          item.external ? (
+            <a
+              key={item.label}
+              href={item.href}
+              className={styles.sidebarLink}
+              target="_blank"
+              rel="noopener noreferrer">
+              {item.label}
+            </a>
+          ) : (
+            <Link key={item.label} to={item.to!} className={styles.sidebarLink}>
+              {item.label}
+            </Link>
+          ),
+        )}
+      </nav>
+    </div>
+  );
+}
 
 // Reset sidebar state when sidebar changes
 // Use React key to unmount/remount the children
@@ -69,6 +109,7 @@ export default function DocRootLayoutSidebar({
             styles.sidebarViewport,
             hiddenSidebar && styles.sidebarViewportHidden,
           )}>
+          {!hiddenSidebar && <SidebarHeader />}
           <DocSidebar
             sidebar={sidebar}
             path={pathname}

--- a/src/theme/DocRoot/Layout/Sidebar/styles.module.css
+++ b/src/theme/DocRoot/Layout/Sidebar/styles.module.css
@@ -26,7 +26,61 @@
   .sidebarViewport {
     top: 0;
     position: sticky;
-    height: 100%;
+    height: 100vh;
     max-height: 100vh;
+    /* Single scroll region: search + quick links + the whole doc nav scroll
+       together as one, like the live docs sidebar. */
+    overflow-y: auto;
   }
+}
+
+/* --- Sidebar header: search + quick links (moved out of the navbar) --- */
+.sidebarHeader {
+  padding: 1rem 0.75rem 0.75rem;
+  margin-top: var(--ifm-navbar-height);
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+.sidebarSearch {
+  margin-bottom: 0.75rem;
+}
+
+/* Make the Algolia search button fill the sidebar width, Goldsky-style */
+.sidebarSearch :global(.DocSearch-Button) {
+  width: 100%;
+  margin: 0;
+  border-radius: 8px;
+  height: 40px;
+}
+
+/* Quick links directly under the search box at the top of the sidebar
+   (plain, no box). Legal links (Licensing/Terms/Privacy) stay at the bottom
+   of the doc nav tree, reached by scrolling. */
+.sidebarLinks {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebarLink {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-700);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.sidebarLink:hover {
+  background: var(--envio-accent-tint, rgba(255, 130, 103, 0.09));
+  color: var(--envio-accent, #f4613f);
+  text-decoration: none;
+}
+
+.sidebarLinkArrow {
+  font-size: 0.75rem;
+  opacity: 0.6;
 }

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import {useActivePlugin} from '@docusaurus/plugin-content-docs/client';
+import {useLocation} from '@docusaurus/router';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import Admonition from '@theme/Admonition';
+import Link from '@docusaurus/Link';
+
+// Envio Cloud pages live in the HyperIndex plugin but are their own section,
+// so the HyperIndex version banner should not appear on them.
+const ENVIO_CLOUD_RE =
+  /^\/docs\/HyperIndex\/(hosted-service|self-hosting|organisation-setup|envio-cloud-cli)/;
+
+// Rendered by DocItem/Layout inside the content column (above the
+// breadcrumbs), so it's constrained to the article width like any other
+// admonition — not spanning the full page across the TOC.
+//
+// Deferred to client-side render (useIsBrowser) so it stays out of the SSR
+// HTML stream, keeping the content-start-position low for agent crawlers.
+export default function DocVersionBanner() {
+  const activePlugin = useActivePlugin();
+  const pluginId = activePlugin?.pluginId;
+  const {pathname} = useLocation();
+  const isBrowser = useIsBrowser();
+
+  if (!isBrowser) {
+    return null;
+  }
+
+  if (pluginId === 'HyperIndexV2') {
+    return (
+      <Admonition type="warning" title="You're viewing v2 documentation">
+        <p>
+          This is the <strong>v2</strong> HyperIndex documentation. We highly
+          recommend migrating to <strong>v3</strong> — follow the{' '}
+          <Link to="/docs/HyperIndex/migrate-to-v3">v3 migration guide</Link>.
+        </p>
+      </Admonition>
+    );
+  }
+
+  if (pluginId === 'HyperIndex' && !ENVIO_CLOUD_RE.test(pathname)) {
+    return (
+      <Admonition type="info" title="You're viewing v3 documentation">
+        <p>
+          This is the <strong>v3</strong> HyperIndex documentation. Still on an
+          older version? Open the{' '}
+          <Link to="/docs/v2/HyperIndex/overview">v2 documentation</Link> and
+          consider{' '}
+          <Link to="/docs/HyperIndex/migrate-to-v3">migrating to v3</Link>.
+        </p>
+      </Admonition>
+    );
+  }
+
+  return null;
+}

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -26,9 +26,9 @@ function Footer() {
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          maxWidth: "var(--ifm-container-width)",
-          margin: "0 auto",
-          padding: "0 1rem",
+          width: "100%",
+          margin: "0",
+          padding: "0 1.5rem",
           height: "var(--ifm-navbar-height)",
           fontSize: "0.875rem",
         }}


### PR DESCRIPTION
## What

A cosmetic and navigation-only refresh of the docs site. No documentation content, page slugs, or URLs change. This is purely presentation and structure.

## Changes

- Rebranded styling: Geist font, coral/gold accents, dark navbar, softer light-mode background
- Flattened the navbar into product tabs: HyperIndex (v3 latest / v2), HyperSync, HyperRPC, Envio Cloud, with a GitHub icon and a Sign in button
- Moved search and Changelog / Showcase / Blog / Shipper's Logs into the left sidebar
- Gave Envio Cloud its own dedicated sidebar section
- Added a per-page "Copy page" menu (view as Markdown, open in ChatGPT / Claude / Perplexity, connect MCP to Cursor / VS Code / Codex)
- Added a divider and a Support (Discord) link above the LLM Documentation entry in every section

## Scope and safety

- 13 files, all theme / config / component. Zero content files touched.
- Production build passes with `onBrokenLinks: "throw"` (all internal links resolve, 348 docs).
- SSR output is unchanged for crawlers: the Copy page menu and version banner render client-side only (`useIsBrowser`), so GEO / AEO / SEO source order is preserved.
- No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Copy page” button on docs pages with quick actions like copying content, opening the page in AI tools, and viewing raw Markdown.
  * Added a searchable docs sidebar with quick links and improved navigation for key product areas.
  * Introduced clearer version awareness with banners for v2/v3 documentation.

* **Style**
  * Refreshed the docs site branding, typography, colors, navbar, sidebar, and footer for a more consistent look.

* **Bug Fixes**
  * Improved sidebar scrolling and layout on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->