### PR TITLE
fix(seo): single social preview image on overview pages

### DIFF
--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -7,11 +7,6 @@ description: Explore HyperIndex, a blazing-fast multichain indexer for real-time
 image: /docs-assets/og/HyperIndex/overview.png
 ---
 
-<Head>
-  <meta name="og:image" content="/img/preview-banner.png" />
-  <meta name="twitter:image" content="/img/preview-banner.png" />
-</Head>
-
 **HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications.
 
 ![Sync Process](../../static/img/sync.gif)

--- a/docs/HyperIndexV2/overview.md
+++ b/docs/HyperIndexV2/overview.md
@@ -4,12 +4,8 @@ title: "HyperIndex: Fast Multichain Blockchain Indexer"
 sidebar_label: Overview
 slug: /overview
 description: Explore HyperIndex, a blazing-fast multichain indexer for real-time blockchain data.
+image: /docs-assets/og/HyperIndexV2/overview.png
 ---
-
-<Head>
-  <meta name="og:image" content="/img/preview-banner.png" />
-  <meta name="twitter:image" content="/img/preview-banner.png" />
-</Head>
 
 **HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications.
 


### PR DESCRIPTION
The HyperIndex and HyperIndex v2 overview pages had a leftover hardcoded `og:image`/`twitter:image` `<Head>` block from before the per-page social-card generator existed. As a result each page emitted two `og:image` tags and link unfurls (Discord/Slack/X) showed two images.

This drops the stale block so both pages use the generated per-page card like the rest of the docs, and pins the v2 overview card explicitly.

Verified the generated cards exist and each page now emits a single `og:image`.