### PR TITLE
fix(docs): align navbar GitHub button height with Sign in button

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -970,17 +970,24 @@ article a:hover {
   color: var(--envio-accent);
 }
 
-/* --- GitHub navbar link shown as the GitHub mark, not text ----------- */
+/* --- GitHub navbar link shown as the GitHub mark, boxed to match Sign in --- */
 .header-github-link {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid #333;
+  border-radius: 8px;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .header-github-link::before {
   content: "";
   display: inline-block;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   background-color: currentColor;
   -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>')
     no-repeat center / contain;
@@ -989,13 +996,17 @@ article a:hover {
 }
 
 .header-github-link:hover {
-  opacity: 0.7;
+  border-color: #555;
+  background: rgba(255, 255, 255, 0.05);
 }
 
 /* --- Sign in: filled white button on the far right (like the landing) --- */
 .navbar__item--signin {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
   border-radius: 8px;
-  padding: 6px 16px;
+  padding: 0 16px;
   font-weight: 600;
   background: #ffffff !important;
   color: #000000 !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -975,8 +975,8 @@ article a:hover {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 38px;
+  height: 38px;
   border: 1px solid #333;
   border-radius: 8px;
   box-sizing: border-box;
@@ -1004,7 +1004,7 @@ article a:hover {
 .navbar__item--signin {
   display: inline-flex;
   align-items: center;
-  height: 36px;
+  height: 38px;
   border-radius: 8px;
   padding: 0 16px;
   font-weight: 600;


### PR DESCRIPTION
Boxes the navbar GitHub button and pins it to the same height as the Sign in button so the two line up. Matches the boxed GitHub button on envio.dev.

- GitHub button: bordered box, 38px, centred icon
- Sign in: pinned to the same 38px height
- Global navbar, so it applies across every docs page

Verified locally on desktop and mobile (both buttons render at exactly 38px, top/bottom aligned).

## Screenshots

**Before**, bare GitHub icon sitting shorter than the Sign in button.

![before buttons](https://github.com/enviodev/docs/raw/docs-audit-assets/pr1000/before-buttons.png)

**After**, bordered 38px box aligned with Sign in.

![after buttons](https://github.com/enviodev/docs/raw/docs-audit-assets/pr1000/after-buttons.png)

Full navbar for context.

**Before**

![before navbar](https://github.com/enviodev/docs/raw/docs-audit-assets/pr1000/before-navbar.png)

**After**

![after navbar](https://github.com/enviodev/docs/raw/docs-audit-assets/pr1000/after-navbar.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the GitHub navigation icon with a bordered, rounded 38×38 layout and updated hover effects.
  - Improved desktop “Sign in” button alignment and sizing while preserving its existing visual appearance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
