### PR TITLE
chore(seo): exclude legacy v2 docs and search page from sitemap (GTM-3901)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -296,6 +296,11 @@ const config = {
             "/docs/HyperSync-LLM/**",
             "/docs/HyperRPC-LLM/**",
             "/docs/EnvioCloud-LLM/**",
+            // Legacy v2 docs near-duplicate the live v3 pages; keep them out of
+            // the sitemap so they don't compete for the same rankings.
+            "/docs/v2/HyperIndex/**",
+            // Client-side search results page carries no indexable content.
+            "/search",
           ],
         },
       }),


### PR DESCRIPTION
Adds two entries to the sitemap `ignorePatterns`:

- `/docs/v2/HyperIndex/**` — legacy v2 pages near-duplicate the live v3 docs; keeping them out of the sitemap avoids competing for the same rankings.
- `/search` — the client-side search results page has no indexable content.

Config-only change to the existing sitemap plugin options. No URLs change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO**
  * Excluded legacy HyperIndex v2 documentation and the client-side search results page from sitemap indexing.
  * Prevents outdated or non-content pages from appearing in search engine results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Linear: GTM-3901