### PR TITLE
perf(docs): cache hashed build assets immutably (GTM-3901)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -326,6 +326,15 @@
   ],
   "headers": [
     {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/(.*).md",
       "headers": [
         {


### PR DESCRIPTION
Adds a `Cache-Control: public, max-age=31536000, immutable` header for `/assets/(.*)` in `vercel.json`.

Docusaurus content-hashes everything under `/assets/` (JS/CSS/imported images), so a new build emits new filenames — the immutable header lets browsers serve unchanged assets from cache across repeat visits and internal navigation instead of revalidating each one. Scoped to `/assets/` only; HTML and non-hashed `static/` files (e.g. `/img/`) are untouched.

---
Linear: GTM-3901