### PR TITLE
docs: add meta descriptions to hosted service feature and monitoring pages (GTM-3901)

### DIFF
--- a/docs/HyperIndex/Hosted_Service/hosted-service-features.md
+++ b/docs/HyperIndex/Hosted_Service/hosted-service-features.md
@@ -3,6 +3,7 @@ id: hosted-service-features
 title: Features
 sidebar_label: Features
 slug: /hosted-service-features
+description: Envio Cloud features to manage and secure your hosted blockchain indexer, including deployment tags, IP whitelisting, and API key authentication.
 ---
 
 # Envio Cloud Features

--- a/docs/HyperIndex/Hosted_Service/hosted-service-monitoring.md
+++ b/docs/HyperIndex/Hosted_Service/hosted-service-monitoring.md
@@ -3,6 +3,7 @@ id: hosted-service-monitoring
 title: Monitoring Your Indexer
 sidebar_label: Monitoring
 slug: /hosted-service-monitoring
+description: Monitor your hosted blockchain indexer on Envio Cloud with the real-time dashboard, deployment status, logs, error detection, and configurable alerts.
 ---
 
 # Monitoring Your Blockchain Indexer


### PR DESCRIPTION
Two hosted-service pages had no `description` front matter, so their search snippets fell back to a truncated first line. Adds concise, accurate descriptions (both under 160 chars) drawn from each page's own content.

---
Linear: GTM-3901