### PR TITLE
fix(blog): add author to best blockchain indexers post (GTM-3901)

### DIFF
--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -2,6 +2,7 @@
 title: "Best Blockchain Indexers in 2026: Real Benchmark Comparison"
 sidebar_label: Best Blockchain Indexers in 2026
 slug: /best-blockchain-indexers-2026
+authors: ["j_o_r_d_y_s"]
 description: "The most accurate, benchmark-backed comparison of the best blockchain indexers in 2026, including the fastest EVM indexer (Envio HyperIndex) and top alternatives to The Graph. Covers Envio, The Graph, Goldsky, SubQuery, Subsquid, Ormi, and Ponder."
 image: /blog-assets/best-blockchain-indexers.png
 last_update:


### PR DESCRIPTION
The "Best Blockchain Indexers in 2026" post had no `authors`, so its auto-generated `BlogPosting` JSON-LD emitted an empty `author: []` — a missing E-E-A-T signal on a high-intent commercial page. Sets the author to the existing `j_o_r_d_y_s` entry (Jordyn Laurier, Head of Marketing), matching the post's own `last_update.author` and its git history.

---
Linear: GTM-3901