### PR TITLE
HyperRPC docs: billing section with sub-month invoicing caveat [HOS-1619]

### DIFF
--- a/docs/HyperRPC/overview-hyperrpc.md
+++ b/docs/HyperRPC/overview-hyperrpc.md
@@ -36,6 +36,7 @@ HyperSync provides significantly faster performance and much greater flexibility
 - [Supported Methods](#supported-methods)
 - [Supported Networks](#supported-networks)
 - [Getting Started](#getting-started)
+- [Billing](#billing)
 - [Development Status](#development-status)
 
 ## What is HyperRPC?
@@ -119,6 +120,14 @@ To start using HyperRPC:
 
 4. **Provide Feedback**:
    Your testing and feedback are incredibly valuable as we continue to improve HyperRPC. Let us know about your experience in our [Discord](https://discord.gg/envio).
+
+## Billing
+
+HyperRPC usage is billed monthly in arrears at **$4 per million JSON-RPC method calls**, with a $1 monthly minimum. Each method in a JSON-RPC batch request counts as one call.
+
+:::note Sub-month invoicing
+Invoices normally cover a full calendar month, but usage may occasionally be invoiced for a sub-period of the month — for example, a mid-month invoice when usage is substantial, with the remainder of the month invoiced at month end. Split invoices never overlap, so no usage is ever billed twice, and the $1 monthly minimum applies at most once per calendar month.
+:::
 
 ## Development Status
 


### PR DESCRIPTION
Docs side of [HOS-1614](https://linear.app/envio/issue/HOS-1614/hyperrpc-billing-handle-partial-bills-already-paid-for-a-period) / [HOS-1619](https://linear.app/envio/issue/HOS-1619): adds a Billing section to the HyperRPC overview (there was none) stating the $4/1M-method-calls postpaid pricing and the $1 monthly minimum, with a caveat that usage may occasionally be invoiced in sub-month periods — e.g. a mid-month invoice for substantial usage with the remainder billed at month end. Split invoices never overlap and the monthly minimum applies at most once per calendar month.

Backend: enviodev/envio-operator#449. The `HyperRPC-LLM/hyperrpc-complete.mdx` mirror is generated by `scripts/consolidate-hyperindex-docs.js`, so only the source page is edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added billing information to the HyperRPC overview.
  * Documented monthly arrears billing, pricing, minimum charges, batch-call counting, and sub-month invoice handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->