### PR TITLE
feat(seo): add Dataset structured data to benchmarks page (GTM-3901)

### DIFF
--- a/docs/HyperIndex/benchmarks.md
+++ b/docs/HyperIndex/benchmarks.md
@@ -6,6 +6,47 @@ slug: /benchmarks
 description: Discover HyperIndex benchmarks and see why it's the fastest blockchain data indexer.
 ---
 
+import Head from '@docusaurus/Head';
+
+{/* Dataset structured data: describes this benchmark page for search + answer
+    engines and points them at the open benchmark data. Metadata only — it does
+    not restate the figures in the table below. */}
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      "name": "HyperIndex Blockchain Indexer Benchmarks",
+      "description":
+        "Independent, reproducible performance benchmarks comparing Envio HyperIndex against other blockchain indexers, including The Graph, Ponder, and Subsquid, across real-world indexing scenarios. Based on benchmarks conducted by Sentio.",
+      "url": "https://docs.envio.dev/docs/HyperIndex/benchmarks",
+      "keywords": [
+        "blockchain indexer",
+        "indexing benchmark",
+        "Envio HyperIndex",
+        "The Graph",
+        "Ponder",
+        "Subsquid",
+        "EVM",
+      ],
+      "publisher": { "@id": "https://envio.dev/#organization" },
+      "isAccessibleForFree": true,
+      "distribution": [
+        {
+          "@type": "DataDownload",
+          "encodingFormat": "text/html",
+          "contentUrl": "https://github.com/enviodev/sentio-benchmark",
+        },
+        {
+          "@type": "DataDownload",
+          "encodingFormat": "text/html",
+          "contentUrl": "https://github.com/enviodev/open-indexer-benchmark",
+        },
+      ],
+    })}
+  </script>
+</Head>
+
 # HyperIndex Performance Benchmarks
 
 ## Overview

--- a/docs/HyperIndex/benchmarks.md
+++ b/docs/HyperIndex/benchmarks.md
@@ -31,17 +31,9 @@ import Head from '@docusaurus/Head';
       ],
       "publisher": { "@id": "https://envio.dev/#organization" },
       "isAccessibleForFree": true,
-      "distribution": [
-        {
-          "@type": "DataDownload",
-          "encodingFormat": "text/html",
-          "contentUrl": "https://github.com/enviodev/sentio-benchmark",
-        },
-        {
-          "@type": "DataDownload",
-          "encodingFormat": "text/html",
-          "contentUrl": "https://github.com/enviodev/open-indexer-benchmark",
-        },
+      "sameAs": [
+        "https://github.com/enviodev/sentio-benchmark",
+        "https://github.com/enviodev/open-indexer-benchmark",
       ],
     })}
   </script>


### PR DESCRIPTION
Adds a hidden `Dataset` JSON-LD block to the benchmarks page via `@docusaurus/Head` — metadata only, injected into `<head>`.

- **No visible content changes**: the benchmark table and every figure are byte-for-byte identical (diff is +41 insertions, 0 deletions).
- The schema describes the page as a benchmark dataset and points at the open, already-linked benchmark repos (`sentio-benchmark`, `open-indexer-benchmark`), so answer engines cite Envio's own data as the source. It does not restate any per-row numbers.
- `publisher` references the shared Organization entity added site-wide.

Linear: GTM-3901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the HyperIndex benchmark page with structured metadata to improve search engine understanding and discoverability.
  * Added benchmark dataset details and links to the associated benchmark repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->