### PR TITLE
fix(docs): repair broken links found in audit

### DIFF
--- a/docs/EnvioCloud-LLM/envio-cloud-complete.mdx
+++ b/docs/EnvioCloud-LLM/envio-cloud-complete.mdx
@@ -616,7 +616,7 @@ The webhook channel sends a structured JSON payload via HTTP POST to any URL you
 **Custom Headers (optional):** When creating a webhook channel, you can add custom HTTP headers that will be sent with every request. This is useful for services that require authentication via API keys or bearer tokens — for example, incident.io requires an `Authorization: Bearer ` header.
 
 :::warning
-The webhook channel is a generic HTTP endpoint. It is not guaranteed to work with all third-party services — please see the [integration guides below](#webhook-integrations) for supported setup instructions. If you need help integrating with a specific service, please reach out on the [Envio Discord](https://discord.envio.dev).
+The webhook channel is a generic HTTP endpoint. It is not guaranteed to work with all third-party services — please see the [integration guides below](#webhook-integrations) for supported setup instructions. If you need help integrating with a specific service, please reach out on the [Envio Discord](https://discord.gg/envio).
 :::
 
 **Webhook Payload Schema:**

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -3724,7 +3724,6 @@ To use these indexers as a reference for your own development:
 For complete API documentation and usage examples, see:
 
 - [Sablier API Overview](https://docs.sablier.com/api/overview#envio)
-- [Implementation Caveats](https://docs.sablier.com/api/caveats)
 
 :::note
 These are official indexers maintained by the Sablier team and represent production-quality implementations. They serve as an excellent example of professional blockchain indexer development and are regularly updated to support the latest protocol features.

--- a/docs/HyperIndex/Examples/example-sablier.md
+++ b/docs/HyperIndex/Examples/example-sablier.md
@@ -62,7 +62,6 @@ To use these indexers as a reference for your own development:
 For complete API documentation and usage examples, see:
 
 - [Sablier API Overview](https://docs.sablier.com/api/overview#envio)
-- [Implementation Caveats](https://docs.sablier.com/api/caveats)
 
 :::note
 These are official indexers maintained by the Sablier team and represent production-quality implementations. They serve as an excellent example of professional blockchain indexer development and are regularly updated to support the latest protocol features.

--- a/docs/HyperIndex/Hosted_Service/hosted-service-monitoring.md
+++ b/docs/HyperIndex/Hosted_Service/hosted-service-monitoring.md
@@ -84,7 +84,7 @@ The webhook channel sends a structured JSON payload via HTTP POST to any URL you
 **Custom Headers (optional):** When creating a webhook channel, you can add custom HTTP headers that will be sent with every request. This is useful for services that require authentication via API keys or bearer tokens — for example, incident.io requires an `Authorization: Bearer <token>` header.
 
 :::warning
-The webhook channel is a generic HTTP endpoint. It is not guaranteed to work with all third-party services — please see the [integration guides below](#webhook-integrations) for supported setup instructions. If you need help integrating with a specific service, please reach out on the [Envio Discord](https://discord.envio.dev).
+The webhook channel is a generic HTTP endpoint. It is not guaranteed to work with all third-party services — please see the [integration guides below](#webhook-integrations) for supported setup instructions. If you need help integrating with a specific service, please reach out on the [Envio Discord](https://discord.gg/envio).
 :::
 
 **Webhook Payload Schema:**

--- a/docs/HyperIndexV2/Examples/example-sablier.md
+++ b/docs/HyperIndexV2/Examples/example-sablier.md
@@ -12,27 +12,23 @@ The following blockchain indexers serve as exceptional reference implementations
 
 ## Overview
 
-[Sablier](https://sablier.com/) is a token streaming protocol that enables real-time finance on the blockchain, allowing tokens to be streamed continuously over time. These official Sablier indexers track streaming activity across 18 different EVM-compatible chains, providing comprehensive data through a unified GraphQL API.
+[Sablier](https://sablier.com/) is a token streaming protocol that enables real-time finance on the blockchain, allowing tokens to be streamed continuously over time. These official Sablier indexers track streaming activity across many EVM-compatible chains, providing comprehensive data through a unified GraphQL API.
 
 ## Professional Indexer Suite
 
-Sablier maintains three specialized indexers, each targeting a specific part of their protocol:
+Sablier maintains two public indexers, each targeting a specific part of their protocol:
 
-### 1. [Lockup Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/lockup)
+### 1. [Streams Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/streams)
 
-Tracks the core Sablier lockup contracts, which handle the streaming of tokens with fixed durations and amounts. This indexer provides data about stream creation, cancellation, and withdrawal events. Used primarily for the vesting functionality of Sablier.
+Tracks Sablier's payment-stream data across both the Lockup and Flow products. Lockup covers streams with fixed durations and amounts (creation, cancellation, and withdrawal events), while Flow covers open-ended streaming with dynamic flow rates. For more detail, see the [Lockup indexer docs](https://docs.sablier.com/api/lockup/indexers) and the [Flow indexer docs](https://docs.sablier.com/api/flow/indexers).
 
-### 2. [Flow Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/flow)
+### 2. [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
 
-Monitors Sablier's advanced streaming functionality, allowing for dynamic flow rates and more complex streaming scenarios. This indexer captures stream modifications, batch operations, and other flow-specific events. Powers the payments side of the Sablier application.
-
-### 3. [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
-
-Tracks Sablier's Merkle Airdrops, which enables efficient batch stream creation using cryptographic proofs. This indexer captures data about batch creations, claims, and related activities. Used for both Airstreams and Instant Airdrops functionality.
+Tracks Sablier's Merkle airdrop campaigns, which enable efficient batch stream creation using cryptographic proofs. This indexer captures data about campaign creation, claims, and related activity, powering both Airstreams and Instant Airdrops. For more detail, see the [Airdrops indexer docs](https://docs.sablier.com/api/airdrops/indexers).
 
 ## Key Features
 
-- **Comprehensive Multichain Support**: Indexes data across 18 different EVM chains
+- **Comprehensive Multichain Support**: Indexes data across many EVM-compatible chains
 - **Professionally Maintained**: Used in production by the Sablier team and their partners
 - **Extensive Test Coverage**: Includes comprehensive testing to ensure data accuracy
 - **Optimized Performance**: Implements efficient data processing techniques
@@ -56,10 +52,9 @@ These blockchain indexers demonstrate several development best practices:
 
 To use these indexers as a reference for your own development:
 
-1. Clone the specific repository based on your needs:
-   - [Lockup Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/lockup-envio)
-   - [Flow Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/flow-envio)
-   - [Merkle Indexer](https://github.com/sablier-labs/subgraphs/tree/main/apps/merkle-envio)
+1. Clone the indexer that matches your needs:
+   - [Streams Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/streams)
+   - [Airdrops Indexer](https://github.com/sablier-labs/indexers/tree/main/envio/airdrops)
 2. Review the file structure and implementation patterns
 3. Examine the event handlers for efficient data processing techniques
 4. Study the schema design for effective entity modeling
@@ -67,7 +62,6 @@ To use these indexers as a reference for your own development:
 For complete API documentation and usage examples, see:
 
 - [Sablier API Overview](https://docs.sablier.com/api/overview#envio)
-- [Implementation Caveats](https://docs.sablier.com/api/caveats)
 
 :::note
 These are official indexers maintained by the Sablier team and represent production-quality implementations. They serve as an excellent example of professional blockchain indexer development and are regularly updated to support the latest protocol features.

--- a/docs/HyperSync-LLM/hypersync-complete.mdx
+++ b/docs/HyperSync-LLM/hypersync-complete.mdx
@@ -892,7 +892,7 @@ All HyperSync clients require an API token for authentication. Tokens are used t
 
 To get an API token:
 
-1. Visit [Envio](https://.envio.dev)
+1. Visit [Envio](https://envio.dev)
 2. Register or sign in with your github account
 3. Navigate to the API Tokens section
 4. Create a new token

--- a/docs/HyperSync-LLM/hypersync-complete.mdx
+++ b/docs/HyperSync-LLM/hypersync-complete.mdx
@@ -2374,7 +2374,7 @@ Testnet: https://fuel-testnet.hypersync.xyz
 
 Below is an example of a Hyperfuel query in each of our clients searching the first 1,300,000 blocks for all `input` objects of a specific `asset-id`. This example returns 10,543 inputs in around 100ms - not including latency.
 
-## Rust ([repo](https://github.com/enviodev/hyperfuel-client-rust/tree/main/examples/asset-id))
+## Rust ([repo](https://github.com/enviodev/hyperfuel-client-rust/tree/main/examples))
 
 ```rust
 use hyperfuel_client::{Client, ClientConfig};

--- a/docs/HyperSync/HyperFuel/hyperfuel.md
+++ b/docs/HyperSync/HyperFuel/hyperfuel.md
@@ -37,7 +37,7 @@ HyperFuel requires an API token. Generate one from the [Envio Dashboard](https:/
 
 Below is an example of a Hyperfuel query in each of our clients searching the first 1,300,000 blocks for all `input` objects of a specific `asset-id`. This example returns 10,543 inputs in around 100ms - not including latency.
 
-## Rust ([repo](https://github.com/enviodev/hyperfuel-client-rust/tree/main/examples/asset-id))
+## Rust ([repo](https://github.com/enviodev/hyperfuel-client-rust/tree/main/examples))
 
 ```rust
 use hyperfuel_client::{Client, ClientConfig};

--- a/docs/HyperSync/hypersync-clients.md
+++ b/docs/HyperSync/hypersync-clients.md
@@ -134,7 +134,7 @@ All HyperSync clients require an API token for authentication. Tokens are used t
 
 To get an API token:
 
-1. Visit [Envio](https://.envio.dev)
+1. Visit [Envio](https://envio.dev)
 2. Register or sign in with your github account
 3. Navigate to the API Tokens section
 4. Create a new token


### PR DESCRIPTION
Fixes broken hyperlinks spotted during a docs link audit. Every replacement URL was verified live.

- HyperSync clients page: malformed `https://.envio.dev` now `https://envio.dev`
- Cloud monitoring page: dead Discord URL now the canonical `https://discord.gg/envio`
- HyperFuel page: Rust example link pointed at a removed subfolder, now the live `/examples` folder
- Sablier example page: removed the `Implementation Caveats` link (Sablier deleted that page, no replacement; the API Overview link above still covers it)
- Legacy v2 Sablier page: Sablier renamed their `subgraphs` repo to `indexers` and merged the Lockup and Flow indexers into a single Streams indexer, so every repo link on that page was dead. Updated the links and the surrounding copy to match the current two indexer structure, and dropped a stale hardcoded chain count. The v2 specific Handler/Loader section is left as is.

Matching lines in the generated LLM bundles updated to stay in sync.