### PR TITLE
fix(seo): 301 remaining GSC 404s to live destinations

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -322,6 +322,111 @@
       "source": "/docs/HyperIndex/status.md",
       "destination": "/docs/HyperIndex/hosted-service.md",
       "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-may-2024",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-update-may-2024.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-celebrates-first-grantee-multi-chain-liquidation-metrics-indexer",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-celebrates-first-grantee-multi-chain-liquidation-metrics-indexer.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-azuro-developer-grant-multi-chain-indexer",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-azuro-developer-grant-multi-chain-indexer.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-4",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-developer-community-update-no-4.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-community-update-no-8",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-community-update-no-8.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-bounty-erc4626-tokenized-vault-indexer",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-bounty-erc4626-tokenized-vault-indexer.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-empowers-jarvis-network",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-empowers-jarvis-network.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-data-indexing-supports-developers-building-on-harmony",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-data-indexing-supports-developers-building-on-harmony.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-grant-program-now-live",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/envio-grant-program-now-live.md",
+      "destination": "/blog",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/example-liquidation-metrics",
+      "destination": "/docs/HyperIndex/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/HyperIndex/example-uniswap-v3-multi-chain-indexer",
+      "destination": "/docs/HyperIndex/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/migration-guide",
+      "destination": "/docs/HyperIndex/migration-guide",
+      "permanent": true
     }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -427,6 +427,11 @@
       "source": "/docs/migration-guide",
       "destination": "/docs/HyperIndex/migration-guide",
       "permanent": true
+    },
+    {
+      "source": "/blog/page/8",
+      "destination": "/blog",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
Search Console reports 38 URLs under Not found (404). 25 already resolve via existing rules in vercel.json or the client-redirects plugin. This covers the remaining 12 that still hard-404.

- 9 retired blog posts (2024 dev/community updates, grant and customer posts) -> /blog, with .md twins to match the existing convention
- 2 retired HyperIndex example pages -> /docs/HyperIndex/overview, consistent with the existing example-ens redirect
- /docs/migration-guide -> /docs/HyperIndex/migration-guide

/blog/page/8 is intentionally left 404 (stale pagination).

Note: the existing /blog/blog/ catch-all and the v2 docs redirects are already working correctly. Those URLs still appear in Search Console because Google last crawled them before those fixes shipped on 4 June. After this deploys, run VALIDATE FIX on the Not found (404) report so Google recrawls on demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added permanent redirects for additional legacy `/blog/...` URLs to the current blog entry point.
  * Improved navigation by redirecting older HyperIndex documentation/example URLs to the consolidated documentation overview.
  * Added a permanent redirect for the migration guide’s previous URL to the updated HyperIndex migration guide page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->