### PR TITLE
fix(docs): correct outdated counts and a stale limitation note

### DIFF
--- a/docs/HyperIndex/Advanced/wildcard-indexing.mdx
+++ b/docs/HyperIndex/Advanced/wildcard-indexing.mdx
@@ -300,5 +300,3 @@ indexer.contractRegister(
 - For any given chain, only one event of a given signature can be indexed using wildcard indexing. This means that if you have multiple contract definitions in your config that contain the same event signature, only one of them is allowed to be set to `wildcard: true`.
 
 - Either the `contractRegister` or the `onEvent` registration for a given event can take a `where` option, but not both.
-
-- The RPC data source currently supports Topic Filtering only applied to a single wildcard event.

--- a/docs/HyperIndex/Examples/example-uniswap-v4.md
+++ b/docs/HyperIndex/Examples/example-uniswap-v4.md
@@ -14,7 +14,7 @@ This [official Uniswap V4 indexer](https://github.com/enviodev/uniswap-v4-indexe
 
 ## Key Features
 
-- **Multichain Support**: Indexes Uniswap V4 deployments across 15 different blockchain networks in real-time
+- **Multichain Support**: Indexes Uniswap V4 deployments across every supported blockchain network in real-time
 - **Complete Pool Metrics**: Tracks pool statistics including volume, TVL, fees, and other critical metrics
 - **Swap Analysis**: Monitors swap events and liquidity changes with high precision
 - **Hook Integration**: In-progress support for Uniswap V4 hooks and their events

--- a/src/pages/showcase/_data.js
+++ b/src/pages/showcase/_data.js
@@ -1,7 +1,3 @@
-import networkCount from "../../data/network-count.json";
-
-const hyperSyncChainCount = networkCount.hyperSyncChainCount;
-
 const tags = {
   hyperindex: "HyperIndex",
   hypersync: "HyperSync",
@@ -142,8 +138,10 @@ const sites = [
   {
     slug: "chain-density",
     title: "Chain Density",
-    description: `Analyze and visualize transaction and event density for any address across ${hyperSyncChainCount}+ chains.`,
-    longDescription: `Chain Density is a cross-chain analytics tool that visualizes transaction and event density for any wallet address across more than ${hyperSyncChainCount} blockchain networks. Built with Envio's HyperSync, it leverages high-speed data retrieval to quickly scan activity across dozens of chains, generating density maps and activity heatmaps for any given address. The platform is useful for on-chain investigators, portfolio trackers, and anyone looking to understand multi-chain wallet activity patterns without manually checking each network individually.`,
+    description:
+      "Analyze and visualize transaction and event density for any address across dozens of chains.",
+    longDescription:
+      "Chain Density is a cross-chain analytics tool that visualizes transaction and event density for any wallet address across dozens of blockchain networks. Built with Envio's HyperSync, it leverages high-speed data retrieval to quickly scan activity across dozens of chains, generating density maps and activity heatmaps for any given address. The platform is useful for on-chain investigators, portfolio trackers, and anyone looking to understand multi-chain wallet activity patterns without manually checking each network individually.",
     image: "/img/showcase/chaindensity.xyz_.png",
     source: "https://chaindensity.xyz/",
     tags: [tags.hypersync],


### PR DESCRIPTION
Small docs accuracy pass, verified against the live products and the v3.3.0 release notes.

- **Uniswap V4 example** said "15 different blockchain networks"; live v4.xyz now covers more. Dropped the hard number so it stops going stale.
- **Chain Density showcase entry** rendered a chain count higher than the live app advertises. Reworded to avoid a specific number.
- **Wildcard Indexing** listed a "single wildcard event" RPC limitation that v3.3.0 removed. Removed it.

The broader showcase copy cleanup already shipped in #1014.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wildcard indexing limitations to reflect current topic-filtering support.
  * Clarified that the Uniswap V4 example supports deployments across every supported blockchain network in real time.
  * Updated showcase messaging to describe coverage across dozens of chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->