### PR TITLE
Add self-hosted Algolia docs crawl (blog + showcase)

### DIFF
--- a/.github/workflows/algolia-crawl.yml
+++ b/.github/workflows/algolia-crawl.yml
@@ -1,0 +1,45 @@
+name: Algolia docs crawl
+
+on:
+  schedule:
+    # 03:00 UTC nightly
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: algolia-crawl
+  cancel-in-progress: false
+
+jobs:
+  crawl:
+    name: Crawl docs.envio.dev into Algolia
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Verify Algolia secrets are present
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_WRITE_API_KEY: ${{ secrets.ALGOLIA_WRITE_API_KEY }}
+        run: |
+          if [ -z "$ALGOLIA_APP_ID" ] || [ -z "$ALGOLIA_WRITE_API_KEY" ]; then
+            echo "::error::ALGOLIA_APP_ID and ALGOLIA_WRITE_API_KEY must be set as repository secrets."
+            exit 1
+          fi
+
+      - name: Validate docsearch.config.json
+        run: jq empty docsearch.config.json
+
+      - name: Run DocSearch scraper
+        env:
+          APPLICATION_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          API_KEY: ${{ secrets.ALGOLIA_WRITE_API_KEY }}
+        run: |
+          docker run \
+            --rm \
+            --env APPLICATION_ID \
+            --env API_KEY \
+            --env "CONFIG=$(jq -r tostring docsearch.config.json)" \
+            algolia/docsearch-scraper

--- a/docsearch.config.json
+++ b/docsearch.config.json
@@ -1,0 +1,138 @@
+{
+  "index_name": "envio",
+  "sitemap_urls": ["https://docs.envio.dev/sitemap.xml"],
+  "sitemap_alternate_links": false,
+  "start_urls": [
+    {
+      "url": "https://docs.envio.dev/docs/HyperIndex/",
+      "selectors_key": "hyperindex"
+    },
+    {
+      "url": "https://docs.envio.dev/docs/HyperSync/",
+      "selectors_key": "hypersync"
+    },
+    {
+      "url": "https://docs.envio.dev/docs/HyperRPC/",
+      "selectors_key": "hyperrpc"
+    },
+    {
+      "url": "https://docs.envio.dev/blog/",
+      "selectors_key": "blog"
+    },
+    {
+      "url": "https://docs.envio.dev/showcase/",
+      "selectors_key": "showcase"
+    }
+  ],
+  "stop_urls": [
+    "https://docs.envio.dev/docs/v2/",
+    "https://docs.envio.dev/docs/HyperIndex-LLM/",
+    "https://docs.envio.dev/docs/HyperSync-LLM/",
+    "https://docs.envio.dev/docs/HyperRPC-LLM/",
+    "\\.md$",
+    "/llms\\.txt$",
+    "/llms-full\\.txt$",
+    "/llms-full-blog\\.txt$",
+    "https://docs.envio.dev/blog/tag/",
+    "https://docs.envio.dev/blog/author/",
+    "https://docs.envio.dev/blog/archive",
+    "https://docs.envio.dev/blog/rss\\.xml",
+    "https://docs.envio.dev/blog/atom\\.xml",
+    "https://docs.envio.dev/search"
+  ],
+  "selectors": {
+    "default": {
+      "lvl0": {
+        "selector": "",
+        "defaultValue": "Documentation"
+      },
+      "lvl1": "header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    },
+    "hyperindex": {
+      "lvl0": {
+        "selector": "",
+        "defaultValue": "HyperIndex"
+      },
+      "lvl1": "header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    },
+    "hypersync": {
+      "lvl0": {
+        "selector": "",
+        "defaultValue": "HyperSync"
+      },
+      "lvl1": "header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    },
+    "hyperrpc": {
+      "lvl0": {
+        "selector": "",
+        "defaultValue": "HyperRPC"
+      },
+      "lvl1": "header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    },
+    "blog": {
+      "lvl0": {
+        "selector": "",
+        "defaultValue": "Blog"
+      },
+      "lvl1": "article header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    },
+    "showcase": {
+      "lvl0": {
+        "selector": "",
+        "defaultValue": "Showcase"
+      },
+      "lvl1": "main h1",
+      "lvl2": "main h2",
+      "lvl3": "main h3",
+      "lvl4": "main h4",
+      "text": "main p, main li"
+    }
+  },
+  "selectors_exclude": [
+    ".hash-link",
+    ".theme-doc-toc-mobile",
+    ".pagination-nav",
+    ".breadcrumbs"
+  ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "type",
+      "lang",
+      "language",
+      "version",
+      "docusaurus_tag"
+    ]
+  },
+  "js_render": false,
+  "nb_hits": 0
+}


### PR DESCRIPTION
Replaces the managed DocSearch crawl with a self-hosted one.

- Runs nightly and on demand from the Actions tab
- Adds blog and showcase as their own search sections
- Excludes v2 and the LLM doc variants (see `stop_urls`)

Credentials are read from repository secrets, nothing is committed.

The workflow only runs on a schedule or manual dispatch, so merging this does not write to Algolia on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated documentation indexing for HyperIndex, HyperSync, HyperRPC, blog, and showcase content.
  * Added scheduled and manually triggered search-index updates.
  * Configured indexing to exclude outdated, duplicate, and non-content pages for more relevant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->