### PR TITLE
docs: cover API key authentication in the Envio Cloud CLI

### DIFF
--- a/docs/EnvioCloud-LLM/envio-cloud-complete.mdx
+++ b/docs/EnvioCloud-LLM/envio-cloud-complete.mdx
@@ -134,9 +134,9 @@ Restrict requests to specific IP addresses. Only clients connecting from an appr
 Protect your endpoint with an API key—a secret token that clients include with each request to prove they're authorized. This is the recommended option for browser-based dApps and frontends, where users connect from unpredictable IP addresses that can't be allow-listed.
 
 **How it works:**
-- Each indexer (project) gets a **unique API key**, automatically generated and securely stored
-- Retrieve your API key from the deployment dashboard
-- Include it with every request using the `Authorization` header as a Bearer token:
+- Enabling authentication provisions an initial key automatically, stored securely
+- Retrieve your keys from the Security page in the dashboard, or with the Envio Cloud CLI
+- Include a key with every request using the `Authorization` header as a Bearer token:
 
 ```bash
 curl https://<your-endpoint>/v1/graphql \
@@ -145,9 +145,16 @@ curl https://<your-endpoint>/v1/graphql \
 
 Requests without a valid key are rejected with a `401 Unauthorized` response.
 
+**Rotating keys:**
+
+An indexer can hold **several named keys at once**, so you can rotate without downtime: add a new key, migrate your clients onto it, then remove the old one. Removing a key revokes it immediately, so migrate before you remove.
+
+The last remaining key cannot be removed — turn API key authentication off instead if you want to stop requiring a token.
+
 **Benefits:**
 - Works for browser-based apps and frontends with no fixed IP address
-- The same key persists across deployment promotions
+- Keys persist across deployment promotions
+- Rotate credentials without an outage
 - Both your production endpoint and per-deployment URLs are gated by the same policy—no way to bypass authentication
 
 
@@ -973,12 +980,73 @@ envio-cloud indexer env import myindexer myorg --file .env
 
 The `.env` file format is one `KEY=VALUE` per line. Lines starting with `#` are ignored.
 
+#### View the Security Configuration
+
+Both access controls for an indexer — API key authentication and the IP whitelist — are shown by a single command:
+
+```bash
+envio-cloud indexer security get myindexer myorg
+envio-cloud indexer security get myindexer myorg -o json
+```
+
+API keys are never printed here. Use `api-key list --show-tokens` to reveal them.
+
+#### Configure API Key Authentication
+
+Require clients to send an `Authorization: Bearer <token>` header on every request to your indexer's GraphQL endpoints.
+
+```bash
+# Turn it on — an initial key is provisioned automatically
+envio-cloud indexer security api-key enable myindexer myorg
+
+# Check whether it is on, and which keys exist (never prints tokens)
+envio-cloud indexer security api-key status myindexer myorg
+
+# List keys, then reveal the tokens
+envio-cloud indexer security api-key list myindexer myorg
+envio-cloud indexer security api-key list myindexer myorg --show-tokens
+
+# Turn it off — the endpoints stop requiring a token
+envio-cloud indexer security api-key disable myindexer myorg
+```
+
+Tokens are only requested from the API when `--show-tokens` is passed, so a plain listing never puts a secret on the wire.
+
+Query an endpoint with a key. Read the URL from `deployment endpoint` rather than hardcoding a host — it differs per deployment:
+
+```bash
+curl -X POST "$(envio-cloud deployment endpoint myindexer abc1234 myorg)" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ENVIO_API_KEY" \
+  -d '{"query":"{ __typename }"}'
+```
+
+##### Rotating Keys
+
+An indexer can hold several named keys at once, which is how you rotate without downtime: add a new key, migrate your clients onto it, then revoke the old one.
+
+```bash
+envio-cloud indexer security api-key add myindexer myorg production-2026-08
+# ...migrate clients to the new key...
+envio-cloud indexer security api-key remove myindexer myorg production-2026-07
+```
+
+Key names may contain letters, digits, `-`, `.` and `_`, must start with a letter or digit, and must be 63 characters or fewer.
+
+:::info
+Removing a key revokes it **immediately** — any client still using it loses access. A newly added key shows as `provisioning` for a few seconds before its token is available. The last remaining key cannot be removed; disable API key authentication instead.
+:::
+
+:::note
+API key authentication requires a Production tier plan or above.
+:::
+
 #### Configure IP Whitelisting
 
 Restrict access to your indexer's GraphQL endpoint by IP address. Supports IPv4 addresses and CIDR notation.
 
 ```bash
-# View current IP whitelist configuration
+# View the current configuration
 envio-cloud indexer security get myindexer myorg
 
 # Add IPs to the whitelist

--- a/docs/HyperIndex/Hosted_Service/envio-cloud-cli.md
+++ b/docs/HyperIndex/Hosted_Service/envio-cloud-cli.md
@@ -238,12 +238,73 @@ envio-cloud indexer env import myindexer myorg --file .env
 
 The `.env` file format is one `KEY=VALUE` per line. Lines starting with `#` are ignored.
 
+#### View the Security Configuration
+
+Both access controls for an indexer — API key authentication and the IP whitelist — are shown by a single command:
+
+```bash
+envio-cloud indexer security get myindexer myorg
+envio-cloud indexer security get myindexer myorg -o json
+```
+
+API keys are never printed here. Use `api-key list --show-tokens` to reveal them.
+
+#### Configure API Key Authentication
+
+Require clients to send an `Authorization: Bearer <token>` header on every request to your indexer's GraphQL endpoints.
+
+```bash
+# Turn it on — an initial key is provisioned automatically
+envio-cloud indexer security api-key enable myindexer myorg
+
+# Check whether it is on, and which keys exist (never prints tokens)
+envio-cloud indexer security api-key status myindexer myorg
+
+# List keys, then reveal the tokens
+envio-cloud indexer security api-key list myindexer myorg
+envio-cloud indexer security api-key list myindexer myorg --show-tokens
+
+# Turn it off — the endpoints stop requiring a token
+envio-cloud indexer security api-key disable myindexer myorg
+```
+
+Tokens are only requested from the API when `--show-tokens` is passed, so a plain listing never puts a secret on the wire.
+
+Query an endpoint with a key. Read the URL from `deployment endpoint` rather than hardcoding a host — it differs per deployment:
+
+```bash
+curl -X POST "$(envio-cloud deployment endpoint myindexer abc1234 myorg)" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ENVIO_API_KEY" \
+  -d '{"query":"{ __typename }"}'
+```
+
+##### Rotating Keys
+
+An indexer can hold several named keys at once, which is how you rotate without downtime: add a new key, migrate your clients onto it, then revoke the old one.
+
+```bash
+envio-cloud indexer security api-key add myindexer myorg production-2026-08
+# ...migrate clients to the new key...
+envio-cloud indexer security api-key remove myindexer myorg production-2026-07
+```
+
+Key names may contain letters, digits, `-`, `.` and `_`, must start with a letter or digit, and must be 63 characters or fewer.
+
+:::info
+Removing a key revokes it **immediately** — any client still using it loses access. A newly added key shows as `provisioning` for a few seconds before its token is available. The last remaining key cannot be removed; disable API key authentication instead.
+:::
+
+:::note
+API key authentication requires a Production tier plan or above.
+:::
+
 #### Configure IP Whitelisting
 
 Restrict access to your indexer's GraphQL endpoint by IP address. Supports IPv4 addresses and CIDR notation.
 
 ```bash
-# View current IP whitelist configuration
+# View the current configuration
 envio-cloud indexer security get myindexer myorg
 
 # Add IPs to the whitelist

--- a/docs/HyperIndex/Hosted_Service/hosted-service-features.md
+++ b/docs/HyperIndex/Hosted_Service/hosted-service-features.md
@@ -64,9 +64,9 @@ Restrict requests to specific IP addresses. Only clients connecting from an appr
 Protect your endpoint with an API key—a secret token that clients include with each request to prove they're authorized. This is the recommended option for browser-based dApps and frontends, where users connect from unpredictable IP addresses that can't be allow-listed.
 
 **How it works:**
-- Each indexer (project) gets a **unique API key**, automatically generated and securely stored
-- Retrieve your API key from the deployment dashboard
-- Include it with every request using the `Authorization` header as a Bearer token:
+- Enabling authentication provisions an initial key automatically, stored securely
+- Retrieve your keys from the Security page in the dashboard, or with the [Envio Cloud CLI](./envio-cloud-cli.md)
+- Include a key with every request using the `Authorization` header as a Bearer token:
 
 ```bash
 curl https://<your-endpoint>/v1/graphql \
@@ -75,9 +75,16 @@ curl https://<your-endpoint>/v1/graphql \
 
 Requests without a valid key are rejected with a `401 Unauthorized` response.
 
+**Rotating keys:**
+
+An indexer can hold **several named keys at once**, so you can rotate without downtime: add a new key, migrate your clients onto it, then remove the old one. Removing a key revokes it immediately, so migrate before you remove.
+
+The last remaining key cannot be removed — turn API key authentication off instead if you want to stop requiring a token.
+
 **Benefits:**
 - Works for browser-based apps and frontends with no fixed IP address
-- The same key persists across deployment promotions
+- Keys persist across deployment promotions
+- Rotate credentials without an outage
 - Both your production endpoint and per-deployment URLs are gated by the same policy—no way to bypass authentication
 
 

--- a/docs/HyperIndexV2/Hosted_Service/envio-cloud-cli.md
+++ b/docs/HyperIndexV2/Hosted_Service/envio-cloud-cli.md
@@ -238,12 +238,73 @@ envio-cloud indexer env import myindexer myorg --file .env
 
 The `.env` file format is one `KEY=VALUE` per line. Lines starting with `#` are ignored.
 
+#### View the Security Configuration
+
+Both access controls for an indexer — API key authentication and the IP whitelist — are shown by a single command:
+
+```bash
+envio-cloud indexer security get myindexer myorg
+envio-cloud indexer security get myindexer myorg -o json
+```
+
+API keys are never printed here. Use `api-key list --show-tokens` to reveal them.
+
+#### Configure API Key Authentication
+
+Require clients to send an `Authorization: Bearer <token>` header on every request to your indexer's GraphQL endpoints.
+
+```bash
+# Turn it on — an initial key is provisioned automatically
+envio-cloud indexer security api-key enable myindexer myorg
+
+# Check whether it is on, and which keys exist (never prints tokens)
+envio-cloud indexer security api-key status myindexer myorg
+
+# List keys, then reveal the tokens
+envio-cloud indexer security api-key list myindexer myorg
+envio-cloud indexer security api-key list myindexer myorg --show-tokens
+
+# Turn it off — the endpoints stop requiring a token
+envio-cloud indexer security api-key disable myindexer myorg
+```
+
+Tokens are only requested from the API when `--show-tokens` is passed, so a plain listing never puts a secret on the wire.
+
+Query an endpoint with a key. Read the URL from `deployment endpoint` rather than hardcoding a host — it differs per deployment:
+
+```bash
+curl -X POST "$(envio-cloud deployment endpoint myindexer abc1234 myorg)" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ENVIO_API_KEY" \
+  -d '{"query":"{ __typename }"}'
+```
+
+##### Rotating Keys
+
+An indexer can hold several named keys at once, which is how you rotate without downtime: add a new key, migrate your clients onto it, then revoke the old one.
+
+```bash
+envio-cloud indexer security api-key add myindexer myorg production-2026-08
+# ...migrate clients to the new key...
+envio-cloud indexer security api-key remove myindexer myorg production-2026-07
+```
+
+Key names may contain letters, digits, `-`, `.` and `_`, must start with a letter or digit, and must be 63 characters or fewer.
+
+:::info
+Removing a key revokes it **immediately** — any client still using it loses access. A newly added key shows as `provisioning` for a few seconds before its token is available. The last remaining key cannot be removed; disable API key authentication instead.
+:::
+
+:::note
+API key authentication requires a Production tier plan or above.
+:::
+
 #### Configure IP Whitelisting
 
 Restrict access to your indexer's GraphQL endpoint by IP address. Supports IPv4 addresses and CIDR notation.
 
 ```bash
-# View current IP whitelist configuration
+# View the current configuration
 envio-cloud indexer security get myindexer myorg
 
 # Add IPs to the whitelist

--- a/docs/HyperIndexV2/Hosted_Service/hosted-service-features.md
+++ b/docs/HyperIndexV2/Hosted_Service/hosted-service-features.md
@@ -63,9 +63,9 @@ Restrict requests to specific IP addresses. Only clients connecting from an appr
 Protect your endpoint with an API key—a secret token that clients include with each request to prove they're authorized. This is the recommended option for browser-based dApps and frontends, where users connect from unpredictable IP addresses that can't be allow-listed.
 
 **How it works:**
-- Each indexer (project) gets a **unique API key**, automatically generated and securely stored
-- Retrieve your API key from the deployment dashboard
-- Include it with every request using the `Authorization` header as a Bearer token:
+- Enabling authentication provisions an initial key automatically, stored securely
+- Retrieve your keys from the Security page in the dashboard, or with the [Envio Cloud CLI](./envio-cloud-cli.md)
+- Include a key with every request using the `Authorization` header as a Bearer token:
 
 ```bash
 curl https://<your-endpoint>/v1/graphql \
@@ -74,9 +74,16 @@ curl https://<your-endpoint>/v1/graphql \
 
 Requests without a valid key are rejected with a `401 Unauthorized` response.
 
+**Rotating keys:**
+
+An indexer can hold **several named keys at once**, so you can rotate without downtime: add a new key, migrate your clients onto it, then remove the old one. Removing a key revokes it immediately, so migrate before you remove.
+
+The last remaining key cannot be removed — turn API key authentication off instead if you want to stop requiring a token.
+
 **Benefits:**
 - Works for browser-based apps and frontends with no fixed IP address
-- The same key persists across deployment promotions
+- Keys persist across deployment promotions
+- Rotate credentials without an outage
 - Both your production endpoint and per-deployment URLs are gated by the same policy—no way to bypass authentication
 - Negligible added latency, validated in-process on every request
 


### PR DESCRIPTION
The `envio-cloud` CLI gained API key management in [v0.11.0](https://github.com/enviodev/hosted-service-cli/releases/tag/v0.11.0). This documents it, and corrects a page that understated what the feature does.

## CLI reference — new sections

Under **Indexer Commands**:

- **View the Security Configuration** — `security get` now reports both access controls, not just the IP whitelist
- **Configure API Key Authentication** — `enable`, `disable`, `status`, `list`, with the `--show-tokens` behaviour and a working `curl` example
- **Rotating Keys** — `add` / `remove`, the naming rules, and the migrate-before-you-remove warning

The `curl` example reads its URL from `envio-cloud deployment endpoint` rather than hardcoding a host, because the host differs per deployment (`indexer.hyperindex.xyz`, `indexer.us.hyperindex.xyz`, dedicated hosts).

## Features page — a correction, not just an addition

It said:

> Each indexer (project) gets a **unique API key** […] Retrieve your API key from the deployment dashboard

An indexer holds **several named keys at once**, and rotation is the intended workflow — that is how the dashboard's Security page has worked since API key auth shipped. As written, the page implied there was no way off a compromised key short of downtime, which is the opposite of the design.

Now describes multiple named keys, the rotation flow, and that the last key can't be removed (disable auth instead).

## Files

| File | Change |
| --- | --- |
| `HyperIndex/Hosted_Service/envio-cloud-cli.md` | New sections |
| `HyperIndexV2/Hosted_Service/envio-cloud-cli.md` | Mirror — these two are kept identical |
| `HyperIndex/Hosted_Service/hosted-service-features.md` | Corrected |
| `HyperIndexV2/Hosted_Service/hosted-service-features.md` | Corrected (keeps its V2-only latency bullet) |
| `EnvioCloud-LLM/envio-cloud-complete.mdx` | Regenerated with `yarn consolidate-docs` |

## A note on verification

I did not run a full `yarn build`. It rewrites `image:` frontmatter into ~140 unrelated files and regenerates `network-count.json` and `blog-posts-index.json`, which would have buried this diff in unrelated churn. Only `consolidate-docs` was run, which is what regenerates the LLM file.

`onBrokenLinks` is `throw`, so the one new link is worth a second look: `./envio-cloud-cli.md` from each features page. The target exists in both directories, and the same relative-with-extension style is already used on those pages (`./hosted-service-billing.mdx`, `./hosted-service-deployment.md`). CI should confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API key authentication guidance, including retrieval through the Security page and CLI.
  * Added instructions for viewing security settings, enabling or disabling authentication, listing and revealing keys, and querying protected endpoints.
  * Documented named keys, zero-downtime rotation, immediate revocation, provisioning delays, key constraints, and plan requirements.
  * Clarified token exposure and updated IP whitelist configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->