### PR TITLE
GTM-4211: validate the generated llms files and chain redirects on every build

### DIFF
--- a/docs/HyperIndex/Advanced/config-schema-reference.md
+++ b/docs/HyperIndex/Advanced/config-schema-reference.md
@@ -1,6 +1,7 @@
 ---
 id: config-schema-reference
 title: Configuration Schema Reference
+description: Deep-linkable reference for every field and definition in the HyperIndex V3 config.yaml schema.
 sidebar_label: Config Schema Reference
 slug: /config-schema-reference
 ---

--- a/docs/HyperIndex/supported-networks/index.md
+++ b/docs/HyperIndex/supported-networks/index.md
@@ -1,6 +1,7 @@
 ---
 id: index
 title: HyperIndex Supported Networks
+description: Every network HyperIndex supports natively, with chain IDs and HyperSync endpoints, plus RPC support for any other EVM chain and indexing on Fuel.
 sidebar_label: Supported Networks
 slug: /supported-networks
 ---

--- a/docs/HyperIndexV2/Advanced/config-schema-reference.md
+++ b/docs/HyperIndexV2/Advanced/config-schema-reference.md
@@ -1,6 +1,7 @@
 ---
 id: config-schema-reference
 title: Configuration Schema Reference
+description: Deep-linkable reference for every field and definition in the V2 config.yaml JSON Schema.
 sidebar_label: Config Schema Reference
 slug: /config-schema-reference
 ---

--- a/docs/HyperIndexV2/Hosted_Service/hosted-service-features.md
+++ b/docs/HyperIndexV2/Hosted_Service/hosted-service-features.md
@@ -1,6 +1,7 @@
 ---
 id: hosted-service-features
 title: Features
+description: Production features for managing and securing indexer deployments on Envio Cloud, and which plans include them.
 sidebar_label: Features
 slug: /hosted-service-features
 ---

--- a/docs/HyperIndexV2/Hosted_Service/hosted-service-monitoring.md
+++ b/docs/HyperIndexV2/Hosted_Service/hosted-service-monitoring.md
@@ -1,6 +1,7 @@
 ---
 id: hosted-service-monitoring
 title: Monitoring Your Indexer
+description: Monitor a V2 indexer on Envio Cloud with the real-time dashboard, deployment status indicators, network sync progress, and usage statistics.
 sidebar_label: Monitoring
 slug: /hosted-service-monitoring
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -762,6 +762,22 @@ This file is generated from page frontmatter at build time and follows the llmst
               },
             ],
             optional: [
+              // The full-text dumps point back at this file, but nothing here
+              // pointed at them, so an agent starting from llms.txt had no way
+              // to discover them. Listed first because they are the highest
+              // value follow-up for an agent that can ingest them.
+              {
+                label: "Full documentation (llms-full.txt)",
+                href: "https://docs.envio.dev/llms-full.txt",
+                description:
+                  "Every documentation page concatenated as markdown with per-page source URLs, for direct ingestion into a context window.",
+              },
+              {
+                label: "Full blog and case studies (llms-full-blog.txt)",
+                href: "https://docs.envio.dev/llms-full-blog.txt",
+                description:
+                  "Every blog post and case study concatenated as markdown with per-page source URLs.",
+              },
               {
                 label: "Envio website",
                 href: "https://envio.dev",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -258,6 +258,16 @@ try {
   );
 }
 
+// Chain count for the llms.txt header. network-count.json is regenerated from
+// the live chain API on every build, so this tracks reality instead of drifting
+// like a hardcoded number does. The count is EVM-only (update-endpoints.js
+// filters out Fuel and the -traces endpoint variants), which is why Fuel is
+// named separately in the header sentence. Falls back to a deliberately vague
+// phrase rather than a stale figure if the file is missing.
+const hyperSyncChainCountLabel = networkCountData.hyperSyncChainCount
+  ? `${networkCountData.hyperSyncChainCount}+`
+  : "many";
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Envio",
@@ -555,6 +565,15 @@ const config = {
         // V2 is listed in llms.txt for discoverability but stays out of
         // llms-full.txt and the per-page .md copies.
         excludeFromFullPluginIds: ["HyperIndexV2"],
+        // Standalone pages and showcase entries are live, sitemapped pages that
+        // the docs and blog collectors do not own. Both are read from the same
+        // sources that render them, so new entries appear in llms.txt with no
+        // second list to maintain.
+        pages: { path: "src/pages" },
+        showcase: {
+          dataPath: "src/pages/showcase/_data.js",
+          routeBasePath: "showcase",
+        },
         filesConfigs: [
           {
             main: true, // becomes llms.txt
@@ -562,7 +581,7 @@ const config = {
             header: `
 # Envio: Fast, Multi-Chain Blockchain Indexer
 
-> Envio is a real-time multichain blockchain indexer. HyperIndex is a multichain indexer supporting any EVM chain, plus Solana and Fuel. HyperSync is a high-throughput data layer natively available on 70+ EVM chains and Fuel, and supports any EVM chain via RPC. HyperRPC is a read-only JSON-RPC endpoint powered by HyperSync, up to 5x faster than traditional nodes. Benchmark: Envio 1 min vs The Graph 143 min (Uniswap V2 Factory, [Sentio, May 2025](https://docs.envio.dev/docs/HyperIndex/benchmarks.md)).
+> Envio is a real-time multichain blockchain indexer. HyperIndex is a multichain indexer supporting any EVM chain, plus Solana and Fuel. HyperSync is a high-throughput data layer natively available on ${hyperSyncChainCountLabel} EVM chains and Fuel, and supports any EVM chain via RPC. HyperRPC is a read-only JSON-RPC endpoint powered by HyperSync, up to 5x faster than traditional nodes. On the Uniswap V2 Factory case, independent Sentio benchmarks from April 2025 measured Envio at 8s against The Graph at 19m, 142x slower ([full results](https://docs.envio.dev/docs/HyperIndex/benchmarks.md)).
 
 This file is generated from page frontmatter at build time and follows the llmstxt.org standard.
 `,
@@ -725,11 +744,21 @@ This file is generated from page frontmatter at build time and follows the llmst
                 ],
               },
               {
+                heading: "Showcase",
+                source: "showcase",
+                catchAll: true,
+              },
+              {
                 heading: "Legal",
                 include: [
                   "docs/HyperIndex/privacy-policy.{md,mdx}",
                   "docs/HyperIndex/terms-of-service.{md,mdx}",
                 ],
+              },
+              {
+                heading: "Other pages",
+                source: "pages",
+                catchAll: true,
               },
             ],
             optional: [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "yarn start",
     "prebuild": "node ./scripts/update-endpoints.js && node ./scripts/generate-blog-index.js && node ./scripts/generate-shipper-videos.js && node ./scripts/validate-blog-social-images.js && node ./scripts/generate-og-images.js && node ./scripts/generate-blog-og-images.js && node ./scripts/generate-showcase-og-images.js && node ./scripts/test-blog-jsonld.js",
     "build": "docusaurus build",
+    "postbuild": "node ./scripts/validate-llms.js",
     "swizzle": "docusaurus swizzle",
     "update-endpoints": "node ./scripts/update-endpoints.js",
     "test-blog-jsonld": "node ./scripts/test-blog-jsonld.js",
@@ -29,7 +30,8 @@
     "preinstall": "npx only-allow yarn",
     "consolidate-docs": "node ./scripts/consolidate-hyperindex-docs.js --all",
     "build-llm": "yarn consolidate-docs && node ./scripts/validate-blog-social-images.js && npx docusaurus build --config docusaurus.config.llm.js",
-    "start-llm": "yarn consolidate-docs && npx docusaurus start --config docusaurus.config.llm.js"
+    "start-llm": "yarn consolidate-docs && npx docusaurus start --config docusaurus.config.llm.js",
+    "validate-llms": "node ./scripts/validate-llms.js"
   },
   "dependencies": {
     "@cookbookdev/docsbot": "^4.21.23",

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -246,6 +246,98 @@ function GenerateLLMSPlugin(context, options) {
                 return p.split(path.sep).join("/");
             }
 
+            // 1c. collect standalone Docusaurus pages (src/pages/**.mdx).
+            // These are real, indexed pages that the docs/blog collectors miss
+            // because they are not owned by a content plugin. They have no .md
+            // twin, so they are flagged hasMarkdown: false and link to the
+            // plain URL.
+            if (options.pages) {
+                const pagesConfig =
+                    typeof options.pages === "object" ? options.pages : {};
+                const pagesDir = pagesConfig.path || "src/pages";
+                const pagesAbsPath = path.resolve(context.siteDir, pagesDir);
+
+                if (fs.existsSync(pagesAbsPath)) {
+                    const pageFiles = glob.sync("**/*.{md,mdx}", {
+                        cwd: pagesAbsPath,
+                        // Partials and data files are prefixed with _ by
+                        // Docusaurus convention and are not routable.
+                        ignore: ["**/_*.{md,mdx}"],
+                    });
+
+                    for (const file of pageFiles) {
+                        const fullPath = path.join(pagesAbsPath, file);
+                        const parsed = matter(
+                            fs.readFileSync(fullPath, "utf-8")
+                        );
+                        const title = parsed.data.title;
+                        if (!title) continue;
+
+                        const route = toPosix(file).replace(
+                            /(\/index)?\.(md|mdx)$/,
+                            ""
+                        );
+
+                        collectedDocs.push({
+                            filePath: fullPath,
+                            relativePath: toPosix(
+                                path.relative(context.siteDir, fullPath)
+                            ),
+                            title,
+                            description: parsed.data.description || "",
+                            pageUrl: `${url.replace(/\/$/, "")}/${route}`,
+                            source: "pages",
+                            pluginId: "pages",
+                            hasMarkdown: false,
+                            tags: [],
+                        });
+                    }
+                }
+            }
+
+            // 1d. collect showcase entries from the same data file that renders
+            // the showcase pages, so adding a site to _data.js also lists it
+            // here with no second place to update.
+            if (options.showcase) {
+                const showcaseConfig =
+                    typeof options.showcase === "object"
+                        ? options.showcase
+                        : {};
+                const dataPath = path.resolve(
+                    context.siteDir,
+                    showcaseConfig.dataPath || "src/pages/showcase/_data.js"
+                );
+                const routeBasePath = showcaseConfig.routeBasePath || "showcase";
+
+                if (fs.existsSync(dataPath)) {
+                    // Dynamic import rather than require: the data file is ESM
+                    // and require(esm) only works on Node 20.19+, while the
+                    // repo supports Node >=20.0.
+                    const mod = await import(`file://${dataPath}`);
+                    const sites = mod.sites || [];
+
+                    for (const site of sites) {
+                        if (!site.slug || !site.title) continue;
+                        collectedDocs.push({
+                            filePath: dataPath,
+                            relativePath: `${toPosix(
+                                path.relative(context.siteDir, dataPath)
+                            )}#${site.slug}`,
+                            title: site.title,
+                            description: site.description || "",
+                            pageUrl: `${url.replace(
+                                /\/$/,
+                                ""
+                            )}/${routeBasePath}/${site.slug}`,
+                            source: "showcase",
+                            pluginId: "showcase",
+                            hasMarkdown: false,
+                            tags: [],
+                        });
+                    }
+                }
+            }
+
             function orderDocs(includeOrder) {
                 if (!includeOrder || includeOrder.length === 0) {
                     return [];
@@ -283,15 +375,22 @@ function GenerateLLMSPlugin(context, options) {
             }
 
             function formatDocBullet(doc, opts = {}) {
+                // Docs and blog posts get a .md twin written by
+                // writeMarkdownCopies; standalone pages and showcase entries
+                // do not, so they link to the rendered URL instead.
+                const href =
+                    doc.hasMarkdown === false
+                        ? doc.pageUrl
+                        : `${doc.pageUrl}.md`;
                 if (opts.compact) {
-                    return `- [${doc.title}](${doc.pageUrl}.md)`;
+                    return `- [${doc.title}](${href})`;
                 }
                 const desc =
                     doc.description ||
                     (doc.title.length > 20
                         ? `${doc.title} section of the docs.`
                         : "");
-                return `- [${doc.title}](${doc.pageUrl}.md): ${desc}`;
+                return `- [${doc.title}](${href}): ${desc}`;
             }
 
             // Match a doc against a section/subsection node. Returns docs that
@@ -455,12 +554,86 @@ function GenerateLLMSPlugin(context, options) {
                 )}/llms.txt`;
                 const directive = `> For the complete documentation index, see [llms.txt](${llmsTxtUrl}).\n\n`;
 
+                // Source files link to siblings by relative source path
+                // (../Advanced/hypersync.md) and to assets by relative repo
+                // path (../../static/img/sync.gif). Both break in the .md copy,
+                // because the copy is served from the flattened slug URL rather
+                // than its source directory. Resolve each one against the
+                // source tree and rewrite it to an absolute site path.
+                const byRelativePath = new Map(
+                    docs.map((d) => [d.relativePath, d])
+                );
+                // Docs are served from a flattened slug URL, so most relative
+                // links in the source resolve in URL space rather than against
+                // the source tree. Both spaces are tried.
+                const siteRoot = siteConfig.url.replace(/\/$/, "");
+                const byUrlPath = new Map(
+                    docs.map((d) => [d.pageUrl.replace(siteRoot, ""), d])
+                );
+
+                const rewriteRelativeLinks = (content, doc) => {
+                    const sourceDir = path.posix.dirname(doc.relativePath);
+                    const urlDir = path.posix.dirname(
+                        doc.pageUrl.replace(siteRoot, "")
+                    );
+                    return content.replace(
+                        /(\]\()(\.{1,2}\/[^)\s]+)(\))/g,
+                        (match, open, target, close) => {
+                            const [pathPart, hash = ""] = target.split(/(#.*)$/);
+                            const resolved = path.posix.normalize(
+                                path.posix.join(sourceDir, pathPart)
+                            );
+                            const urlResolved = path.posix.normalize(
+                                path.posix.join(urlDir, pathPart)
+                            );
+
+                            // URL space first, matching how the rendered page
+                            // resolves the link.
+                            const urlHit =
+                                byUrlPath.get(urlResolved) ||
+                                byUrlPath.get(urlResolved.replace(/\.mdx?$/, ""));
+                            if (urlHit) {
+                                return `${open}${urlHit.pageUrl}.md${hash}${close}`;
+                            }
+
+                            // Sibling doc or blog post -> its published .md
+                            // twin. Docusaurus links are commonly written
+                            // without an extension (./testing), so try the
+                            // usual suffixes before giving up.
+                            const hit =
+                                byRelativePath.get(resolved) ||
+                                byRelativePath.get(`${resolved}.md`) ||
+                                byRelativePath.get(`${resolved}.mdx`) ||
+                                byRelativePath.get(`${resolved}/index.md`) ||
+                                byRelativePath.get(`${resolved}/index.mdx`);
+                            if (hit) {
+                                return `${open}${hit.pageUrl}.md${hash}${close}`;
+                            }
+
+                            // static/ is served from the site root.
+                            if (resolved.startsWith("static/")) {
+                                return `${open}/${resolved.slice(
+                                    "static/".length
+                                )}${hash}${close}`;
+                            }
+
+                            console.warn(
+                                `[plugin-generate-llms] ${doc.relativePath}: could not resolve relative link "${target}"`
+                            );
+                            return match;
+                        }
+                    );
+                };
+
                 for (const doc of docs) {
                     const rawContent = fs.readFileSync(doc.filePath, "utf-8");
 
                     // Use gray-matter to strip frontmatter
                     const parsed = matter(rawContent);
-                    const cleanContent = parsed.content.trimStart();
+                    const cleanContent = rewriteRelativeLinks(
+                        parsed.content.trimStart(),
+                        doc
+                    );
 
                     // Convert pageUrl to relative path inside build
                     let relativePath = doc.pageUrl.replace(
@@ -520,10 +693,16 @@ function GenerateLLMSPlugin(context, options) {
                     // llms.txt resolves. llms-full.txt is restricted further
                     // to keep V2 (and similar legacy content) out of the
                     // concatenated knowledge dump.
-                    writeMarkdownCopies(collectedDocs);
+                    // Pages and showcase entries have no markdown source to
+                    // copy, so they are excluded here and from llms-full.
+                    writeMarkdownCopies(
+                        collectedDocs.filter((d) => d.hasMarkdown !== false)
+                    );
 
                     const fullDocsPool = collectedDocs.filter(
-                        (d) => !excludeFromFullPluginIds.has(d.pluginId)
+                        (d) =>
+                            !excludeFromFullPluginIds.has(d.pluginId) &&
+                            d.hasMarkdown !== false
                     );
 
                     // Generate llms-full variants: one for docs, one for blog.

--- a/scripts/validate-llms.js
+++ b/scripts/validate-llms.js
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * Validates the generated llms files and the hand-authored chain redirects.
+ *
+ * Runs as `postbuild`, so it sees the real build output rather than a
+ * reconstruction of it. Two classes of check:
+ *
+ *   INTERNAL  Anything decidable from the build output alone. These FAIL the
+ *             build, because they are deterministic and a failure means we
+ *             would ship a broken file.
+ *
+ *   EXTERNAL  Anything that depends on another host being up (envio.dev, the
+ *             chain API). These only WARN. A transient outage or a rate limit
+ *             on someone else's service must never block a docs deploy.
+ *
+ * The external half exists because the per-chain redirects in vercel.json are a
+ * hand-authored snapshot. Chains get added and removed upstream, and nothing
+ * else notices when a redirect target stops existing.
+ *
+ * Usage:
+ *   node scripts/validate-llms.js              internal + external
+ *   node scripts/validate-llms.js --internal   skip network checks
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const BUILD_DIR = path.join(ROOT, "build");
+const SITE_URL = "https://docs.envio.dev";
+const CHAIN_API = "https://chains.hyperquery.xyz/active_chains";
+
+const SKIP_EXTERNAL =
+  process.argv.includes("--internal") || process.env.VALIDATE_LLMS_EXTERNAL === "0";
+
+const errors = [];
+const warnings = [];
+const fail = (msg) => errors.push(msg);
+const warn = (msg) => warnings.push(msg);
+
+/** Pull every markdown link target out of a text file. */
+const linksIn = (text) =>
+  [...text.matchAll(/\]\((https?:\/\/[^)\s]+)\)/g)].map((m) => m[1]);
+
+// ---------------------------------------------------------------------------
+// Internal checks
+// ---------------------------------------------------------------------------
+
+function checkFilesExist() {
+  const expected = ["llms.txt", "llms-full.txt", "llms-full-blog.txt"];
+  for (const name of expected) {
+    const p = path.join(BUILD_DIR, name);
+    if (!fs.existsSync(p)) {
+      fail(`${name} was not generated`);
+      continue;
+    }
+    if (fs.statSync(p).size === 0) fail(`${name} is empty`);
+  }
+}
+
+function checkStructure(llms) {
+  if (!llms.startsWith("# ")) fail("llms.txt does not start with an H1 title");
+  if (!/^> /m.test(llms)) fail("llms.txt has no blockquote summary line");
+
+  const sections = [...llms.matchAll(/^(#{2,3}) (.+)$/gm)];
+  if (sections.length === 0) fail("llms.txt has no sections");
+
+  // A heading immediately followed by another heading means a selector matched
+  // nothing, which is how a whole product silently drops out of the index.
+  const lines = llms.split("\n");
+  for (const [i, line] of lines.entries()) {
+    if (!/^#{2,3} /.test(line)) continue;
+    const rest = lines.slice(i + 1);
+    const nextHeading = rest.findIndex((l) => /^#{2,3} /.test(l));
+    const body = (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).join("\n");
+    const isParent = /^#{2} /.test(line) && /^### /.test((rest.find((l) => l.trim()) || ""));
+    if (!isParent && !body.includes("- [")) {
+      fail(`llms.txt section "${line.replace(/^#+ /, "")}" contains no entries`);
+    }
+  }
+
+  // The generator falls back to "<Title> section of the docs." when a page has
+  // no frontmatter description. That is filler, not a description.
+  for (const m of llms.matchAll(/^- \[.+?\]\(.+?\): (.*section of the docs\.)$/gm)) {
+    fail(`llms.txt entry uses filler description "${m[1]}" (add a frontmatter description)`);
+  }
+  for (const m of llms.matchAll(/^- (\[.+?\]\(.+?\)): *$/gm)) {
+    fail(`llms.txt entry ${m[1]} has an empty description`);
+  }
+}
+
+/** Every docs.envio.dev link in llms.txt must exist in the build output. */
+function checkInternalLinks(llms) {
+  const internal = [...new Set(linksIn(llms))].filter((u) => u.startsWith(SITE_URL));
+
+  for (const url of internal) {
+    const rel = url.slice(SITE_URL.length).replace(/^\//, "").split("#")[0];
+    if (!rel) continue;
+
+    // Entries point at one of three things: a generated .md twin, a plain
+    // asset that ships as-is (the llms-full variants), or, for pages with no
+    // twin, the rendered route.
+    const candidates = rel.endsWith(".md")
+      ? [rel]
+      : [rel, path.join(rel, "index.html"), `${rel}.html`];
+
+    if (!candidates.some((c) => fs.existsSync(path.join(BUILD_DIR, c)))) {
+      fail(`llms.txt links to ${url}, which is not in the build output`);
+    }
+  }
+}
+
+/**
+ * The .md copies are served from a flattened slug URL, so any surviving
+ * relative link resolves against the wrong directory and 404s.
+ */
+function checkMarkdownCopies() {
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) return walk(full);
+      return e.isFile() && e.name.endsWith(".md") ? [full] : [];
+    });
+  };
+
+  for (const file of [...walk(path.join(BUILD_DIR, "docs")), ...walk(path.join(BUILD_DIR, "blog"))]) {
+    const text = fs.readFileSync(file, "utf-8");
+    const relative = [...text.matchAll(/\]\((\.{1,2}\/[^)\s]+)\)/g)].map((m) => m[1]);
+    if (relative.length > 0) {
+      const rel = path.relative(BUILD_DIR, file);
+      fail(`${rel} still contains relative links (${[...new Set(relative)].join(", ")})`);
+    }
+  }
+}
+
+/**
+ * Coverage drift. Anything in the sitemap that llms.txt does not mention is
+ * probably a page nobody remembered to add. Deliberate omissions live in
+ * SITEMAP_ONLY, so adding one is an explicit decision rather than a silence.
+ */
+const SITEMAP_ONLY = [
+  /^\/$/,
+  /^\/blog\/?$/,
+  /^\/blog\/tag(\/|$)/,
+  /^\/showcase\/?$/,
+];
+
+function checkCoverage(llms) {
+  const sitemapPath = path.join(BUILD_DIR, "sitemap.xml");
+  if (!fs.existsSync(sitemapPath)) {
+    warn("sitemap.xml not found, skipping coverage check");
+    return;
+  }
+
+  const sitemap = fs.readFileSync(sitemapPath, "utf-8");
+  const urls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+  const listed = new Set(
+    linksIn(llms).map((u) => u.replace(/\.md$/, "").replace(/\/$/, ""))
+  );
+
+  const missing = urls.filter((u) => {
+    const route = u.slice(SITE_URL.length) || "/";
+    if (SITEMAP_ONLY.some((re) => re.test(route))) return false;
+    return !listed.has(u.replace(/\/$/, ""));
+  });
+
+  for (const u of missing) {
+    warn(`in sitemap but not in llms.txt: ${u}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// External checks
+// ---------------------------------------------------------------------------
+
+async function head(url) {
+  try {
+    const res = await fetch(url, { redirect: "follow", signal: AbortSignal.timeout(15000) });
+    return res.status;
+  } catch (e) {
+    return null;
+  }
+}
+
+async function mapLimit(items, limit, fn) {
+  const out = [];
+  let i = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (i < items.length) {
+        const idx = i++;
+        out[idx] = await fn(items[idx]);
+      }
+    })
+  );
+  return out;
+}
+
+/**
+ * The per-chain redirects point at envio.dev. Chains move upstream, so these
+ * targets rot silently. Verify each distinct destination still resolves.
+ */
+async function checkChainRedirects() {
+  const vercelPath = path.join(ROOT, "vercel.json");
+  if (!fs.existsSync(vercelPath)) return;
+
+  const redirects = JSON.parse(fs.readFileSync(vercelPath, "utf-8")).redirects || [];
+  const targets = [
+    ...new Set(
+      redirects
+        .map((r) => r.destination)
+        .filter((d) => typeof d === "string" && d.includes("envio.dev/chains/"))
+    ),
+  ];
+
+  if (targets.length === 0) return;
+
+  const statuses = await mapLimit(targets, 8, head);
+  let broken = 0;
+  targets.forEach((url, i) => {
+    const status = statuses[i];
+    if (status === null) {
+      warn(`could not reach ${url}`);
+    } else if (status >= 400) {
+      broken++;
+      const sources = redirects
+        .filter((r) => r.destination === url)
+        .map((r) => r.source);
+      warn(`redirect target ${url} returns ${status}, reached from ${sources.join(", ")}`);
+    }
+  });
+
+  console.log(
+    `[validate-llms] chain redirect targets checked: ${targets.length}, broken: ${broken}`
+  );
+}
+
+/**
+ * Chains added or removed upstream. A chain in the API with no marketing page
+ * is a redirect we cannot make, and a chain we redirect to that has left the
+ * API is a redirect we should retire.
+ */
+async function checkChainInventory() {
+  let api;
+  try {
+    const res = await fetch(CHAIN_API, { signal: AbortSignal.timeout(15000) });
+    api = await res.json();
+  } catch (e) {
+    warn(`could not reach the chain API (${CHAIN_API}), skipping inventory check`);
+    return;
+  }
+
+  // A "-traces" entry is an alternative endpoint for a chain already in the
+  // list, sharing its chain id, so it never gets its own marketing page.
+  const chains = api.filter((c) => c.name && !c.name.toLowerCase().includes("traces"));
+
+  // envio.dev suffixes a slug with the chain id when the bare slug is already
+  // taken (plume -> plume-98866), so a chain counts as covered if either form
+  // resolves. Without this the check cries wolf on every suffixed chain.
+  const candidates = (c) =>
+    [c.name, c.chain_id ? `${c.name}-${c.chain_id}` : null].filter(Boolean);
+
+  const results = await mapLimit(chains, 8, async (c) => {
+    for (const slug of candidates(c)) {
+      const status = await head(`https://envio.dev/chains/${slug}`);
+      if (status === null) return { chain: c, unreachable: true };
+      if (status < 400) return { chain: c, covered: true };
+    }
+    return { chain: c, covered: false };
+  });
+
+  const missing = results.filter((r) => r.covered === false).map((r) => r.chain.name);
+  for (const n of missing) {
+    warn(`chain "${n}" is live in the chain API but has no page on envio.dev/chains`);
+  }
+
+  console.log(
+    `[validate-llms] chains in API (excluding traces): ${chains.length}, without a marketing page: ${missing.length}`
+  );
+}
+
+/**
+ * llms-full.txt and llms-full-blog.txt must hold exactly the pages llms.txt
+ * advertises. A silent gap here is worse than a missing file, because the dump
+ * still looks complete to whatever ingests it.
+ */
+function checkFullTextParity(llms) {
+  const sourcesIn = (name) => {
+    const p = path.join(BUILD_DIR, name);
+    if (!fs.existsSync(p)) return null;
+    return new Set(
+      [...fs.readFileSync(p, "utf-8").matchAll(/^<!-- source: (\S+) -->$/gm)].map((m) => m[1])
+    );
+  };
+
+  const linked = [...new Set(linksIn(llms))]
+    .filter((u) => u.startsWith(SITE_URL) && u.endsWith(".md"))
+    .map((u) => u.replace(/\.md$/, ""));
+
+  const pairs = [
+    // V2 is deliberately indexed but kept out of the concatenated dump.
+    ["llms-full.txt", linked.filter((u) => u.includes("/docs/") && !u.includes("/docs/v2/"))],
+    ["llms-full-blog.txt", linked.filter((u) => u.includes("/blog/"))],
+  ];
+
+  for (const [name, expected] of pairs) {
+    const actual = sourcesIn(name);
+    if (!actual) continue;
+    for (const u of expected) {
+      if (!actual.has(u)) fail(`${name} is missing ${u}, which llms.txt lists`);
+    }
+    for (const u of actual) {
+      if (!expected.includes(u)) fail(`${name} contains ${u}, which llms.txt does not list`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!fs.existsSync(BUILD_DIR)) {
+    console.error("[validate-llms] no build directory, run a build first");
+    process.exit(1);
+  }
+
+  checkFilesExist();
+
+  const llmsPath = path.join(BUILD_DIR, "llms.txt");
+  if (fs.existsSync(llmsPath)) {
+    const llms = fs.readFileSync(llmsPath, "utf-8");
+    checkStructure(llms);
+    checkInternalLinks(llms);
+    checkFullTextParity(llms);
+    checkCoverage(llms);
+  }
+  checkMarkdownCopies();
+
+  if (SKIP_EXTERNAL) {
+    console.log("[validate-llms] external checks skipped");
+  } else {
+    await checkChainRedirects();
+    await checkChainInventory();
+  }
+
+  for (const w of warnings) console.warn(`[validate-llms] warning: ${w}`);
+  for (const e of errors) console.error(`[validate-llms] error: ${e}`);
+
+  if (errors.length > 0) {
+    console.error(
+      `\n[validate-llms] failed with ${errors.length} error(s) and ${warnings.length} warning(s)`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[validate-llms] passed with ${warnings.length} warning(s)`
+  );
+}
+
+main().catch((e) => {
+  console.error("[validate-llms] crashed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
> Stacked on #1026. That one goes first.

## Why

Nothing checked these files after they were generated.

The per-chain redirects in `vercel.json` are a hand-authored snapshot from the crawl-budget work. Chains move upstream, so a redirect target can stop existing with nothing to notice. That is how `envio.dev/chains/base` became a live 404 that `/docs/HyperIndex/base` still redirects into.

## What it does

One script, wired as `postbuild` so it sees the real build output rather than a reconstruction of it.

**Internal checks, these fail the build.** Deterministic, and a failure means we would ship a broken file.

- the three llms files exist and are non-empty
- `llms.txt` has a title, a summary line, and no section that matched nothing
- no filler or empty descriptions
- every `docs.envio.dev` link resolves to something in the build output
- `llms-full.txt` and `llms-full-blog.txt` hold exactly the pages `llms.txt` lists
- no relative links survive in the per-page `.md` copies

**External checks, these only warn.** An outage or a rate limit on someone else's host must never block a docs deploy.

- every distinct `envio.dev/chains` redirect target still resolves
- every chain in the live API has a marketing page

The chain checks skip traces entries, which share a chain id with the chain they belong to and never get their own page, and accept the id-suffixed slug form (`plume-98866`) so suffixed chains are not reported as missing.

## Verification

Injected each defect class into the build output and confirmed it is caught and exits non-zero, then that a clean build exits zero.

| injected | caught |
| --- | --- |
| dead `.md` link | yes |
| dead plain-file link | yes |
| filler description | yes |
| empty description | yes |
| section matching nothing | yes |
| relative link in a `.md` copy | yes |

On the current build it passes with two warnings, both the known Base 404, which is #1191 in the ui repo.

Runs in about 8 seconds.

## Escape hatch

`node scripts/validate-llms.js --internal` skips the network checks. Also available as `yarn validate-llms`.
