### PR TITLE
fix(docs): mobile and tablet compatibility pass (GTM-4035)

### DIFF
--- a/blog/2026-03-20-best-blockchain-indexers.md
+++ b/blog/2026-03-20-best-blockchain-indexers.md
@@ -256,8 +256,6 @@ There is no official hosted service. You deploy and manage your own infrastructu
 ## Feature comparison
 
 
-<div className="scroll-table" tabIndex={0} role="region" aria-label="Feature comparison table">
-
 | Feature | Envio | The Graph | Goldsky | SubQuery | Subsquid (SQD) | Ormi | Ponder |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Event handlers | Yes | Yes | Yes (subgraphs) | Yes | Yes | Yes | Yes |
@@ -272,8 +270,6 @@ There is no official hosted service. You deploy and manage your own infrastructu
 | Independently benchmarked speed | Fastest: 8 seconds (Sentio Uniswap V2 Factory benchmark, May 2025) | 19 minutes (Sentio Uniswap V2 Factory benchmark, May 2025) | Benchmarked (Goldsky_Subgraph, Sentio benchmarks) | Benchmarked (single-contract benchmark) | 2 minutes (Sentio Uniswap V2 Factory benchmark, May 2025) | Not benchmarked | 21 minutes (Sentio Uniswap V2 Factory benchmark, May 2025) |
 | White glove migration | Yes | No | No | No | No | Partial | No |
 | AI-assisted development | Yes | Yes | Yes | Yes | Yes | Yes | No |
-
-</div>
 
 
 Across this comparison, Envio is the only indexer with true wildcard indexing, supports multichain from a single indexer, and is independently benchmarked as fastest in class at 142x faster than The Graph on the Sentio Uniswap V2 Factory workload (May 2025). These capabilities are powered by HyperSync, a proprietary data engine that replaces standard RPC with direct access up to 2000x faster.

--- a/blog/2026-07-10-envio-vs-the-graph.md
+++ b/blog/2026-07-10-envio-vs-the-graph.md
@@ -54,8 +54,6 @@ HyperIndex tracks per-entity state history for every unfinalised block at the fr
 
 ## Head-to-Head at a Glance
 
-<div className="scroll-table" tabIndex={0} role="region" aria-label="Envio vs The Graph comparison table">
-
 | Comparison Point | Envio HyperIndex | The Graph |
 | --- | --- | --- |
 | Handler language | TypeScript in Node, any npm package | AssemblyScript compiled to WebAssembly |
@@ -64,8 +62,6 @@ HyperIndex tracks per-entity state history for every unfinalised block at the fr
 | Reorg handling | Framework-level, rollback on by default | Automatic via graph-node, bounded by prune settings |
 | Query language | Standard GraphQL, plus a converter for subgraph queries | Custom GraphQL dialect |
 | Hosted runtime | Envio Cloud, GitHub-native deploy, or self-host via Docker | Subgraph Studio and the decentralised network |
-
-</div>
 
 ## Switching From The Graph
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -443,6 +443,35 @@ const config = {
             activeBaseRegex:
               "^/docs/HyperIndex/(hosted-service|self-hosting|organisation-setup|envio-cloud-cli)",
           },
+          // Changelog / Showcase / Blog / Shipper's Logs otherwise live only in
+          // the docs sidebar header, which is display:none below 997px — so on
+          // every phone and on an iPad in portrait they had no entry point at
+          // all (the footer only carries Blog). These mirror them into the
+          // mobile drawer and are hidden again once the sidebar reappears.
+          {
+            href: "https://envio.dev/changelog",
+            label: "Changelog",
+            position: "left",
+            className: "navbar__item--mobile-only",
+          },
+          {
+            to: "/showcase",
+            label: "Showcase",
+            position: "left",
+            className: "navbar__item--mobile-only",
+          },
+          {
+            to: "/blog",
+            label: "Blog",
+            position: "left",
+            className: "navbar__item--mobile-only",
+          },
+          {
+            to: "/videos",
+            label: "Shipper's Logs",
+            position: "left",
+            className: "navbar__item--mobile-only",
+          },
           {
             href: "https://github.com/enviodev",
             position: "right",

--- a/src/components/MarkdownTable/index.js
+++ b/src/components/MarkdownTable/index.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useRef, useState } from "react";
+
+/**
+ * Wide markdown tables have to scroll inside the content column rather than
+ * push the whole page sideways. Whatever does that scrolling has to be
+ * reachable by keyboard, so it needs `tabindex="0"` and a named
+ * `role="region"` — a bare `overflow-x: auto` box is unreachable without a
+ * pointer, and the content inside it becomes unreadable for keyboard users.
+ *
+ * The attributes are only applied once the wrapper actually overflows.
+ * Applying them unconditionally would add a stray tab stop, a landmark and a
+ * swipe hint to every narrow table on the site.
+ */
+export default function MarkdownTable(props) {
+  const wrapperRef = useRef(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) {
+      return undefined;
+    }
+
+    const measure = () =>
+      setIsScrollable(wrapper.scrollWidth - wrapper.clientWidth > 1);
+
+    measure();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+
+    // Watch the table as well as the wrapper: the wrapper tracks the content
+    // column, the table tracks its own content width, and either can change
+    // whether the pair overflows.
+    const observer = new ResizeObserver(measure);
+    observer.observe(wrapper);
+    if (wrapper.firstElementChild) {
+      observer.observe(wrapper.firstElementChild);
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={
+        isScrollable ? "table-wrapper table-wrapper--scrollable" : "table-wrapper"
+      }
+      tabIndex={isScrollable ? 0 : undefined}
+      role={isScrollable ? "region" : undefined}
+      aria-label={isScrollable ? "Scrollable table" : undefined}
+    >
+      <table {...props} />
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -367,6 +367,18 @@ article .markdown table {
   -webkit-overflow-scrolling: touch;
 }
 
+/* …except where a table is already inside a scroll container. Those wrappers
+   carry `tabindex="0"` and `role="region"`, which is what makes the table
+   keyboard-scrollable; letting the inner <table> become the scrolling element
+   instead would move the scroll off the focusable node and strand keyboard
+   users. Hand scrolling back to the wrapper and let the table size to its
+   content (see the `width: max-content` rule above). */
+article .markdown .scroll-table > table,
+article .markdown .table-wrapper > table {
+  max-width: none;
+  overflow-x: visible;
+}
+
 /* YouTube embeds are authored as raw <iframe width="560" height="315">, which
    is wider than the content column on any phone and drags the whole page
    sideways. Scale them to the column and keep the 16:9 box. */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -350,15 +350,32 @@ table td {
   }
 }
 
-/* Fallback for tables that are not wrapped by markdown */
-@media (max-width: 768px) {
-  article .markdown > table {
-    display: block;
-    width: max-content;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
+/* Fallback for tables that aren't wrapped in a scroll container.
+   Deliberately not inside a media query: the doc content column is at its
+   narrowest (~511px) on a 1024px tablet in portrait, where the desktop layout
+   has kicked in and the sidebar takes 300px — so a wide table pushes the whole
+   page sideways at widths the old max-width:768px fallback never covered.
+   A descendant selector (not `>`) so tables nested inside other markdown
+   elements are covered too.
+
+   `max-width` + `overflow-x` only: no `width: max-content`, which would stop
+   ordinary tables from filling the content column on desktop. */
+article .markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* YouTube embeds are authored as raw <iframe width="560" height="315">, which
+   is wider than the content column on any phone and drags the whole page
+   sideways. Scale them to the column and keep the 16:9 box. */
+.markdown iframe {
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  border: 0;
 }
 
 /* Clean alert styling */
@@ -510,10 +527,20 @@ table td {
   }
 }
 
+/* The drawer is a flex column whose first child is the brand bar (the row with
+   the wordmark and the close button). The items pane is the second child, so
+   it should simply take whatever height is left.
+
+   It previously offset itself by --ifm-navbar-height and set its own height to
+   100dvh minus that, as if it started at the top of the viewport. The brand bar
+   is shorter than the navbar, so that left a ~60px empty band under it and
+   pushed the pane's last ~50px below the fold. `min-height: 0` is what lets a
+   flex child actually shrink so the inner list scrolls instead of overflowing. */
 .navbar-sidebar__items {
-  margin-top: var(--ifm-navbar-height);
-  height: calc(100dvh - var(--ifm-navbar-height));
-  max-height: calc(100dvh - var(--ifm-navbar-height));
+  margin-top: 0;
+  height: auto;
+  max-height: none;
+  min-height: 0;
   overflow: visible; /* avoid clipping links; let inner list handle scroll */
   flex: 1 1 auto;
 }
@@ -521,6 +548,7 @@ table td {
 /* Let the inner list area scroll instead of the container */
 .navbar-sidebar__item.menu {
   overflow-y: auto;
+  max-height: 100%;
 }
 
 /* While sidebar is open, ensure clicks go to the sidebar, not the navbar */
@@ -712,6 +740,12 @@ html:not([data-theme="dark"]) {
 
   /* Search now lives in the left sidebar on desktop — hide the navbar copy */
   .navbar .DocSearch-Button {
+    display: none !important;
+  }
+
+  /* Changelog / Showcase / Blog / Shipper's Logs are in the sidebar header at
+     this width, so the mobile-drawer copies would be duplicates. */
+  .navbar__item--mobile-only {
     display: none !important;
   }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -283,9 +283,11 @@ table td {
   border-bottom: 1px solid #262626;
 }
 
-/* Scrollable wrappers for wide markdown/blog tables */
-.markdown .table-wrapper,
-.scroll-table {
+/* Scrollable wrappers for wide markdown/blog tables. Every markdown table is
+   wrapped in `.table-wrapper` by src/components/MarkdownTable, which also adds
+   `tabindex="0"` and a named `role="region"` once the wrapper overflows, so
+   the scroller is reachable by keyboard. */
+.markdown .table-wrapper {
   display: block;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
@@ -294,40 +296,37 @@ table td {
   margin-bottom: 1rem;
 }
 
-.markdown .table-wrapper::-webkit-scrollbar,
-.scroll-table::-webkit-scrollbar {
+.markdown .table-wrapper::-webkit-scrollbar {
   height: 10px;
   -webkit-appearance: none;
 }
 
-.markdown .table-wrapper::-webkit-scrollbar-thumb,
-.scroll-table::-webkit-scrollbar-thumb {
+.markdown .table-wrapper::-webkit-scrollbar-thumb {
   background-color: rgba(128, 128, 128, 0.5);
   border-radius: 5px;
 }
 
-.markdown .table-wrapper::-webkit-scrollbar-track,
-.scroll-table::-webkit-scrollbar-track {
+.markdown .table-wrapper::-webkit-scrollbar-track {
   background-color: rgba(128, 128, 128, 0.1);
   border-radius: 5px;
 }
 
-.markdown .table-wrapper > table,
-.scroll-table > table {
+.markdown .table-wrapper > table {
   width: max-content;
   min-width: 100%;
   margin: 0;
 }
 
-.scroll-table:focus-visible {
+.markdown .table-wrapper:focus-visible {
   outline: 2px solid var(--ifm-color-primary);
   outline-offset: 2px;
   border-radius: 4px;
 }
 
 @media (max-width: 768px) {
-  .markdown .table-wrapper::after,
-  .scroll-table::after {
+  /* Only on wrappers that actually overflow, otherwise every narrow table
+     picks up a hint to swipe somewhere it cannot go. */
+  .markdown .table-wrapper--scrollable::after {
     content: "Swipe horizontally to view more \2192";
     display: block;
     margin-top: 0.35rem;
@@ -337,53 +336,27 @@ table td {
     white-space: nowrap;
   }
 
-  .markdown .table-wrapper > table,
-  .scroll-table > table {
+  .markdown .table-wrapper > table {
     font-size: 0.8125rem;
   }
 
   .markdown .table-wrapper > table th,
-  .markdown .table-wrapper > table td,
-  .scroll-table > table th,
-  .scroll-table > table td {
+  .markdown .table-wrapper > table td {
     padding: 8px 10px;
   }
 }
 
-/* Fallback for tables that aren't wrapped in a scroll container.
-   Deliberately not inside a media query: the doc content column is at its
-   narrowest (~511px) on a 1024px tablet in portrait, where the desktop layout
-   has kicked in and the sidebar takes 300px — so a wide table pushes the whole
-   page sideways at widths the old max-width:768px fallback never covered.
-   A descendant selector (not `>`) so tables nested inside other markdown
-   elements are covered too.
-
-   `max-width` + `overflow-x` only: no `width: max-content`, which would stop
-   ordinary tables from filling the content column on desktop. */
-article .markdown table {
-  display: block;
-  max-width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* …except where a table is already inside a scroll container. Those wrappers
-   carry `tabindex="0"` and `role="region"`, which is what makes the table
-   keyboard-scrollable; letting the inner <table> become the scrolling element
-   instead would move the scroll off the focusable node and strand keyboard
-   users. Hand scrolling back to the wrapper and let the table size to its
-   content (see the `width: max-content` rule above). */
-article .markdown .scroll-table > table,
-article .markdown .table-wrapper > table {
-  max-width: none;
-  overflow-x: visible;
-}
-
 /* YouTube embeds are authored as raw <iframe width="560" height="315">, which
    is wider than the content column on any phone and drags the whole page
-   sideways. Scale them to the column and keep the 16:9 box. */
-.markdown iframe {
-  max-width: 100%;
+   sideways. Scale them down to the column and keep the 16:9 box.
+
+   Scoped to video hosts, and capped at the width they were authored at, so
+   this neither stretches a 560px embed across a desktop content column nor
+   forces 16:9 onto an embed that is not a video. */
+.markdown iframe[src*="youtube.com"],
+.markdown iframe[src*="youtube-nocookie.com"],
+.markdown iframe[src*="youtu.be"] {
+  max-width: 560px;
   width: 100%;
   height: auto;
   aspect-ratio: 16 / 9;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -171,8 +171,13 @@
     padding: 1rem;
   }
 
+  /* "Documentation" is a single 13-character word that needs ~289px at 2.5rem.
+     The content box is only 279px on a 375px phone (iPhone SE / 13 mini) and
+     224px at 320px, so a flat 2.5rem hard-broke the word across two lines
+     ("Documentatio" / "n"). Scaling with the viewport keeps it on one line all
+     the way down to 320px and still reaches 2.5rem on wider phones. */
   .title {
-    font-size: 2.5rem;
+    font-size: clamp(1.75rem, 9vw, 2.5rem);
   }
 
   .docsGrid {

--- a/src/pages/showcase/index.js
+++ b/src/pages/showcase/index.js
@@ -88,10 +88,7 @@ function ShowcaseCards() {
     <div className="container">
       <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem" }}>
         {sites.map((site, idx) => (
-          <div
-            key={idx}
-            style={{ display: "flex", flex: "0 0 calc((100% - 2rem) / 3)" }}
-          >
+          <div key={idx} className="showcase-card-cell">
             <ShowcaseCard site={site} />
           </div>
         ))}
@@ -118,6 +115,24 @@ export default function Showcase() {
         .showcase-card:hover {
           border-color: #454545 !important;
           transform: scale(1.02);
+        }
+        /* Three across is only readable once there's room for it. The cell
+           width used to be a flat one third at every size, which on a phone
+           left ~121px cards with a ~79px description column — six lines for a
+           one-line sentence. */
+        .showcase-card-cell {
+          display: flex;
+          flex: 0 0 calc((100% - 2rem) / 3);
+        }
+        @media (max-width: 996px) {
+          .showcase-card-cell {
+            flex-basis: calc((100% - 1rem) / 2);
+          }
+        }
+        @media (max-width: 600px) {
+          .showcase-card-cell {
+            flex-basis: 100%;
+          }
         }
       `}</style>
       <main className="margin-vert--lg">

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -3,9 +3,11 @@ import MDXComponents from "@theme-original/MDXComponents";
 import HyperSyncChainCount, {
   HyperSyncChainCountPlain,
 } from "@site/src/components/HyperSyncChainCount";
+import MarkdownTable from "@site/src/components/MarkdownTable";
 
 export default {
   ...MDXComponents,
+  table: MarkdownTable,
   HyperSyncChainCount,
   HyperSyncChainCountPlain,
 };


### PR DESCRIPTION
Responsive pass over the docs site, checked at phone and tablet widths against the live site.

### What was wrong

- Video embeds were authored at a fixed width, so pages carrying one could be scrolled sideways on a phone
- Wide tables ran past the edge on a tablet in portrait, where the desktop layout leaves a much narrower content column
- Changelog, Showcase, Blog and Shipper's Logs only existed in the desktop sidebar, so they had no entry point at all on a phone or a tablet in portrait
- Showcase cards kept a three across layout at every size, leaving very narrow cards on a phone
- The homepage heading broke a word across two lines on smaller iPhones
- The mobile menu had a band of empty space under the header and its last stretch sat below the fold

### What changed

Six scoped fixes across `custom.css`, `docusaurus.config.js`, the showcase page and the homepage styles. Desktop rendering is unchanged.

### Verification

Ran against a production build, 1,348 page and viewport measurements over 337 pages at 375, 430, 768 and 1024. No horizontal overflow anywhere and no load errors. Tables still fill the content column at desktop width.

The second commit fixes an accessibility regression found while reviewing the first. The new table rule had moved scrolling off the wrapper that carries `tabindex="0"` and `role="region"`, which would have stranded keyboard users on the two blog comparison tables.

The third commit takes that further after review. Markdown tables are now wrapped by a component rather than a CSS fallback, so the scroll container carries `tabindex="0"`, `role="region"` and an accessible name, and only once it actually overflows. The video embed rule is scoped to video hosts and capped at the width the embeds were authored at, so desktop rendering really is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation links for Changelog, Showcase, Blog, and Shipper’s Logs.
  * Added responsive Showcase layouts with three, two, or one column depending on screen size.
  * Added responsive 16:9 sizing for YouTube embeds.

* **Bug Fixes**
  * Improved mobile navigation drawer scrolling and sizing.
  * Prevented narrow-screen homepage titles from wrapping awkwardly.
  * Made markdown tables scrollable only when needed, with improved accessibility and swipe guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
