### PR TITLE
docs(solana): update HyperIndex SVM docs to the shipped 3.7.0 API

### DIFF
--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -114,31 +114,50 @@ Everything HyperSync-backed lives under the chain's `experimental` key:
 
 ### Choosing an endpoint and a start slot
 
-Two public Solana HyperSync endpoints exist, and they differ in how far back they
-serve, not in what they return:
+Two public Solana HyperSync endpoints exist:
 
-| Endpoint | Serves history back to |
-| --- | --- |
-| `https://solana.hypersync.xyz` | slot **436,162,000** (measured 2026-08-18) |
-| `https://solana-mainnet-history.hypersync.xyz` | at least slot **403,000,000** (measured 2026-08-18) |
+| Endpoint | Oldest slot served | Head |
+| --- | --- | --- |
+| `https://solana.hypersync.xyz` | **403,000,000** | 440,067,639 |
+| `https://solana-mainnet-history.hypersync.xyz` | **403,000,000** | 440,067,639 |
 
-Both reported a head of 440,063,001 on 2026-08-18. Treat both the head and the
-history floor as moving targets: query `GET <endpoint>/height` for the head, and
-expect the floor to roll forward. Do not copy a floor number into a config as if
-it were permanent.
+Measured 2026-08-18 by bisecting `from_slot` against each endpoint. On that date
+the two were indistinguishable: same floor to the slot, same head. They have not
+always been, so prefer whichever one your project already pins rather than
+switching on the assumption that they are interchangeable.
 
-:::danger A `start_block` below the floor is silently skipped
-If `start_block` is earlier than the endpoint's history floor, the indexer does
-**not** error and does **not** stall. The server fast-forwards `next_slot` to the
-floor, so the sync reports healthy, progresses normally, and quietly writes no
-rows at all for every slot before the floor.
+Treat both numbers as moving. Query `GET <endpoint>/height` for the head, and
+re-probe the floor rather than copying one into a config as if it were permanent.
+403,000,000 is a suspiciously round number, which is what a deliberate backfill
+target looks like; it is not a guarantee.
+
+:::danger A `start_block` below the floor stalls the sync silently
+If `start_block` is earlier than the endpoint's history floor, the server does
+**not** error. It returns an empty page with `next_slot` equal to the `from_slot`
+you sent, so the cursor never advances and the indexer retries the same empty
+range forever while reporting itself healthy.
+
+To probe the floor directly, send a one-slot query and compare `next_slot` against
+what you asked for. Below the floor they are equal; at or above it, `next_slot` is
+`from_slot + 1`:
+
+```bash
+curl -sS -X POST https://solana.hypersync.xyz/query \
+  -H "Authorization: Bearer $ENVIO_API_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"from_slot": 403000000, "to_slot": 403000001,
+       "include_all_blocks": true,
+       "field_selection": {"block": ["slot"]}}' | jq .next_slot
+# 403000001  => served
+# 403000000  => below the floor
+```
 
 Two consequences:
 
-- Pick the endpoint that actually covers the range you want, then set
-  `start_block` at or above its floor.
-- If a backfill produced fewer early rows than you expected, re-probe the floor
-  before assuming your discriminators or handlers are wrong.
+- Pick an endpoint that covers the range you want, then set `start_block` at or
+  above its floor.
+- If a backfill is not progressing, check `next_slot` against `from_slot` before
+  assuming your discriminators or handlers are wrong.
 :::
 
 ### `programs`

--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -27,10 +27,10 @@ name: my-solana-indexer
 description: Index Jupiter swaps and Metaplex NFT mints
 ecosystem: svm
 chains:
-  - start_block: 417995000                 # a SLOT number, not a block
+  - start_block: 437000000                 # a SLOT number, not a block
     experimental:
       hypersync_config:
-        url: https://solana.hypersync.xyz  # the HyperSync endpoint serving instructions
+        url: https://solana.hypersync.xyz  # required: the HyperSync endpoint serving instructions
       programs:
         # --- decoded from an Anchor IDL ---
         - name: Jupiter
@@ -40,6 +40,7 @@ chains:
             - name: sharedAccountsRoute
               discriminator: "0xc1209b3341d69c81"
               field_selection:
+                transaction_fields: [signature, feePayer, success]
                 token_balance_fields: true
         # --- decoded from an inline schema (no IDL) ---
         - name: Raydium
@@ -57,8 +58,7 @@ chains:
                 - userDestTokenAccount
               field_selection:
                 token_balance_fields: true
-                transaction_fields:
-                  - signatures
+                transaction_fields: [signature]
 ```
 
 ## Top-level fields
@@ -70,8 +70,10 @@ chains:
 | `chains` | ✅ | — | One or more chains to index (see below). |
 | `description` | — | — | Free-text description. |
 | `schema` | — | `schema.graphql` | Path to your GraphQL schema. |
+| `handlers` | - | `src/handlers` | Directory that handler files are auto-loaded from. |
 | `full_batch_size` | — | `5000` | Batch size for processing. |
 | `storage` | — | `postgres: true` | Storage backends (`postgres`, `clickhouse`). |
+| `disable_default_cross_chain` | - | `false` | Make entities and effect caches per-chain instead of shared across chains. |
 
 :::note No EVM-style global fields
 For Solana, several EVM top-level fields don't apply: `contracts`,
@@ -107,8 +109,37 @@ Everything HyperSync-backed lives under the chain's `experimental` key:
 
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `hypersync_config.url` | ✅ | - | The HyperSync endpoint that serves instructions (e.g. `https://solana.hypersync.xyz`). |
+| `hypersync_config` | ✅ | - | Block containing `url`. Both the block and `url` are required: a chain with an `experimental` key but no `hypersync_config` fails config validation rather than falling back to a default. |
 | `programs` | ✅ | - | Solana programs to index on this chain (see below). |
+
+### Choosing an endpoint and a start slot
+
+Two public Solana HyperSync endpoints exist, and they differ in how far back they
+serve, not in what they return:
+
+| Endpoint | Serves history back to |
+| --- | --- |
+| `https://solana.hypersync.xyz` | slot **436,162,000** (measured 2026-08-18) |
+| `https://solana-mainnet-history.hypersync.xyz` | at least slot **403,000,000** (measured 2026-08-18) |
+
+Both reported a head of 440,063,001 on 2026-08-18. Treat both the head and the
+history floor as moving targets: query `GET <endpoint>/height` for the head, and
+expect the floor to roll forward. Do not copy a floor number into a config as if
+it were permanent.
+
+:::danger A `start_block` below the floor is silently skipped
+If `start_block` is earlier than the endpoint's history floor, the indexer does
+**not** error and does **not** stall. The server fast-forwards `next_slot` to the
+floor, so the sync reports healthy, progresses normally, and quietly writes no
+rows at all for every slot before the floor.
+
+Two consequences:
+
+- Pick the endpoint that actually covers the range you want, then set
+  `start_block` at or above its floor.
+- If a backfill produced fewer early rows than you expected, re-probe the floor
+  before assuming your discriminators or handlers are wrong.
+:::
 
 ### `programs`
 
@@ -117,19 +148,20 @@ Everything HyperSync-backed lives under the chain's `experimental` key:
 | `name` | ✅ | - | A unique name you choose. Used in handlers (`onInstruction({ program: "<name>" })`) and generated types. |
 | `program_id` | ✅ | - | The base58 program address. |
 | `instructions` | ✅ | - | Instructions to match within this program (see below). |
-| `idl` | - | - | Path to an Anchor IDL JSON. If set, HyperIndex derives each instruction's `args` + `accounts` from it. **Mutually exclusive** with per-instruction inline `args`/`accounts`. |
+| `idl` | - | - | Path to an Anchor IDL JSON, relative to `config.yaml`. If set, HyperIndex derives each instruction's `args` + `accounts` from the IDL entry matching that instruction's configured `discriminator`. **Mutually exclusive** with per-instruction inline `args`/`accounts`. |
 | `handler` | - | auto | Path to the file that registers this program's handlers. By default handler files are auto-loaded. |
 
 ## `instructions`
 
 Each entry selects one instruction of the program to index. Only `name` is
-required, but in practice you'll add a `discriminator` so HyperIndex can tell your
-instruction apart from the program's others.
+required by the schema, but in practice `discriminator` is required too: it is
+both how HyperIndex tells your instruction apart from the program's others and how
+it resolves the decode layout.
 
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `name` | ✅ | — | The instruction name. For Anchor IDL programs this should match the IDL instruction (the snake_cased name is used to derive the default discriminator). Also the key in `onInstruction({ instruction: "<name>" })`. |
-| `discriminator` | — | — | Hex bytes that identify the instruction (e.g. `"0xc1209b3341d69c81"`). **Modern Anchor IDLs (0.30+) embed it, so HyperIndex reads it automatically; legacy Anchor IDLs and native/inline-schema instructions need it set explicitly.** See [discriminators](/docs/HyperIndex/solana/decoding#discriminators). Without a discriminator (embedded or configured), the instruction matches purely on program + filters and isn't decoded by discriminator. |
+| `name` | ✅ | - | The instruction name, unique per program. It is the key in `onInstruction({ instruction: "<name>" })` and in the generated types. It is a label only: matching is done by `discriminator`, so the name need not equal the IDL's. |
+| `discriminator` | - | - | Hex bytes that identify the instruction (e.g. `"0xc1209b3341d69c81"`). **Always set it, including for modern Anchor IDLs.** HyperIndex reads the discriminator only from this key, never from an IDL's embedded `discriminator` array, and it is also the key it looks the IDL layout up by. Omit it and the instruction matches *every* instruction of the program and decodes nothing (`params` is `undefined`). See [discriminators](/docs/HyperIndex/solana/decoding#discriminators). |
 | `is_inner` | — | *unset* | `true` = inner (CPI) only, `false` = top-level only, **omitted = matches both**. |
 | `args` | — | — | Inline argument schema (Borsh), `{ name, type }` per arg. Requires `accounts` too. Mutually exclusive with the program's `idl`. See [supported types](/docs/HyperIndex/solana/decoding#supported-argument-types). |
 | `accounts` | — | — | Inline ordered list of account names. The Nth name labels the Nth account. Requires `args` too. |
@@ -143,21 +175,25 @@ By default a handler receives only the instruction itself, plus its block's
 
 | Key | Value | Adds to the handler's `instruction` |
 | --- | --- | --- |
-| `transaction_fields` | list of field names | `instruction.transaction.<field>` for each selected field: `signatures`, `feePayer`, `success`, `err`, `fee`, `computeUnitsConsumed`, `accountKeys`, `recentBlockhash`, `version`, `transactionIndex`. |
+| `transaction_fields` | list of field names | `instruction.transaction.<field>` for each selected field: `signature`, `allSignatures`, `feePayer`, `success`, `err`, `fee`, `computeUnitsConsumed`, `accountKeys`, `recentBlockhash`, `version`, `transactionIndex`. |
 | `block_fields` | list of field names | `instruction.block.<field>` on top of the always-present `slot`/`time`/`hash`: `height`, `parentSlot`, `parentHash`. |
 | `token_balance_fields` | `true` | `instruction.transaction.tokenBalances`: pre/post SPL Token balances. Independent of `transaction_fields`. |
 | `log_fields` | `true` | `instruction.logs`: program logs scoped to this instruction. |
 
 ```yaml
 field_selection:
-  transaction_fields:
-    - signatures
-    - feePayer
-  block_fields:
-    - height
+  transaction_fields: [signature, feePayer, success]
+  block_fields: [height]
   token_balance_fields: true
   log_fields: true
 ```
+
+:::note `signature` vs `allSignatures`
+`signature` is the scalar transaction id (a `string`) and is what nearly every
+handler wants. `allSignatures` is the full `readonly string[]` of signatures from
+every signer, which only matters for multi-signer analysis. They are selected
+independently: selecting `signature` does **not** give you `allSignatures`.
+:::
 
 Unselected fields are typed as compile errors in the handler (`FieldNotSelected`),
 so reading a field you forgot to select fails at `tsc` time, not silently at

--- a/docs/HyperIndex/solana/configuration.md
+++ b/docs/HyperIndex/solana/configuration.md
@@ -131,15 +131,30 @@ re-probe the floor rather than copying one into a config as if it were permanent
 403,000,000 is a suspiciously round number, which is what a deliberate backfill
 target looks like; it is not a guarantee.
 
-:::danger A `start_block` below the floor stalls the sync silently
-If `start_block` is earlier than the endpoint's history floor, the server does
-**not** error. It returns an empty page with `next_slot` equal to the `from_slot`
-you sent, so the cursor never advances and the indexer retries the same empty
-range forever while reporting itself healthy.
+:::danger A `start_block` below the floor is silently wrong, in one of two ways
+A below-floor request never errors. What happens instead depends on whether the
+range you asked for reaches the floor:
 
-To probe the floor directly, send a one-slot query and compare `next_slot` against
-what you asked for. Below the floor they are equal; at or above it, `next_slot` is
-`from_slot + 1`:
+- **The range reaches the floor** (an indexer with no `end_block`, so it runs
+  toward head). The server skips straight to the floor and serves from there.
+  Sync looks perfectly healthy and simply never writes a row for any slot before
+  the floor. This is the dangerous one: nothing anywhere reports a problem.
+- **The whole range sits below the floor** (`start_block` and `end_block` both
+  earlier than it). There is nothing to skip to, so the server returns an empty
+  page with `next_slot` equal to the `from_slot` it was sent. The cursor never
+  advances and the indexer retries the same empty range indefinitely.
+
+Measured on 2026-08-18 against `solana.hypersync.xyz` (floor 403,000,000):
+
+| Request | `next_slot` returned | Rows |
+| --- | --- | --- |
+| `from_slot: 100`, no `to_slot` | 403,000,001 | serves from the floor |
+| `from_slot: 100, to_slot: 200` | 100 | none, no progress |
+| `from_slot: 402999999, to_slot: 403000002` | 403,000,001 | serves from the floor |
+
+To probe the floor directly, send a one-slot bounded query and compare
+`next_slot` against what you asked for. Below the floor they are equal; at or
+above it, `next_slot` is `from_slot + 1`:
 
 ```bash
 curl -sS -X POST https://solana.hypersync.xyz/query \
@@ -152,12 +167,15 @@ curl -sS -X POST https://solana.hypersync.xyz/query \
 # 403000000  => below the floor
 ```
 
+Note the `to_slot` is what makes this a reliable probe. Without it the server
+skips ahead to the floor and answers successfully from any `from_slot`.
+
 Two consequences:
 
 - Pick an endpoint that covers the range you want, then set `start_block` at or
   above its floor.
-- If a backfill is not progressing, check `next_slot` against `from_slot` before
-  assuming your discriminators or handlers are wrong.
+- If a backfill produced no early rows, or is not progressing at all, check the
+  floor before assuming your discriminators or handlers are wrong.
 :::
 
 ### `programs`

--- a/docs/HyperIndex/solana/decoding.md
+++ b/docs/HyperIndex/solana/decoding.md
@@ -39,11 +39,19 @@ instructions:
     discriminator: "0x09"                # 1-byte native
 ```
 
+:::warning Always set `discriminator`, even with an IDL
+HyperIndex reads the discriminator **only** from `config.yaml`. Modern Anchor IDLs
+(0.30+) embed a `discriminator` array, but codegen ignores it, and it is the
+configured bytes that the IDL's argument/account layout is looked up by.
+
+Omit `discriminator` and two things happen at once: the instruction matches
+*every* instruction of the program, and no layout resolves, so `params` is
+`undefined` on every one of them. Neither failure raises an error.
+:::
+
 ### Computing an Anchor discriminator
 
-Modern Anchor IDLs (0.30+) embed the discriminator, so HyperIndex reads it from
-the IDL automatically. **Legacy Anchor IDLs don't include it**, so you compute it
-from the instruction name:
+For an Anchor program, compute the 8-byte sighash from the instruction name:
 
 ```typescript
 import { createHash } from "node:crypto";
@@ -64,10 +72,13 @@ HyperIndex resolves an instruction's argument/account layout in this order:
 
 | Source | When | How to use |
 | --- | --- | --- |
-| **Anchor IDL** | Program has `idl:` set | HyperIndex derives `args` + `accounts` from the IDL for every instruction. |
-| **Inline schema** | Instruction has `args` + `accounts` | You declare the layout directly. Mutually exclusive with `idl`. |
-| **Bundled** | Program id matches a built-in schema | Currently only **Metaplex Token Metadata** — no `idl`/inline needed. |
-| **None** | No schema available | The instruction still matches and fires the handler, but `params` is `undefined` (you can read raw `instruction.data` / `instruction.accounts`). |
+| **Inline schema** | Instruction has both `args` and `accounts` | You declare the layout directly. Highest priority; mutually exclusive with the program's `idl`. |
+| **Anchor IDL** | Program has `idl:` set | HyperIndex derives `args` + `accounts` from the IDL entry whose discriminator matches the instruction's configured `discriminator`. |
+| **Bundled** | Program id matches a built-in schema | Currently only **Metaplex Token Metadata**: no `idl`/inline needed. Looked up by `discriminator` the same way. |
+| **None** | No schema resolved | The instruction still matches and fires the handler, but `params` is `undefined` (you can read raw `instruction.data` / `instruction.accounts`). |
+
+The order above is the resolution order: inline `args`+`accounts` win, then the
+IDL or bundled schema keyed by `discriminator`, then nothing.
 
 ### Anchor IDLs
 
@@ -85,14 +96,15 @@ experimental:
       idl: idls/jupiter.json
       instructions:
         - name: route
-          discriminator: "0xe517cb977ae3ad2a" # legacy IDL: supply the sighash
+          discriminator: "0xe517cb977ae3ad2a"
         - name: sharedAccountsRoute
           discriminator: "0xc1209b3341d69c81"
 ```
 
-With an IDL set, you only list each instruction's `name` (+ `discriminator` for
-legacy IDLs) — the args and accounts come from the IDL. Don't add inline
-`args`/`accounts`; they're mutually exclusive with `idl`.
+With an IDL set, list each instruction's `name` and `discriminator`; the args and
+accounts come from the IDL, matched on those discriminator bytes. Don't add inline
+`args`/`accounts`; they're mutually exclusive with `idl`. Supplying only one of
+`args`/`accounts` is a config error: they must be given together or both omitted.
 
 ### Inline schema (no IDL)
 
@@ -134,7 +146,7 @@ The right column is how each value appears in `params.args`.
 | `bool` | boolean |
 | `u8` `u16` `u32`, `i8` `i16` `i32` | number |
 | `u64` `u128` `i64` `i128` | **decimal string** (precision-safe) |
-| `f32` `f64` | number (`null` if NaN/Inf) |
+| `f32` `f64` | number |
 | `string` | string |
 | `bytes` | `0x`-prefixed hex string |
 | `pubkey` (alias `publicKey`) | base58 string |
@@ -207,12 +219,16 @@ function mapRoute(params: SvmInstructionParams) {
 
 Decoding returns `undefined` (rather than crashing) when:
 
-- the discriminator didn't match a configured instruction with a schema;
+- the instruction has no `discriminator` in `config.yaml`, so no layout could be
+  looked up;
+- the configured discriminator matched no schema entry (a stale IDL, or the wrong
+  sighash);
 - there were too few accounts for the named list;
 - the argument bytes didn't decode cleanly (wrong/partial layout).
 
-The indexer keeps running and logs at debug. Always `if (!params) return;` before
-using it — or fall back to the raw `instruction.data` and `instruction.accounts`.
+None of these throws, and the indexer keeps running. `params` is optional in the
+type system too, so always `if (!params) return;` before using it, or fall back to
+the raw `instruction.data` and `instruction.accounts`.
 
 ## Known limitations
 

--- a/docs/HyperIndex/solana/evm-vs-solana.md
+++ b/docs/HyperIndex/solana/evm-vs-solana.md
@@ -22,7 +22,7 @@ difference in one place.
 | ABI | Anchor IDL (or an inline schema) |
 | Event / log | Instruction |
 | `indexer.onEvent` | `indexer.onInstruction` |
-| `event.params.<name>` | `instruction.params.args.<name>` |
+| `event.params.<name>` | `instruction.params?.args.<name>` (optional) |
 | Event signature / topic0 | Instruction discriminator |
 | Indexed event args | Account positions / `account_filters` |
 | `indexer.onBlock` | `indexer.onSlot` |
@@ -41,7 +41,8 @@ difference in one place.
 | `start_block` | block number | **slot** number |
 | Matching key | event signature (from ABI) | `discriminator` (hex, 1/2/4/8 bytes) |
 | Decoding source | ABI | Anchor IDL, inline `args`+`accounts`, or bundled |
-| Field selection | global, rich block/transaction field lists | per-instruction: `transaction_fields`/`block_fields` (field name lists), `token_balance_fields`/`log_fields` (`true`) |
+| Field selection | global, plus a per-event inline `fields` option | per-instruction only, in `config.yaml`: `transaction_fields`/`block_fields` (field name lists), `token_balance_fields`/`log_fields` (`true`). The EVM inline `fields` option does not apply to SVM. |
+| Data source config | HyperSync endpoint inferred from `chains[].id` | `experimental.hypersync_config.url` is **required** and explicit |
 | Reorg options | `rollback_on_reorg`, `save_full_history` | handled automatically on the HyperSync source (rolls back on reorg); the RPC source is finalized-only |
 
 :::note `chains`, not `networks`
@@ -77,7 +78,7 @@ indexer.onInstruction(
     const sourceMint = params.accounts.sourceMint;  // base58
     const programId = instruction.programId;        // base58
     const slot = instruction.block.slot;
-    const txSig = instruction.transaction.signatures[0]; // needs transaction_fields: [signatures]
+    const txSig = instruction.transaction.signature;  // needs transaction_fields: [signature]
     const isInner = instruction.isInner;            // CPI?
   },
 );
@@ -86,7 +87,7 @@ indexer.onInstruction(
 Key handler-level differences:
 
 - **`params` is optional.** EVM `event.params` is always populated (the ABI is known); Solana decoding can fail, so always `if (!params) return;`.
-- **Numbers as strings.** `u64`/`u128`/`i64`/`i128` arrive as decimal strings — wrap in `BigInt(...)`. (Smaller ints are JS numbers.)
+- **Decoded big ints are strings.** `u64`/`u128`/`i64`/`i128` **args** arrive as decimal strings; wrap in `BigInt(...)`. (Smaller ints are JS numbers.) Note this applies to decoded args only: `fee`, `computeUnitsConsumed`, and token-balance `preAmount`/`postAmount` are already `bigint`.
 - **Addresses are base58.** No `0x` lowercase/checksum concerns; pubkeys are base58 strings.
 - **Opt in to context.** Transaction fields, token balances, and logs require [field selection](/docs/HyperIndex/solana/configuration#field-selection); on EVM the event always carries block/transaction context.
 - **Chain id is `0`.** Single-cluster today; `context.chain.id === 0`.
@@ -106,12 +107,13 @@ underneath a Jupiter route). See
 Solana instruction events can carry **pre/post SPL Token balance snapshots** for
 the whole transaction (`token_balance_fields: true`). This gives you net token
 movement (the balance *change*) without indexing every transfer instruction —
-there's no direct EVM equivalent built into the event. See
+there's no direct EVM equivalent built into the event. The amounts are `bigint`
+raw base units, and each entry carries the mint's `decimals`. See
 [Token balances](/docs/HyperIndex/solana/instruction-handlers#token-balances-and-balance-changes).
 
 ## Slots vs blocks
 
-- `start_block` is a **slot**. Use `GET https://solana.hypersync.xyz/height` to find the current head; HyperSync keeps a rolling window, so don't hard-code an ancient slot.
+- `start_block` is a **slot**. Use `GET https://solana.hypersync.xyz/height` to find the current head. Each endpoint also has a history floor, and a `start_block` below it is [silently skipped rather than rejected](/docs/HyperIndex/solana/configuration#choosing-an-endpoint-and-a-start-slot), so don't hard-code an ancient slot.
 - Some slots have **no block** (skipped leader). Slot handlers must handle the empty case.
 - The handler arg for `onSlot` is `{ slot: number }`, not a `block` object.
 

--- a/docs/HyperIndex/solana/getting-started.md
+++ b/docs/HyperIndex/solana/getting-started.md
@@ -65,13 +65,13 @@ Set `start_block` to a few tens of thousands of slots below the head for a quick
 backfill, or to the slot your program was deployed at for a fuller history -
 provided that slot sits above the endpoint's floor.
 
-:::danger A `start_block` below the endpoint's floor stalls the sync
-It does not error. The server returns an empty page with `next_slot` equal to the
-`from_slot` you sent, so the cursor never advances and the indexer sits there
-retrying the same empty range while reporting itself healthy. Both
-`https://solana.hypersync.xyz` and `https://solana-mainnet-history.hypersync.xyz`
-served from slot 403,000,000 when measured on 2026-08-18, but treat that as a
-moving number. See
+:::danger A `start_block` below the endpoint's floor is silently wrong
+It never errors. An indexer running toward head skips straight to the floor and
+syncs happily, writing nothing at all for the slots before it. An indexer whose
+`end_block` is also below the floor stalls instead: the server returns an empty
+page with `next_slot` equal to the `from_slot` it was sent, so the cursor never
+advances. Both endpoints served from slot 403,000,000 when measured on
+2026-08-18, but treat that as a moving number. See
 [choosing an endpoint](/docs/HyperIndex/solana/configuration#choosing-an-endpoint-and-a-start-slot)
 for how to probe it.
 :::

--- a/docs/HyperIndex/solana/getting-started.md
+++ b/docs/HyperIndex/solana/getting-started.md
@@ -50,20 +50,29 @@ my-indexer/
 
 `envio init` also runs codegen, installs dependencies, and initializes git.
 
-## 2. Pick a start slot
+## 2. Pick an endpoint and a start slot
 
-`start_block` in `config.yaml` is a **slot number**, not a block number, and
-HyperSync for Solana keeps a rolling window of recent history — so don't hard-code
-an old slot. Query the current head and start somewhere sensible below it:
+`start_block` in `config.yaml` is a **slot number**, not a block number. Each
+HyperSync endpoint serves history back to its own floor slot, and that floor rolls
+forward over time, so don't hard-code an old slot. Query the current head first:
 
 ```bash
 curl -s https://solana.hypersync.xyz/height
-# => {"height": 421234567}
+# => 440063001
 ```
 
-Set `start_block` in `config.yaml` to, say, a few thousand slots below the head
-for a quick backfill, or to the slot your program was deployed at for a full history
-(within the retention window).
+Set `start_block` to a few tens of thousands of slots below the head for a quick
+backfill, or to the slot your program was deployed at for a fuller history -
+provided that slot sits above the endpoint's floor.
+
+:::danger A `start_block` below the endpoint's floor is silently skipped
+It does not error and it does not stall: the server fast-forwards to the floor, so
+the indexer syncs happily and reports healthy while writing nothing at all for the
+slots before it. `https://solana.hypersync.xyz` served from slot 436,162,000 and
+`https://solana-mainnet-history.hypersync.xyz` from at least 403,000,000 when
+measured on 2026-08-18, but treat both as moving numbers. See
+[choosing an endpoint](/docs/HyperIndex/solana/configuration#choosing-an-endpoint-and-a-start-slot).
+:::
 
 ## 3. Run it
 
@@ -98,13 +107,13 @@ instructions you want, then write a handler. The shortest path:
 
 1. **Point at an Anchor IDL** if you have one — HyperIndex derives the argument and account layout for you ([IDL decoding](/docs/HyperIndex/solana/decoding#anchor-idls)).
 2. **Or declare an inline schema** (`args` + `accounts`) for programs without an IDL ([inline schema](/docs/HyperIndex/solana/decoding#inline-schema-no-idl)).
-3. Add a `discriminator` per instruction so HyperIndex knows which instruction to match ([discriminators](/docs/HyperIndex/solana/decoding#discriminators)).
+3. Add a `discriminator` to every instruction. It is how HyperIndex matches the instruction *and* how it looks up the layout, including when an IDL is set ([discriminators](/docs/HyperIndex/solana/decoding#discriminators)).
 4. Register a handler with [`indexer.onInstruction`](/docs/HyperIndex/solana/instruction-handlers).
 
 ```yaml title="config.yaml"
 ecosystem: svm
 chains:
-  - start_block: 417995000 # example only; query /height (step 2) and pick a recent slot within the retention window
+  - start_block: 437000000 # example only; query /height (step 2) and pick a recent slot above the endpoint's floor
     experimental:
       hypersync_config:
         url: https://solana.hypersync.xyz
@@ -115,8 +124,7 @@ chains:
             - name: CreateMetadataAccountV3
               discriminator: "0x21"
               field_selection:
-                transaction_fields:
-                  - signatures
+                transaction_fields: [signature]
 ```
 
 ```typescript title="src/handlers/TokenMetadataHandlers.ts"
@@ -132,7 +140,7 @@ indexer.onInstruction(
       id: params.accounts.metadata,
       mint: params.accounts.mint ?? "",
       createdAtSlot: instruction.block.slot,
-      lastTxSignature: instruction.transaction.signatures[0],
+      lastTxSignature: instruction.transaction.signature,
     });
   },
 );

--- a/docs/HyperIndex/solana/getting-started.md
+++ b/docs/HyperIndex/solana/getting-started.md
@@ -58,20 +58,22 @@ forward over time, so don't hard-code an old slot. Query the current head first:
 
 ```bash
 curl -s https://solana.hypersync.xyz/height
-# => 440063001
+# => 440067639
 ```
 
 Set `start_block` to a few tens of thousands of slots below the head for a quick
 backfill, or to the slot your program was deployed at for a fuller history -
 provided that slot sits above the endpoint's floor.
 
-:::danger A `start_block` below the endpoint's floor is silently skipped
-It does not error and it does not stall: the server fast-forwards to the floor, so
-the indexer syncs happily and reports healthy while writing nothing at all for the
-slots before it. `https://solana.hypersync.xyz` served from slot 436,162,000 and
-`https://solana-mainnet-history.hypersync.xyz` from at least 403,000,000 when
-measured on 2026-08-18, but treat both as moving numbers. See
-[choosing an endpoint](/docs/HyperIndex/solana/configuration#choosing-an-endpoint-and-a-start-slot).
+:::danger A `start_block` below the endpoint's floor stalls the sync
+It does not error. The server returns an empty page with `next_slot` equal to the
+`from_slot` you sent, so the cursor never advances and the indexer sits there
+retrying the same empty range while reporting itself healthy. Both
+`https://solana.hypersync.xyz` and `https://solana-mainnet-history.hypersync.xyz`
+served from slot 403,000,000 when measured on 2026-08-18, but treat that as a
+moving number. See
+[choosing an endpoint](/docs/HyperIndex/solana/configuration#choosing-an-endpoint-and-a-start-slot)
+for how to probe it.
 :::
 
 ## 3. Run it

--- a/docs/HyperIndex/solana/instruction-handlers.md
+++ b/docs/HyperIndex/solana/instruction-handlers.md
@@ -53,17 +53,17 @@ indexer.onInstruction(
       mint: accounts.mint ?? "",
       updateAuthority: accounts.update_authority,
       createdAtSlot: instruction.block.slot,
-      lastTxSignature: instruction.transaction.signatures[0],
+      lastTxSignature: instruction.transaction.signature,
     });
   },
 );
 ```
 
 :::note Reading `instruction.transaction`
-`instruction.transaction.signatures[0]` is only populated when the instruction
-opts into it via [field selection](/docs/HyperIndex/solana/configuration#field-selection)
-(`transaction_fields: [signatures]` in `config.yaml`). Without it the field is
-absent and won't type-check.
+`instruction.transaction.signature` is only populated when the instruction opts
+into it via [field selection](/docs/HyperIndex/solana/configuration#field-selection)
+(`transaction_fields: [signature]` in `config.yaml`). Without it the field is
+typed `FieldNotSelected` and won't type-check.
 :::
 
 ## The instruction object
@@ -108,12 +108,13 @@ error pointing at the config key to add.
 
 ```typescript
 type SvmTransaction = {
-  signatures: readonly string[];   // signatures[0] is the transaction id
+  signature: string;                 // the transaction id, a scalar
+  allSignatures: readonly string[];  // every signer's signature; selected separately
   transactionIndex: number;
   feePayer?: string;
   success?: boolean;
   err?: string;
-  fee?: bigint;                    // lamports
+  fee?: bigint;                      // lamports
   computeUnitsConsumed?: bigint;
   accountKeys: readonly string[];
   recentBlockhash?: string;
@@ -121,6 +122,16 @@ type SvmTransaction = {
   tokenBalances?: readonly SvmTokenBalance[]; // with token_balance_fields: true
 };
 ```
+
+The object itself is always there (`{}` when you selected nothing), so a missing
+selection is a compile error on the property, not a crash on `undefined`.
+
+:::tip `signature`, not `signatures[0]`
+The identifying signature is the scalar `instruction.transaction.signature`. The
+array of every signer's signature is a separate field, `allSignatures`, selected
+with its own entry in `transaction_fields` - selecting `signature` does not
+give you `allSignatures`. Nearly every handler wants the scalar.
+:::
 
 ### Token balances and balance changes
 
@@ -134,9 +145,10 @@ account touched by the transaction.
 type SvmTokenBalance = {
   account?: string;     // token account (base58)
   mint?: string;
-  owner?: string;
-  preAmount?: string;   // balance before the tx — u64 as a decimal string
-  postAmount?: string;  // balance after the tx  — u64 as a decimal string
+  owner?: string;       // owner at end of tx; falls back to owner on entry if it was closed
+  decimals?: number;    // mint decimals, for scaling the raw amounts
+  preAmount?: bigint;   // raw base units before the tx; absent if the account was created in it
+  postAmount?: bigint;  // raw base units after the tx;  absent if the account was closed in it
 };
 ```
 
@@ -144,28 +156,35 @@ type SvmTokenBalance = {
 indexer.onInstruction(
   { program: "Jupiter", instruction: "sharedAccountsRoute" },
   async ({ instruction, context }) => {
-    const txSig = instruction.transaction.signatures[0];
-    if (!txSig) return;
+    const txSig = instruction.transaction.signature;
 
     for (const b of instruction.transaction.tokenBalances ?? []) {
       if (!b.account) continue;
-      const pre = BigInt(b.preAmount ?? "0");
-      const post = BigInt(b.postAmount ?? "0");
+      const delta = (b.postAmount ?? 0n) - (b.preAmount ?? 0n); // signed
       context.TokenDelta.set({
         id: `${txSig}:${b.account}`,
         account: b.account,
         mint: b.mint ?? "",
         owner: b.owner,
-        delta: post - pre, // signed
+        decimals: b.decimals,
+        delta,
       });
     }
   },
 );
 ```
 
-:::tip Amounts are strings
-`preAmount`/`postAmount` (and any `u64`+ decoded arg) are **decimal strings** to
-avoid precision loss. Wrap them in `BigInt(...)` for arithmetic.
+:::tip Amounts are `bigint`, and `decimals` comes with them
+`preAmount`/`postAmount` are raw base units typed as **`bigint`** - no
+`BigInt(...)` wrapper, and `?? 0n` rather than `?? "0"` for the absent case. Both
+being absent means the balance entry carries no movement at all, which is worth
+distinguishing from a genuine zero.
+
+`decimals` arrives on the same object, so scaling to a human-readable amount no
+longer needs a per-mint lookup.
+
+Two things to watch: don't let a `bigint` reach an entity field typed as a string
+in `schema.graphql`, and don't `JSON.stringify` one - that throws.
 :::
 
 :::note Native SOL balances
@@ -250,7 +269,7 @@ deterministic entity ids and use `set` (which is insert-or-update). A common
 Solana id is the transaction signature combined with the instruction path:
 
 ```typescript
-const id = `${instruction.transaction.signatures[0]}:${instruction.instructionAddress.join(".")}`;
+const id = `${instruction.transaction.signature}:${instruction.instructionAddress.join(".")}`;
 ```
 
 ## Testing
@@ -267,27 +286,38 @@ import { createTestIndexer } from "envio";
 describe("my solana indexer", () => {
   it("indexes instructions in the pinned window", async () => {
     const indexer = createTestIndexer();
-    const result = await indexer.process({
-      chains: { 0: { startBlock: 420_620_000, endBlock: 420_620_200 } },
+    await indexer.process({
+      chains: { 0: { startBlock: 437_452_000, endBlock: 437_452_060 } },
     });
 
-    // result.changes is an array of per-batch checkpoints:
-    //   [{ block, chainId, eventsProcessed, <EntityName>: { sets: [...] } }, ...]
-    const sets = result.changes.flatMap(
-      (c) => c.TokenMetadataAccount?.sets ?? [],
-    );
-    expect(sets.length).toBeGreaterThan(0);
+    // Read the resulting rows straight off the test indexer.
+    const rows = await indexer.TokenMetadataAccount.getAll();
+    expect(rows.length).toBeGreaterThan(0);
   }, 120_000); // generous timeout - this hits the network
 });
 ```
 
+Each entity on the test indexer exposes `get` / `getOrThrow` / `getAll` /
+`getWhere` / `set`. `process` also returns per-batch checkpoints on
+`result.changes` (`[{ block, chainId, <EntityName>: { sets, deleted } }, …]`) if
+you'd rather assert on what each batch wrote.
+
 To keep a separate test config instead, point the `ENVIO_CONFIG` environment
 variable at a `config.test.yaml` (with its own `start_block`/`end_block`) before
-importing `envio`.
+importing `envio`. Interpolating an env var into `end_block` in the main
+`config.yaml` works too, as long as you set it before the `envio` import.
 
-Because these tests hit the real endpoint, assert on **shape and invariants**
-(e.g. "produced rows", "deltas equal post − pre", "saw ≥ 2 programs") rather than
-exact counts.
+Two practical notes:
+
+- SVM has **no synthetic/simulate items** in the test harness. Chain overrides
+  only accept a slot range, so these tests run the real handlers against a live
+  endpoint and need `ENVIO_API_TOKEN`. Without a token, `POST /query` 401s are
+  retried rather than failing fast, so a token-less run hangs until the test
+  timeout instead of erroring.
+- Because they hit the real endpoint, assert on **shape and invariants** ("produced
+  rows", "delta equals post minus pre", "saw at least 2 programs") rather than exact
+  counts. Zero rows means the build is wrong, and a wrong `discriminator` is the
+  usual cause: it fires nothing while every log stays green.
 
 ## Related
 

--- a/docs/HyperIndex/solana/solana.md
+++ b/docs/HyperIndex/solana/solana.md
@@ -49,6 +49,16 @@ Choose **Solana** when prompted, then pick a starter template (a Metaplex NFT
 instruction indexer, or a minimal slot handler). See
 [Getting Started](/docs/HyperIndex/solana/getting-started) for the full walkthrough.
 
+## Data endpoint and history
+
+Every Solana chain must name its HyperSync endpoint explicitly under
+`experimental.hypersync_config.url` - it is a **required** field, with no default
+applied when it is missing. Each endpoint serves history back to its own floor
+slot, and that floor moves forward over time, so pick both the endpoint and
+`start_block` deliberately. See
+[choosing an endpoint](/docs/HyperIndex/solana/configuration#choosing-an-endpoint-and-a-start-slot)
+for the current endpoints and the silent-skip failure mode to avoid.
+
 ## Mental model: coming from EVM?
 
 If you've used HyperIndex on EVM, the shift is mostly vocabulary:
@@ -57,7 +67,7 @@ If you've used HyperIndex on EVM, the shift is mostly vocabulary:
 | --- | --- |
 | Contract + ABI | Program + IDL |
 | Event (`onEvent`) | Instruction (`onInstruction`) |
-| `event.params` | `instruction.params.args` |
+| `event.params` | `instruction.params?.args` (optional: decoding can fail) |
 | Topic0 / event signature | Instruction discriminator |
 | Block (`onBlock`) | Slot (`onSlot`) |
 | Hex addresses `0x…` | Base58 addresses |
@@ -68,10 +78,10 @@ See [EVM vs Solana](/docs/HyperIndex/solana/evm-vs-solana) for the full picture.
 ## What's supported today
 
 - **Instruction indexing** via [`indexer.onInstruction`](/docs/HyperIndex/solana/instruction-handlers) — match by program + discriminator.
-- **IDL-aware decoding** — point at a standard Anchor IDL (legacy or 0.30+) and HyperIndex derives the argument and account layout. No IDL? Declare an [inline schema](/docs/HyperIndex/solana/decoding#inline-schema-no-idl).
+- **IDL-aware decoding**: point at a standard Anchor IDL (legacy or 0.30+) and HyperIndex derives the argument and account layout. The `discriminator` is always read from `config.yaml`, never from the IDL. No IDL? Declare an [inline schema](/docs/HyperIndex/solana/decoding#inline-schema-no-idl).
 - **Inner instructions (CPIs)** — decoded the same way as top-level ones, with a full instruction-address path so you can reconstruct the call tree.
 - **Token balances & balance changes** — pre/post SPL Token (and Token-2022) balances per transaction, so you get the net token movement without indexing every transfer. See [token balances](/docs/HyperIndex/solana/instruction-handlers#token-balances-and-balance-changes).
-- **Transaction metadata & logs** — fee payer, fee, compute units, success, signatures, and per-instruction program logs (opt-in via [field selection](/docs/HyperIndex/solana/configuration#field-selection)).
+- **Transaction metadata & logs**: fee payer, fee, compute units, success, the transaction signature, and per-instruction program logs (opt-in via [field selection](/docs/HyperIndex/solana/configuration#field-selection)).
 - **Slot handlers** via [`indexer.onSlot`](/docs/HyperIndex/solana/slot-handlers) + the [Effect API](/docs/HyperIndex/effect-api) for RPC enrichment.
 - **Local dev + GraphQL + Envio Cloud** — the same workflow and hosting as EVM.
 
@@ -81,8 +91,8 @@ See [EVM vs Solana](/docs/HyperIndex/solana/evm-vs-solana) for the full picture.
 - **Account-change subscriptions.** There is no `onAccount`/program-account handler. Account *state* is available only as the accounts referenced by an instruction (plus per-transaction token balances).
 - **A separate log handler.** Logs are a field on the instruction event, not their own handler.
 - **No-code contract import.** Solana has no `contract-import` flow — you configure programs/instructions by hand. (IDLs are wired up in `config.yaml`, not auto-imported.)
-- **ReScript.** Solana indexers are TypeScript only.
-- **Per-field selection.** Field-selection toggles accept `true` only, not field name lists (yet).
+- **ReScript.** Solana indexers are TypeScript only. Codegen emits no ReScript for `ecosystem: svm`, and `envio init` silently picks TypeScript if you ask for ReScript.
+- **Per-field selection on `token_balance_fields` / `log_fields`.** Those two toggles accept `true` only. `transaction_fields` and `block_fields` do take field name lists.
 
 If the piece you need is on this list, [tell us on Discord](https://discord.gg/envio) — there's a good chance we can sequence the work to unblock you, or point you at a [HyperSync-direct](/docs/HyperSync/solana) path that gets the data today.
 

--- a/docs/HyperIndex/whats-new-in-v3.md
+++ b/docs/HyperIndex/whats-new-in-v3.md
@@ -369,7 +369,7 @@ Block handlers are now supported for Fuel indexing.
 
 ### Solana Support (Experimental)
 
-HyperIndex now supports Solana with RPC as a source. This feature is experimental and may undergo minor breaking changes. Solana exposes its block-stream handler as `indexer.onSlot` (rather than `onBlock`) to match Solana's slot-based model.
+HyperIndex now supports Solana. This feature is experimental and may undergo minor breaking changes. Solana exposes its block-stream handler as `indexer.onSlot` (rather than `onBlock`) to match Solana's slot-based model, and program instructions are indexed with `indexer.onInstruction` over a HyperSync source. Solana indexers are TypeScript only.
 
 To initialize a Solana project:
 


### PR DESCRIPTION
The Solana support in HyperIndex was rewritten on a separate lineage. These docs still described the pre-rewrite API. No customer used the old version, so this rewrites rather than patches: it describes the current API as the API, not as a migration.

Verified against `hyperindex@main` at `a95f358`, the commit `envio@3.7.0-svm-alpha.1` was cut from, and cross-checked against 11 real indexers running that version (11/11 codegen clean, 215/215 offline assertions passing). Examples are lifted from those working packs rather than invented.

## The correction that matters most

**The docs told people they could omit `discriminator` when using an IDL. That is wrong, and it fails silently in two ways at once.**

The old claim was that "modern Anchor IDLs (0.30+) embed it, so HyperIndex reads it automatically". In `system_config.rs::resolve_instruction_layout` the layout is looked up *by* `disc_to_bytes(instr.discriminator)`. With no YAML discriminator you get `normalized_discriminator = None`, `byte_len = 0`, and the layout resolves to `(vec![], vec![])`. `SvmEventKind.discriminator` documents `None` as "match every instruction in the program". So following the old docs gives you no filtering and no decoding, with no error. Corroborated independently by a comment in one of the production packs. Now carries a warning box.

## The four API breaks

1. `transaction.signatures[]` is now the scalar `transaction.signature`; the array moved to a separately selected `allSignatures`. The `svm.schema.json` `SvmTransactionField` enum has no `signatures` member.
2. `tokenBalances[].preAmount` / `.postAmount` are `bigint`, not decimal strings, and a new `decimals?: number` sits alongside them, removing the per-mint lookup the docs implied. Added warnings for bigint reaching a string entity field or `JSON.stringify`.
3. `experimental.hypersync_config` is required, not optional-with-a-default. Note the schema's own `url` description still advertises a default; the `required` list overrides it.
4. ReScript was dropped for SVM. `apply_language_override` silently downgrades ReScript to TypeScript for SVM projects.

## Endpoints and the history floor

Re-measured by bisecting `from_slot` against both endpoints on 2026-08-18. Both serve from exactly slot **403,000,000** and both report head **440,067,639**; the gap between them has closed and they are indistinguishable today. They have not always been, so the docs say to keep whatever your project already pins rather than switching on the assumption that they are interchangeable.

**Below the floor the server stalls, it does not fast-forward.** It returns an empty page with `next_slot` equal to the `from_slot` you sent, so the cursor never advances and the indexer retries the same empty range while reporting itself healthy. Since neither the floor nor the head is stable enough to document as a constant, the page carries a curl recipe that probes the floor by comparing `next_slot` against `from_slot`.

## Smaller corrections

- `transaction_fields` and `block_fields` take field-name lists. The old text said the field-selection toggles accept `true` only; only `log_fields` and `token_balance_fields` are booleans.
- Added the missing top-level config keys `handlers` and `disable_default_cross_chain`.
- Testing section rewritten around the real entity getters, with the verified limitation that SVM test configs accept only `startBlock` / `endBlock`, so those tests hit the live endpoint and need `ENVIO_API_TOKEN`.
- `f32` / `f64` documented as `number`; dropped an unverifiable claim about `null` on NaN/Inf.
- One line in `whats-new-in-v3.md` described Solana as RPC-only.

## Deliberately not documented

None of the draft future API spec, since none of it exists in this version: no `idls/` folder discovery, no `Account` object or `onAccount`, no `where` at registration, no `onRawInstruction`. `instruction.params` is still optional throughout and `log_fields` still works. The EVM inline `fields` option is called out as EVM-only in the comparison table.

## Known gaps

- **The endpoint question is not settled.** `hyperindex@main` documents `solana.hypersync.xyz` as the default (29 references, none to the history host) while every production pack pins `solana-mainnet-history`. Both are documented with their floors and the reader chooses. Someone still needs to decide which is canonical.
- The measured gotcha that `instruction.logs` is only populated for slots older than roughly a day (HyperSync enriches `instruction_address` on log rows with a lag) is real but endpoint-specific and was not verifiable here, so it is omitted rather than asserted.
- `codegen_templates.rs` maps `u64`/`u128`/`i64`/`i128` decoded args to `string`, but one production pack coerces them as bigint, which suggests the runtime value may vary. The codegen-derived type is documented; this needs a live run to resolve.

`yarn build` passes. The repo's `preinstall` runs `only-allow yarn`, so pnpm cannot install here despite the `pnpm-lock.yaml` in the tree. The one broken anchor Docusaurus reports is pre-existing, in the generated `HyperIndex-LLM` docs, which are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Solana setup guidance with endpoint selection, history floors, start slots, and stalled-sync troubleshooting.
  * Clarified transaction signature fields, token balance types, field selection, and instruction decoding behavior.
  * Added discriminator requirements, schema resolution guidance, and handling for decoding failures.
  * Updated examples for instruction handlers, testing, ID generation, and Solana indexing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->