### PR TITLE
docs(blog): mark Nikhil Bhintade as a former Envio engineer

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,12 +1,9 @@
 nikbhintade:
   name: Nikhil Bhintade
-  title: Growth Engineer at Envio
+  title: Former Growth Engineer at Envio
   url: /blog/author/nikbhintade
   image_url: /blog-assets/authors/nikbhintade.jpg
-  description: "Working on developer experience, ecosystem growth, and technical content around blockchain indexing and Web3 infrastructure."
-  socials:
-    twitter: https://x.com/nikbhintade
-    linkedin: https://linkedin.com/in/nikbhintade
+  description: "Worked on developer experience, ecosystem growth, and technical content around blockchain indexing and Web3 infrastructure."
 j_o_r_d_y_s:
   name: Jordyn Laurier
   title: Head of Marketing at Envio


### PR DESCRIPTION
Nikhil no longer works at Envio. This keeps his credit in place while removing the personal links and the wording that reads as current staff.

## Changes

- Title becomes `Former Growth Engineer at Envio`
- X and LinkedIn links removed
- Description kept, switched to past tense
- Avatar, byline and `/blog/author/nikbhintade` unchanged

## Verified

- Full `pnpm build` passes, exit 0
- Author page still lists all 6 of his posts with the avatar
- Bylines on those posts are unaffected
- Description retained so the author page keeps a real meta description rather than falling back to `Blog posts by Nikhil Bhintade.`

## Note

`AuthorPage` guards `title`, `description` and `socials` individually, so removing the socials block renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes GTM-4407