### PR TITLE
Remove the expired Alchemy migration offer

### DIFF
--- a/blog/2025-11-26-dev-update-november-2025.md
+++ b/blog/2025-11-26-dev-update-november-2025.md
@@ -107,7 +107,7 @@ Alchemy Subgraphs are officially sunsetting on **December 8, 2025**. Many teams 
 
 Envio is supporting affected teams with **2 months of free hosting**, faster backfills, multichain indexing, and full white-glove migration support to help you move over smoothly. HyperIndex gives you a modern indexing setup with real-time syncing and production ready deployments, making the transition quick and reliable.
 
-If your subgraphs are affected and you need to migrate, chat to our team or check out this [page](https://envio.dev/alchemy-migration) for more information and we will help you get set up.
+If your subgraphs are affected and you need to migrate, chat to our team in [Discord](https://discord.gg/envio) and we will help you get set up.
 
 For a full walkthrough on how to migrate, read our guide on [How to Migrate Alchemy Subgraphs to Envio](https://docs.envio.dev/docs/HyperIndex/migrate-from-alchemy).
 

--- a/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
+++ b/blog/2025-12-3-migrating-alchemy-subgraphs-to-envio.md
@@ -78,7 +78,7 @@ Envio has a dedicated migration cursor flow so you do not have to replay your en
 
 After this, you can run the indexer locally with Docker or deploy directly to [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service). Once deployed, your indexer will sync with HyperSync-level speed.
 
-If you prefer hands-on help, or would like the team to check your setup, you can book a free migration call [here](https://envio.dev/alchemy-migration). Alternatively, reach out in [Discord](https://discord.gg/envio).
+If you prefer hands-on help, or would like the team to check your setup, reach out in [Discord](https://discord.gg/envio).
 
 ## What changes when you leave Alchemy?
 
@@ -95,7 +95,7 @@ Your application code stays untouched. Queries stay close to what you already us
 
 Alchemy stepping away from Subgraphs does not mean your project has to stop. Migrating to Envio is fast, stable, and gives you a more reliable long-term foundation for your data.
 
-Book a [migration call](https://envio.dev/alchemy-migration), move your Subgraphs, and keep shipping without interruption.
+Move your Subgraphs and keep shipping without interruption.
 
 ## Frequently asked questions
 

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -2234,12 +2234,6 @@ Use the [Indexer Migration Validator](https://github.com/enviodev/indexer-migrat
 
 **File:** `migrate-from-alchemy.md`
 
-:::note
-Note: Alchemy subgraphs sunset on Dec 8th, 2025. Envio is offering affected Alchemy users 2 months of free hosting on Envio, along with full white-glove migration support to help projects move over smoothly.
-
-For more info on how you can start your free trial or book migration support, visit this [page](https://envio.dev/alchemy-migration) to learn more.
-:::
-
 Migrating Alchemy subgraphs to Envio’s HyperIndex is a simple and developer-friendly process. Alchemy subgraphs follow The Graph’s model and HyperIndex uses a very similar structure, so most of your existing setup can carry over cleanly.
 
 If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our Quickstart guide before you begin your migration from Alchemy. If you are new to the category entirely, see what a blockchain indexer is for the wider context.

--- a/docs/HyperIndex/migrate-from-alchemy.md
+++ b/docs/HyperIndex/migrate-from-alchemy.md
@@ -6,12 +6,6 @@ slug: /migrate-from-alchemy
 description: Easily migrate your existing Alchemy subgraphs to Envio for 142x faster indexing than subgraphs, multichain support, and a better developer experience.
 ---
 
-:::note
-Note: Alchemy subgraphs sunset on Dec 8th, 2025. Envio is offering affected Alchemy users 2 months of free hosting on Envio, along with full white-glove migration support to help projects move over smoothly.
-
-For more info on how you can start your free trial or book migration support, visit this [page](https://envio.dev/alchemy-migration) to learn more.
-:::
-
 Migrating Alchemy subgraphs to Envio’s HyperIndex is a simple and developer-friendly process. Alchemy subgraphs follow The Graph’s model and HyperIndex uses a very similar structure, so most of your existing setup can carry over cleanly.
 
 If you're familiar with The Graph’s libraries, the migration process should be straightforward. You can also utilize tools like Cursor to speed things up. If you are new to HyperIndex, we strongly recommend starting with our [Quickstart](/docs/HyperIndex/quickstart) guide before you begin your migration from Alchemy. If you are new to the category entirely, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.


### PR DESCRIPTION
The time-boxed Alchemy migration offer (2 months free hosting around the Dec 8, 2025 subgraph sunset) has run its course, and the `envio.dev/alchemy-migration` landing page is being removed in enviodev/ui#1204. This cleans up the docs side:

- `docs/HyperIndex/migrate-from-alchemy.md` and its LLM-docs mirror: drop the offer `:::note` callout (the technical migration guide itself stays)
- November 2025 dev update and the Dec 2025 Alchemy migration blog post: retarget links that pointed at the offer page to Discord, or drop them

The old landing-page URL 301s to the migration guide from the ui PR, so any external links that still exist keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance to direct readers to Discord for assistance.
  * Removed outdated migration-call links and Alchemy sunset notices.
  * Simplified related blog and documentation content to reflect current migration resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->