### PR TITLE
fix(llms): write .md copies for index-excluded LLM mirror plugins

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -630,8 +630,10 @@ const config = {
     [
       require.resolve("./plugins/plugin-generate-llms"),
       {
-        // LLM-mirror plugins are bundled re-exports of other docs — skip them
-        // entirely to avoid duplication.
+        // LLM-mirror plugins are bundled re-exports of other docs — keep them
+        // out of the llms.txt / llms-full.txt indexes to avoid duplication.
+        // Their .md copies are still written so the pages resolve when
+        // fetched directly (e.g. /docs/HyperSync-LLM/hypersync-complete.md).
         excludePluginIds: [
           "HyperIndex-LLM",
           "HyperSync-LLM",

--- a/plugins/plugin-generate-llms.js
+++ b/plugins/plugin-generate-llms.js
@@ -116,9 +116,13 @@ function GenerateLLMSPlugin(context, options) {
                     plugin[0] === "@docusaurus/plugin-content-docs"
                 ) {
                     const config = plugin[1];
-                    if (config.id && excludePluginIds.has(config.id)) {
-                        continue;
-                    }
+                    // Excluded plugins stay out of the llms.txt /
+                    // llms-full.txt indexes but still get .md copies
+                    // written, so their pages resolve when fetched
+                    // directly (e.g. the *-LLM mirror bundles).
+                    const indexExcluded = Boolean(
+                        config.id && excludePluginIds.has(config.id)
+                    );
                     const docsPath = path.resolve(config.path);
                     const routeBasePath = config.routeBasePath || "";
 
@@ -158,6 +162,7 @@ function GenerateLLMSPlugin(context, options) {
                             pageUrl,
                             source: "docs",
                             pluginId: config.id || "",
+                            indexExcluded,
                             tags: Array.isArray(parsed.data.tags)
                                 ? parsed.data.tags
                                 : [],
@@ -349,6 +354,7 @@ function GenerateLLMSPlugin(context, options) {
 
                 for (const pattern of includeOrder) {
                     for (const doc of collectedDocs) {
+                        if (doc.indexExcluded) continue;
                         const docPath = toPosix(doc.filePath);
                         const pat = toPosix(pattern);
 
@@ -404,6 +410,7 @@ function GenerateLLMSPlugin(context, options) {
                 const out = [];
 
                 for (const doc of collectedDocs) {
+                    if (doc.indexExcluded) continue;
                     if (claimed.has(doc.relativePath)) continue;
                     if (doc.source !== source) continue;
 
@@ -701,6 +708,7 @@ function GenerateLLMSPlugin(context, options) {
 
                     const fullDocsPool = collectedDocs.filter(
                         (d) =>
+                            !d.indexExcluded &&
                             !excludeFromFullPluginIds.has(d.pluginId) &&
                             d.hasMarkdown !== false
                     );


### PR DESCRIPTION
## Why

The `.md` twins of the four LLM mirror bundles 404 in production — e.g. `https://docs.envio.dev/docs/HyperSync-LLM/hypersync-complete.md` — so agents (and Claude chat) can't fetch them.

Root cause: `docusaurus.config.js` passes `excludePluginIds: ["HyperIndex-LLM", "HyperSync-LLM", "HyperRPC-LLM", "EnvioCloud-LLM"]` to `plugin-generate-llms.js`, and the plugin applied that exclusion at **collection time** — before docs ever reached `writeMarkdownCopies()`. The exclusion's intent was only to keep the mirror bundles out of the `llms.txt` index (they're re-exports of other docs), but it accidentally suppressed their `.md` copies too. The middleware and `vercel.json` rewrites deliberately pass `.md` URLs straight through to the filesystem, so the missing static files 404.

## What

Instead of skipping excluded plugins entirely, collect their docs with an `indexExcluded` flag, then filter that flag in the three index-facing spots:

- `orderDocs` (legacy `includeOrder` matching)
- `selectDocs` (structured sections)
- the `llms-full` pool

`writeMarkdownCopies()` is untouched, so it now receives the mirror docs and emits their `.md` twins. Also updated the now-stale comment in `docusaurus.config.js`.

Net behavior: mirror pages still stay out of `llms.txt`, `llms-full.txt`, and `llms-full-blog.txt`, but their `.md` twins get written — so both the direct `.md` URL and `Accept: text/markdown` negotiation resolve.

## Verification

- `yarn build` passes; the `validate-llms.js` postbuild reports 0 warnings (including its `checkMarkdownCopies` relative-link scan over the new files).
- All four twins now land in the build output: `build/docs/{HyperIndex,HyperSync,HyperRPC,EnvioCloud}-LLM/*.md`, each with the llms.txt discovery directive prepended.
- `grep -c "LLM/" build/llms.txt` → 0, and none of the mirror bundles appear as entries in the `llms-full` variants (only pre-existing in-body links from other docs mention them).

After deploy: `curl -sI https://docs.envio.dev/docs/HyperSync-LLM/hypersync-complete.md` should return 200 with `Content-Type: text/markdown` (`vercel.json` already sets that header for `/(.*).md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generated documentation indexes to omit excluded content while retaining Markdown copies for direct access.
  * Clarified the behavior of excluded documentation in generated content guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->