### PR TITLE
docs: repoint Indexer Explorer links after the page was retired (GTM-4279)

### DIFF
--- a/docs/EnvioCloud-LLM/envio-cloud-complete.mdx
+++ b/docs/EnvioCloud-LLM/envio-cloud-complete.mdx
@@ -55,7 +55,7 @@ Envio Cloud provides a seamless GitHub-integrated deployment workflow:
 
 **Multiple Indexers**: Deploy several indexers from a single repository using different configurations, branches, or directories.
 
-You can view and manage your hosted indexers in the [Envio Explorer](https://envio.dev/explorer).
+You can view and manage your hosted indexers in the [Envio Cloud dashboard](https://envio.dev/app).
 
 
 

--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -358,7 +358,7 @@ Next step: Running your Indexer locally or Deploying to Envio Cloud.
 Contract Import is the recommended path, but you can also bootstrap an indexer from:
 
 - **Templates** — pre-built `ERC20` or Greeter projects, selectable from the `pnpx envio init` interactive prompt.
-- **Examples** — copy and adapt an existing indexer from the [Envio Explorer](https://envio.dev/explorer), our Tutorials, or the [GitHub repositories](https://github.com/enviodev).
+- **Examples** — copy and adapt an existing indexer from our Examples, our Tutorials, or the [GitHub repositories](https://github.com/enviodev).
 
 ---
 

--- a/docs/HyperIndex/Hosted_Service/hosted-service.md
+++ b/docs/HyperIndex/Hosted_Service/hosted-service.md
@@ -43,7 +43,7 @@ Envio Cloud provides a seamless GitHub-integrated deployment workflow:
 
 **Multiple Indexers**: Deploy several indexers from a single repository using different configurations, branches, or directories.
 
-You can view and manage your hosted indexers in the [Envio Explorer](https://envio.dev/explorer).
+You can view and manage your hosted indexers in the [Envio Cloud dashboard](https://envio.dev/app).
 
 
 

--- a/docs/HyperIndex/contract-import.md
+++ b/docs/HyperIndex/contract-import.md
@@ -253,4 +253,4 @@ Next step: [Running your Indexer locally](./running-locally) or [Deploying to En
 Contract Import is the recommended path, but you can also bootstrap an indexer from:
 
 - **Templates** — pre-built `ERC20` or [Greeter](./greeter-tutorial) projects, selectable from the `pnpx envio init` interactive prompt.
-- **Examples** — copy and adapt an existing indexer from our [Examples](./Examples/example-uniswap-v4), our [Tutorials](./tutorial-erc20-token-transfers), or the [GitHub repositories](https://github.com/enviodev).
+- **Examples** — copy and adapt an existing indexer from our [Examples](./example-uniswap-v4-multi-chain-indexer), our [Tutorials](./tutorial-erc20-token-transfers), or the [GitHub repositories](https://github.com/enviodev).

--- a/docs/HyperIndex/contract-import.md
+++ b/docs/HyperIndex/contract-import.md
@@ -253,4 +253,4 @@ Next step: [Running your Indexer locally](./running-locally) or [Deploying to En
 Contract Import is the recommended path, but you can also bootstrap an indexer from:
 
 - **Templates** — pre-built `ERC20` or [Greeter](./greeter-tutorial) projects, selectable from the `pnpx envio init` interactive prompt.
-- **Examples** — copy and adapt an existing indexer from the [Envio Explorer](https://envio.dev/explorer), our [Tutorials](./tutorial-erc20-token-transfers), or the [GitHub repositories](https://github.com/enviodev).
+- **Examples** — copy and adapt an existing indexer from our [Examples](./Examples/example-uniswap-v4), our [Tutorials](./tutorial-erc20-token-transfers), or the [GitHub repositories](https://github.com/enviodev).

--- a/docs/HyperIndexV2/Hosted_Service/hosted-service.md
+++ b/docs/HyperIndexV2/Hosted_Service/hosted-service.md
@@ -43,7 +43,7 @@ Envio Cloud provides a seamless GitHub-integrated deployment workflow:
 
 **Multiple Indexers**: Deploy several indexers from a single repository using different configurations, branches, or directories.
 
-You can view and manage your hosted indexers in the [Envio Explorer](https://envio.dev/explorer).
+You can view and manage your hosted indexers in the [Envio Cloud dashboard](https://envio.dev/app).
 
 
 

--- a/docs/HyperIndexV2/getting-started.md
+++ b/docs/HyperIndexV2/getting-started.md
@@ -51,7 +51,7 @@ Select your preferred template from the interactive prompt.
 
 Use existing example indexers as a starting point. You can find these examples in:
 
-- [Envio Explorer](https://envio.dev/explorer)
+- [Examples](./Examples/example-uniswap-v4)
 - [Tutorials](./tutorial-erc20-token-transfers)
 - [GitHub Repositories](https://github.com/enviodev)
 

--- a/docs/HyperIndexV2/getting-started.md
+++ b/docs/HyperIndexV2/getting-started.md
@@ -51,7 +51,7 @@ Select your preferred template from the interactive prompt.
 
 Use existing example indexers as a starting point. You can find these examples in:
 
-- [Examples](./Examples/example-uniswap-v4)
+- [Examples](./example-uniswap-v4-multi-chain-indexer)
 - [Tutorials](./tutorial-erc20-token-transfers)
 - [GitHub Repositories](https://github.com/enviodev)
 


### PR DESCRIPTION
The public Indexer Explorer at `envio.dev/explorer` was removed in enviodev/ui#1195. That PR added a `/explorer` to `/` 301, so the links below are not broken, they land on the marketing homepage. Six files still name the Explorer as the place to do something.

## Changes

| File | Was | Now |
|---|---|---|
| `docs/HyperIndex/Hosted_Service/hosted-service.md` | view and manage hosted indexers in the Envio Explorer | Envio Cloud dashboard at `envio.dev/app` |
| `docs/HyperIndexV2/Hosted_Service/hosted-service.md` | same | same |
| `docs/HyperIndex/contract-import.md` | copy an existing indexer from the Envio Explorer | our Examples section |
| `docs/HyperIndexV2/getting-started.md` | Envio Explorer bullet | Examples bullet |
| `docs/HyperIndex-LLM/hyperindex-complete.mdx` | generated | regenerated |
| `docs/EnvioCloud-LLM/envio-cloud-complete.mdx` | generated | regenerated |

The two LLM mirrors were rebuilt with `node scripts/consolidate-hyperindex-docs.js --all`. Diff is one line each, no drift.

## Scope

No slugs, filenames or URLs change, so no redirects are needed.

Blog posts are left alone. Seven historical posts link to `envio.dev/explorer` and resolve through the redirect.

Closes GTM-4279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and hosted indexer links to point to the Envio Cloud dashboard.
  * Updated examples links to reference the relevant Envio Examples resources.
  * Improved documentation navigation for getting started and contract import workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->