### PR TITLE
docs: sharpen metadata on three high-rank zero-click pages (GTM-4338)

### DIFF
--- a/docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md
+++ b/docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md
@@ -3,7 +3,7 @@ id: tutorial-erc20-token-transfers
 title: Indexing ERC20 Token Transfers on Base
 sidebar_label: Indexing ERC20 Token Transfers on Base
 slug: /tutorial-erc20-token-transfers
-description: Learn how to index and query USDC ERC20 transfers on Base using Envio.
+description: Step-by-step ERC20 indexing tutorial. Index USDC token transfers on Base and query them through a GraphQL API, in under 5 minutes.
 ---
 
 ## Introduction

--- a/docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md
+++ b/docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md
@@ -3,7 +3,7 @@ id: tutorial-erc20-token-transfers
 title: Indexing ERC20 Token Transfers on Base
 sidebar_label: Indexing ERC20 Token Transfers on Base
 slug: /tutorial-erc20-token-transfers
-description: Step-by-step ERC20 indexing tutorial. Index USDC token transfers on Base and query them through a GraphQL API, in under 5 minutes.
+description: Step-by-step ERC20 indexing tutorial. Index USDC token transfers on Base and query them through a GraphQL API, set up in under 5 minutes.
 ---
 
 ## Introduction

--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -3,7 +3,7 @@ id: overview
 title: "HyperIndex: Fast Multichain Blockchain Indexer"
 sidebar_label: Overview
 slug: /overview
-description: HyperIndex turns on-chain events into a GraphQL API in minutes. Envio's multichain indexer, independently benchmarked as the fastest.
+description: HyperIndex turns onchain events into a GraphQL API in minutes. Envio's multichain indexer, independently benchmarked as the fastest.
 image: /docs-assets/og/HyperIndex/overview.png
 ---
 

--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -3,7 +3,7 @@ id: overview
 title: "HyperIndex: Fast Multichain Blockchain Indexer"
 sidebar_label: Overview
 slug: /overview
-description: HyperIndex is Envio's multichain indexing framework, independently benchmarked as the fastest blockchain indexer. On-chain events to a GraphQL API in minutes.
+description: HyperIndex turns on-chain events into a GraphQL API in minutes. Envio's multichain indexer, independently benchmarked as the fastest.
 image: /docs-assets/og/HyperIndex/overview.png
 ---
 

--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -3,7 +3,7 @@ id: overview
 title: "HyperIndex: Fast Multichain Blockchain Indexer"
 sidebar_label: Overview
 slug: /overview
-description: Explore HyperIndex, a blazing-fast multichain indexer for real-time blockchain data.
+description: HyperIndex is Envio's multichain indexing framework, independently benchmarked as the fastest blockchain indexer. On-chain events to a GraphQL API in minutes.
 image: /docs-assets/og/HyperIndex/overview.png
 ---
 

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -11,7 +11,7 @@ image: /docs-assets/og/HyperSync/overview.png
 
 ## What is HyperSync?
 
-HyperSync is a purpose-built data retrieval layer for on-chain data, built from the ground up in Rust. It serves as an alternative to traditional JSON-RPC endpoints, letting you filter and select exactly the data you need. On the workloads in our [performance benchmarks](#performance-benchmarks), scans that take hours or days over RPC complete in seconds.
+HyperSync is a purpose-built data retrieval layer for onchain data, built from the ground up in Rust. It serves as an alternative to traditional JSON-RPC endpoints, letting you filter and select exactly the data you need. On the workloads in our [performance benchmarks](#performance-benchmarks), scans that take hours or days over RPC complete in seconds.
 
 :::info HyperSync & HyperIndex
 

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -11,7 +11,7 @@ image: /docs-assets/og/HyperSync/overview.png
 
 ## What is HyperSync?
 
-HyperSync is a purpose-built, high-performance data retrieval layer that gives developers unprecedented access to blockchain data. Built from the ground up in Rust, HyperSync serves as an alternative to traditional JSON-RPC endpoints, offering dramatically faster queries and more flexible data access patterns.
+HyperSync is Envio's ultra-fast blockchain data API, a direct replacement for traditional JSON-RPC endpoints that delivers up to 2000x faster data access. Built from the ground up in Rust, it offers flexible query patterns across dozens of EVM chains and Fuel, with client libraries for Python, Rust, Node.js and Go.
 
 :::info HyperSync & HyperIndex
 

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -11,7 +11,7 @@ image: /docs-assets/og/HyperSync/overview.png
 
 ## What is HyperSync?
 
-HyperSync is a purpose-built data retrieval layer for onchain data, built from the ground up in Rust. It serves as an alternative to traditional JSON-RPC endpoints, letting you filter and select exactly the data you need and turning scans that take hours or days over RPC into seconds.
+HyperSync is a purpose-built data retrieval layer for on-chain data, built from the ground up in Rust. It serves as an alternative to traditional JSON-RPC endpoints, letting you filter and select exactly the data you need. On the workloads in our [performance benchmarks](#performance-benchmarks), scans that take hours or days over RPC complete in seconds.
 
 :::info HyperSync & HyperIndex
 

--- a/docs/HyperSync/overview.md
+++ b/docs/HyperSync/overview.md
@@ -11,7 +11,7 @@ image: /docs-assets/og/HyperSync/overview.png
 
 ## What is HyperSync?
 
-HyperSync is Envio's ultra-fast blockchain data API, a direct replacement for traditional JSON-RPC endpoints that delivers up to 2000x faster data access. Built from the ground up in Rust, it offers flexible query patterns across dozens of EVM chains and Fuel, with client libraries for Python, Rust, Node.js and Go.
+HyperSync is a purpose-built data retrieval layer for onchain data, built from the ground up in Rust. It serves as an alternative to traditional JSON-RPC endpoints, letting you filter and select exactly the data you need and turning scans that take hours or days over RPC into seconds.
 
 :::info HyperSync & HyperIndex
 


### PR DESCRIPTION
Linear: [GTM-4338](https://linear.app/envio/issue/GTM-4338/title-meta-pass-on-the-4-high-rank-zero-click-urls).

Three pages rank in the top five for queries with real volume and earn almost no clicks. Search Console, 19 May to 18 Aug 2026:

| Query | Page | Impressions | Clicks | Position |
| -- | -- | -- | -- | -- |
| hyper index | HyperIndex overview | 137 | 1 | 3.2 |
| erc20 indexing | ERC20 tutorial | 84 | 1 | 2.0 |
| hyper sync meaning | HyperSync overview | 20 | 0 | 4.6 |

The ranking is already there, so the listing itself is the only lever left. No titles, slugs or headings change, so no redirects are needed and no assets are added.

## Changes

**docs/HyperIndex/overview.md** — description. Was an adjective ("blazing-fast") with no concrete claim. Now leads with what a reader gets, then the benchmark. 133 characters so it does not truncate.

**docs/HyperIndex/Tutorials/tutorial-erc20-token-transfers.md** — description. Adds the step-by-step framing and the GraphQL API, and scopes the five minute figure to setup and first query the way the page itself does.

**docs/HyperSync/overview.md** — opening paragraph. The original said "unprecedented access" and "dramatically faster" where the same page carries a concrete number. Rewritten to keep the "purpose-built" and "alternative to JSON-RPC" framing and take its claim from the performance table.

## Sourcing

Every claim is already on the site. The benchmark claim is on `docs/HyperIndex/benchmarks.md`, the hours-to-seconds figure is the performance table on the HyperSync overview, and the five minute figure is the tutorial's own introduction. Nothing new is asserted.

The HyperSync paragraph deliberately avoids repeating the 2000x figure, the client library list and the chain count, all of which appear further down that page. The chain count in particular is rendered there with `<HyperSyncChainCount />`, so hardcoding it in the intro would have gone stale.

## After merge

Request indexing for the three URLs in Search Console, then check position and CTR on those queries in about four weeks. The Search Appearance report is not the right measure here since Google removed the FAQ appearance filter in June 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the HyperIndex tutorial’s step-by-step setup, Base USDC transfer indexing, GraphQL querying, and under-five-minute setup time.
  * Updated HyperIndex overview messaging to highlight its GraphQL API, multichain indexing, and independently benchmarked performance.
  * Refined HyperSync documentation to emphasize selective onchain data retrieval, JSON-RPC alternatives, and second-scale scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->