### PR TITLE
docs: link the blockchain indexer explainer from overview and quickstart

### DIFF
--- a/docs/HyperIndex-LLM/hyperindex-complete.mdx
+++ b/docs/HyperIndex-LLM/hyperindex-complete.mdx
@@ -40,7 +40,7 @@ This document contains all HyperIndex documentation consolidated into a single f
 
 **File:** `overview.md`
 
-**HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications.
+**HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications. If you are new to indexing, see what a blockchain indexer is for the wider context.
 
 
 
@@ -111,7 +111,7 @@ For more details about API tokens, including how to generate and implement them,
 
 **File:** `contract-import.md`
 
-The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex.
+The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex. If you are new to indexing, see what a blockchain indexer is for the wider context.
 
 **Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
 

--- a/docs/HyperIndex/contract-import.md
+++ b/docs/HyperIndex/contract-import.md
@@ -6,7 +6,7 @@ slug: /quickstart
 description: Learn to quickly autogenerate and configure a HyperIndex indexer for any smart contract.
 ---
 
-The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex.
+The **Quickstart** enables you to instantly autogenerate a powerful blockchain indexer and start querying blockchain data in minutes. This is the fastest and easiest way to begin using HyperIndex. If you are new to indexing, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.
 
 **Example:** Autogenerate an indexer for the Eigenlayer contract and index its entire history in less than 5 minutes by simply running `pnpx envio init` and providing the contract address from [Etherscan](https://etherscan.io/address/0x858646372cc42e1a627fce94aa7a7033e7cf075a).
 

--- a/docs/HyperIndex/overview.md
+++ b/docs/HyperIndex/overview.md
@@ -7,7 +7,7 @@ description: HyperIndex turns onchain events into a GraphQL API in minutes. Envi
 image: /docs-assets/og/HyperIndex/overview.png
 ---
 
-**HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications.
+**HyperIndex** is a blazing-fast, developer-friendly multichain indexer, optimized for both local development and reliable hosted deployment. It empowers developers to effortlessly build robust backends for blockchain applications. If you are new to indexing, see [what a blockchain indexer is](/blog/what-is-a-blockchain-indexer) for the wider context.
 
 ![Sync Process](../../static/img/sync.gif)
 


### PR DESCRIPTION
`/blog/what-is-a-blockchain-indexer` had no inbound links from the docs except the two migration pages. It sits at position 24 with 2,140 impressions and 3 clicks over the last 90 days.

- links it from HyperIndex overview and the Quickstart, using the anchor already used on the migration pages
- regenerates `hyperindex-complete.mdx`, which inlines both intros

Not included: the supported networks page, which does not mention indexing, and the three new H2s for `evm indexer`, `web3 indexer` and `multi chain indexer`. We rank better for all three on other pages already, so those headings belong there rather than here.
