### PR TITLE
fix(analytics): send docs ratings to GA4 instead of Universal Analytics

### DIFF
--- a/src/components/docsRating.js
+++ b/src/components/docsRating.js
@@ -18,13 +18,13 @@ const DocsRating = ({ label }) => {
   const [downvotes, setDownvotes] = useState(0);
 
   const giveFeedback = (value) => {
-    if (window.ga) {
-      window.ga("send", {
-        hitType: "event",
-        eventCategory: "button",
-        eventAction: "feedback",
-        eventLabel: label,
-        eventValue: value,
+    // Universal Analytics was shut down in 2023 and the site loads gtag via the
+    // Docusaurus gtag plugin, so the old window.ga call never fired. Every
+    // rating since has been discarded.
+    if (typeof window.gtag === "function") {
+      window.gtag("event", "docs_page_rating", {
+        page_id: label,
+        rating: value === 1 ? "helpful" : "not_helpful",
       });
     }
     setHaveVoted(true);


### PR DESCRIPTION
The "Is this page useful?" control in the docs footer calls `window.ga`, which is Universal Analytics. That was shut down in 2023 and the site loads `gtag`, so `window.ga` is undefined and every rating has been silently dropped.

Sends `docs_page_rating` through `gtag` instead, with `page_id` and a `helpful` or `not_helpful` rating. Markup and vote counters unchanged.

Two steps in GA4 after merge, both on the Docs property `G-J0WZ32ZV5B`:

- mark `docs_page_rating` as a key event
- register `page_id` and `rating` as custom dimensions, otherwise the event counts but the parameters stay invisible in reports
