### PR TITLE
docs(blog): answer "what is multichain" on the multichain indexing post

### DIFF
--- a/blog/2025-03-17-what-is-multi-chain-indexing.md
+++ b/blog/2025-03-17-what-is-multi-chain-indexing.md
@@ -23,6 +23,10 @@ Web3 is inherently multichain. Apps no longer operate in isolation. If you are n
 
 Yet querying multiple chains efficiently remains a challenge. Each network has its own architecture, RPC limitations, and data structures, making direct integration complex and resource-intensive. Multichain indexing solves this by providing a unified way to structure, query, and analyze blockchain data across chains without the overhead of managing individual indexing solutions.
 
+## What is multichain?
+
+Multichain describes an application, protocol or dataset that spans more than one blockchain rather than living on a single network. A multichain DeFi protocol might hold liquidity on Ethereum, Base and Arbitrum at once, and a multichain NFT marketplace might list assets across several ecosystems. The term describes how something is deployed, not the technology used to read its data.
+
 ## What is multichain indexing?
 
 Multichain indexing is the process of ingesting, organizing, and providing blockchain data across multiple networks in a unified way. It simplifies the complexity of querying different blockchain infrastructures, giving you access to structured data from various chains through a single interface.


### PR DESCRIPTION
The post ranks for `what is multichain` at position 21.4 with 88 impressions and no clicks over the last 90 days. It defines multichain indexing but never defines multichain on its own.

Adds a 60 word answer under a matching H2, above the existing indexing definition. No other headings, slugs or anchors change.

Left alone deliberately:

- `multichain indexer`, because eight of our URLs already compete for it and HyperIndex overview ranks better at 6.8
- the bare `multichain` and `multi-chain` queries, at positions 45.9 and 35.0, where the results are dominated by the Multichain bridge protocol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining what “multichain” means.
  * Included examples of multichain DeFi protocols and NFT marketplaces.
  * Clarified that “multichain” describes deployment across multiple blockchains, not the technology used to access data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->